### PR TITLE
Remove deprecated v8 API calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(/usr/local/include/php/main)
 include_directories(/usr/local/include/php/sapi)
 
 add_definitions(-DV8_DEPRECATION_WARNINGS)
+add_definitions(-DV8_IMMINENT_DEPRECATION_WARNINGS)
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/config.h")
     add_definitions(-DHAVE_CONFIG_H)

--- a/config.m4
+++ b/config.m4
@@ -144,6 +144,7 @@ if test "$PHP_V8" != "no"; then
   ac_cv_suppress_register_warnings_flag="-Wno-deprecated-register"
 
   AC_DEFINE([V8_DEPRECATION_WARNINGS], [1], [Enable compiler warnings when using V8_DEPRECATED apis.])
+  AC_DEFINE([V8_IMMINENT_DEPRECATION_WARNINGS], [1], [Enable compiler warnings to make it easier to see what v8 apis will be deprecated (V8_DEPRECATED) soon.])
 
   AC_LANG_RESTORE
   LIBS=$old_LIBS

--- a/src/php_v8_a.cc
+++ b/src/php_v8_a.cc
@@ -29,7 +29,6 @@ void php_v8_init()
         return;
     }
 
-    v8::V8::InitializeICU(); // TODO: check whether we actually initialized it
     // NOTE: if we use snapshot and extenal startup data then we have to initialize it (see https://codereview.chromium.org/315033002/)
     // v8::V8::InitializeExternalStartupData(NULL);
     v8::Platform *platform = v8::platform::CreateDefaultPlatform();

--- a/src/php_v8_date.cc
+++ b/src/php_v8_date.cc
@@ -41,9 +41,11 @@ static PHP_METHOD(V8Date, __construct) {
 
     PHP_V8_OBJECT_CONSTRUCT(getThis(), php_v8_context_zv, php_v8_context, php_v8_value);
 
-    v8::Local<v8::Date> local_date = v8::Date::New(isolate, time).As<v8::Date>();
+    v8::MaybeLocal<v8::Value> maybe_local_date = v8::Date::New(context, time);
 
-    PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_date, "Failed to create Date value");
+    PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(maybe_local_date, "Failed to create Date value");
+
+    v8::Local<v8::Date> local_date = maybe_local_date.ToLocalChecked().As<v8::Date>();
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(isolate, local_date, php_v8_value);

--- a/src/php_v8_function.cc
+++ b/src/php_v8_function.cc
@@ -417,7 +417,7 @@ static PHP_METHOD(V8Function, GetScriptOrigin) {
 
     v8::ScriptOrigin script_origin = local_function->GetScriptOrigin();
 
-    php_v8_create_script_origin(return_value, script_origin);
+    php_v8_create_script_origin(return_value, context, script_origin);
 }
 
 

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -161,11 +161,11 @@ static void php_v8_isolate_free(zend_object *object) {
 
     zend_object_std_dtor(&php_v8_isolate->std);
 
-    if (php_v8_isolate->array_buffer_allocator) {
-        delete php_v8_isolate->array_buffer_allocator;
-    }
-
     if (php_v8_isolate->create_params) {
+        if (php_v8_isolate->create_params->array_buffer_allocator) {
+            delete php_v8_isolate->create_params->array_buffer_allocator;
+        }
+
         delete php_v8_isolate->create_params;
     }
 }
@@ -182,10 +182,8 @@ static zend_object *php_v8_isolate_ctor(zend_class_entry *ce) {
     // TODO: inline? module init?
     php_v8_init();
 
-    php_v8_isolate->array_buffer_allocator = new ArrayBufferAllocator();
     php_v8_isolate->create_params = new v8::Isolate::CreateParams();
-
-    php_v8_isolate->create_params->array_buffer_allocator = php_v8_isolate->array_buffer_allocator;
+    php_v8_isolate->create_params->array_buffer_allocator = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
 
     php_v8_isolate->weak_function_templates = new std::map<v8::Persistent<v8::FunctionTemplate> *, php_v8_callbacks_t *>();
     php_v8_isolate->weak_object_templates = new std::map<v8::Persistent<v8::ObjectTemplate> *, php_v8_callbacks_t *>();

--- a/src/php_v8_isolate.h
+++ b/src/php_v8_isolate.h
@@ -117,19 +117,8 @@ extern php_v8_isolate_t * php_v8_isolate_fetch_object(zend_object *obj);
     }                                               \
 
 
-class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
-public:
-    virtual void* Allocate(size_t length) {
-        void* data = AllocateUninitialized(length);
-        return data == NULL ? data : memset(data, 0, length);
-    }
-    virtual void* AllocateUninitialized(size_t length) { return malloc(length); }
-    virtual void Free(void* data, size_t) { free(data); }
-};
-
 struct _php_v8_isolate_t {
     v8::Isolate *isolate;
-    ArrayBufferAllocator *array_buffer_allocator;
     v8::Isolate::CreateParams *create_params;
 
     std::map<v8::Persistent<v8::FunctionTemplate>*, php_v8_callbacks_t *> *weak_function_templates;

--- a/src/php_v8_message.cc
+++ b/src/php_v8_message.cc
@@ -50,7 +50,7 @@ void php_v8_message_create_from_message(zval *return_value, php_v8_isolate_t *ph
 
     /* v8::Message::GetScriptOrigin */
     zval origin_zv;
-    php_v8_create_script_origin(&origin_zv, message->GetScriptOrigin());
+    php_v8_create_script_origin(&origin_zv, context, message->GetScriptOrigin());
     zend_update_property(this_ce, return_value, ZEND_STRL("script_origin"), &origin_zv);
     zval_ptr_dtor(&origin_zv);
 

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -103,7 +103,7 @@ static PHP_METHOD(V8Script, __construct)
         origin = new v8::ScriptOrigin(v8::Undefined(isolate));
 
         zval origin_zv;
-        php_v8_create_script_origin(&origin_zv, *origin);
+        php_v8_create_script_origin(&origin_zv, context, *origin);
         zend_update_property(this_ce, getThis(), ZEND_STRL("origin"), &origin_zv);
 
         zval_ptr_dtor(&origin_zv);

--- a/src/php_v8_script_origin.cc
+++ b/src/php_v8_script_origin.cc
@@ -25,7 +25,7 @@ zend_class_entry *php_v8_script_origin_class_entry;
 #define this_ce php_v8_script_origin_class_entry
 
 
-extern void php_v8_create_script_origin(zval *return_value, v8::ScriptOrigin origin) {
+extern void php_v8_create_script_origin(zval *return_value, v8::Local<v8::Context> context, v8::ScriptOrigin origin) {
     zval options_zv;
 
     object_init_ex(return_value, this_ce);
@@ -38,13 +38,13 @@ extern void php_v8_create_script_origin(zval *return_value, v8::ScriptOrigin ori
     }
 
     /* v8::SourceMapUrl::ResourceLineOffset */
-    if (!origin.ResourceLineOffset().IsEmpty()) {
-        zend_update_property_long(this_ce, return_value, ZEND_STRL("resource_line_offset"), static_cast<zend_long>(origin.ResourceLineOffset()->NumberValue()));
+    if (!origin.ResourceLineOffset().IsEmpty() && origin.ResourceLineOffset()->NumberValue(context).IsJust()) {
+        zend_update_property_long(this_ce, return_value, ZEND_STRL("resource_line_offset"), static_cast<zend_long>(origin.ResourceLineOffset()->NumberValue(context).FromJust()));
     }
 
     /* v8::SourceMapUrl::ResourceColumnOffset */
-    if (!origin.ResourceColumnOffset().IsEmpty()) {
-        zend_update_property_long(this_ce, return_value, ZEND_STRL("resource_column_offset"), static_cast<zend_long>(origin.ResourceColumnOffset()->NumberValue()));
+    if (!origin.ResourceColumnOffset().IsEmpty() && origin.ResourceColumnOffset()->NumberValue(context).IsJust()) {
+        zend_update_property_long(this_ce, return_value, ZEND_STRL("resource_column_offset"), static_cast<zend_long>(origin.ResourceColumnOffset()->NumberValue(context).FromJust()));
     }
 
     /* v8::SourceMapUrl::Options */
@@ -53,8 +53,8 @@ extern void php_v8_create_script_origin(zval *return_value, v8::ScriptOrigin ori
     zval_ptr_dtor(&options_zv);
 
     /* v8::SourceMapUrl::ScriptID */
-    if (!origin.ScriptID().IsEmpty()) {
-        zend_update_property_long(this_ce, return_value, ZEND_STRL("script_id"), static_cast<zend_long>(origin.ScriptID()->NumberValue()));
+    if (!origin.ScriptID().IsEmpty() && origin.ScriptID()->NumberValue(context).IsJust()) {
+        zend_update_property_long(this_ce, return_value, ZEND_STRL("script_id"), static_cast<zend_long>(origin.ScriptID()->NumberValue(context).FromJust()));
     }
 
     /* v8::SourceMapUrl::ResourceName */

--- a/src/php_v8_script_origin.h
+++ b/src/php_v8_script_origin.h
@@ -27,7 +27,7 @@ extern "C" {
 
 extern zend_class_entry* php_v8_script_origin_class_entry;
 
-extern void php_v8_create_script_origin(zval * return_value, v8::ScriptOrigin origin);
+extern void php_v8_create_script_origin(zval * return_value, v8::Local<v8::Context> context, v8::ScriptOrigin origin);
 extern v8::ScriptOrigin *php_v8_create_script_origin_from_zval(zval *value, v8::Isolate *isolate);
 
 PHP_MINIT_FUNCTION (php_v8_script_origin);

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -678,7 +678,7 @@ static PHP_METHOD(V8Value, ToString) {
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);
 
-    v8::MaybeLocal<v8::String> maybe_local = php_v8_value_get_value_local(isolate, php_v8_value)->ToString(isolate);
+    v8::MaybeLocal<v8::String> maybe_local = php_v8_value_get_value_local(isolate, php_v8_value)->ToString(context);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_local, "Failed to convert");

--- a/stubs/src/ObjectValue.php
+++ b/stubs/src/ObjectValue.php
@@ -58,23 +58,52 @@ class ObjectValue extends Value
     }
 
     /**
-     * Sets an own property on this object bypassing interceptors and
-     * overriding accessors or read-only properties.
+     * Implements CreateDataProperty (ECMA-262, 7.3.4).
      *
-     * Note that if the object has an interceptor the property will be set
-     * locally, but since the interceptor takes precedence the local property
-     * will only be returned if the interceptor doesn't return a value.
+     * Defines a configurable, writable, enumerable property with the given value
+     * on the object unless the property already exists and is not configurable
+     * or the object is not extensible.
      *
-     * Note also that this only works for named properties.
-     *
-     * @param Context $context
-     * @param string  $key
-     * @param Value   $value
-     * @param int     $attributes
+     * @param Context   $context
+     * @param NameValue $key
+     * @param Value     $value
      *
      * @return bool
      */
-    public function ForceSet(Context $context, $key, Value $value, $attributes = PropertyAttribute::None)
+    public function CreateDataProperty(Context $context, NameValue $key, Value $value) : bool
+    {
+    }
+
+    /**
+     * Implements CreateDataProperty (ECMA-262, 7.3.4).
+     *
+     * Defines a configurable, writable, enumerable property with the given value
+     * on the object unless the property already exists and is not configurable
+     * or the object is not extensible.
+     *
+     * @param Context $context
+     * @param int     $index
+     * @param Value   $value
+     *
+     * @return bool
+     */
+    public function CreateDataPropertyIndex(Context $context, int $index, Value $value) : bool
+    {
+    }
+
+    /**
+     * Implements DefineOwnProperty.
+     *
+     * In general, CreateDataProperty will be faster, however, does not allow for specifying attributes.
+     *
+     * @param Context   $context
+     * @param NameValue $key
+     * @param Value     $value
+     * @param int       $attributes
+     *
+     * @return bool
+     */
+    public function DefineOwnProperty(Context $context, NameValue $key, Value $value, int $attributes = PropertyAttribute::None) : bool
     {
     }
 

--- a/tests/004-ICU-Intl_DateTimeFormat.phpt
+++ b/tests/004-ICU-Intl_DateTimeFormat.phpt
@@ -1,0 +1,138 @@
+--TEST--
+ICU - Intl.DateTimeFormat()
+--SKIPIF--
+<?php if (!extension_loaded("v8")) console.log "skip"; ?>
+--ENV--
+TZ=UTC
+--INI--
+date.timezone = "UTC"
+--FILE--
+<?php
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+// Tests:
+
+$isolate = new \V8\Isolate();
+$context = new \V8\Context($isolate);
+$v8_helper->injectConsoleLog($context);
+
+// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat#Using_locales
+$source = /** @lang JavaScript 1.8 */
+    <<<HEREDOC
+var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+
+// formats below assume the local time zone of the locale;
+// America/Los_Angeles for the US
+
+// US English uses month-day-year order
+console.log(new Intl.DateTimeFormat('en-US').format(date));
+// → "12/19/2012"
+
+// British English uses day-month-year order
+console.log(new Intl.DateTimeFormat('en-GB').format(date));
+// → "20/12/2012"
+
+// Korean uses year-month-day order
+console.log(new Intl.DateTimeFormat('ko-KR').format(date));
+// → "2012. 12. 20."
+
+// Arabic in most Arabic speaking countries uses real Arabic digits
+console.log(new Intl.DateTimeFormat('ar-EG').format(date));
+// → "٢٠‏/١٢‏/٢٠١٢"
+
+// for Japanese, applications may want to use the Japanese calendar,
+// where 2012 was the year 24 of the Heisei era
+console.log(new Intl.DateTimeFormat('ja-JP-u-ca-japanese').format(date));
+// → "24/12/20"
+
+// when requesting a language that may not be supported, such as
+// Balinese, include a fallback language, in this case Indonesian
+console.log(new Intl.DateTimeFormat(['ban', 'id']).format(date));
+// → "20/12/2012"
+HEREDOC;
+
+(new \V8\Script($context, new \V8\StringValue($isolate, $source)))->Run($context);
+
+$helper->line();
+
+
+// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat#Using_options
+// with en-AU am/AM hack as it causes troubles in CI and inconsistent across different ICU versions
+$source = /** @lang JavaScript 1.8 */
+    <<<HEREDOC
+var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+
+// request a weekday along with a long date
+var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+console.log(new Intl.DateTimeFormat('de-DE', options).format(date));
+// → "Donnerstag, 20. Dezember 2012"
+
+// an application may want to use UTC and make that visible
+options.timeZone = 'UTC';
+options.timeZoneName = 'short';
+console.log(new Intl.DateTimeFormat('en-US', options).format(date));
+// → "Thursday, December 20, 2012, GMT"
+
+// sometimes you want to be more precise
+var options = {
+  hour: 'numeric', minute: 'numeric', second: 'numeric',
+  timeZoneName: 'short'
+};
+console.log(new Intl.DateTimeFormat('en-AU', options).format(date).replace('AM', 'am'));
+// → "2:00:00 pm AEDT"
+
+// sometimes even the US needs 24-hour time
+options = {
+  year: 'numeric', month: 'numeric', day: 'numeric',
+  hour: 'numeric', minute: 'numeric', second: 'numeric',
+  hour12: false
+};
+console.log(date.toLocaleString('en-US', options));
+// → "12/19/2012, 19:00:00"
+HEREDOC;
+
+(new \V8\Script($context, new \V8\StringValue($isolate, $source)))->Run($context);
+
+
+$helper->line();
+
+$source = /** @lang JavaScript 1.8 */
+    <<<HEREDOC
+var date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
+
+// request a weekday along with a long date
+var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+
+options.timeZone = 'America/New_York';
+console.log(new Intl.DateTimeFormat('en-US', options).format(date));
+options.timeZone = 'Europe/Paris';
+console.log(new Intl.DateTimeFormat('fr-FR', options).format(date));
+options.timeZone = 'Europe/Berlin';
+console.log(new Intl.DateTimeFormat('de-DE', options).format(date));
+
+HEREDOC;
+
+(new \V8\Script($context, new \V8\StringValue($isolate, $source)))->Run($context);
+
+
+?>
+--EXPECT--
+12/20/2012
+20/12/2012
+2012. 12. 20.
+٢٠‏/١٢‏/٢٠١٢
+平成24/12/20
+20/12/2012
+
+Donnerstag, 20. Dezember 2012
+Thursday, December 20, 2012, GMT
+3:00:00 am GMT
+12/20/2012, 03:00:00
+
+Wednesday, December 19, 2012
+jeudi 20 décembre 2012
+Donnerstag, 20. Dezember 2012

--- a/tests/004-ICU-Intl_NumberFormat.phpt
+++ b/tests/004-ICU-Intl_NumberFormat.phpt
@@ -1,0 +1,82 @@
+--TEST--
+ICU - Intl.NumberFormat()
+--SKIPIF--
+<?php if (!extension_loaded("v8")) console.log "skip"; ?>
+--FILE--
+<?php
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+// Tests:
+
+$isolate = new \V8\Isolate();
+$context = new \V8\Context($isolate);
+$v8_helper->injectConsoleLog($context);
+
+// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat#Using_locales
+$source = /** @lang JavaScript 1.8 */
+    <<<HEREDOC
+var number = 123456.789;
+
+// German uses comma as decimal separator and period for thousands
+console.log(new Intl.NumberFormat('de-DE').format(number));
+// → 123.456,789
+
+// Arabic in most Arabic speaking countries uses real Arabic digits
+console.log(new Intl.NumberFormat('ar-EG').format(number));
+// → ١٢٣٤٥٦٫٧٨٩
+
+// India uses thousands/lakh/crore separators
+console.log(new Intl.NumberFormat('en-IN').format(number));
+// → 1,23,456.789
+
+// the nu extension key requests a numbering system, e.g. Chinese decimal
+console.log(new Intl.NumberFormat('zh-Hans-CN-u-nu-hanidec').format(number));
+// → 一二三,四五六.七八九
+
+// when requesting a language that may not be supported, such as
+// Balinese, include a fallback language, in this case Indonesian
+console.log(new Intl.NumberFormat(['ban', 'id']).format(number));
+// → 123.456,789
+HEREDOC;
+
+(new \V8\Script($context, new \V8\StringValue($isolate, $source)))->Run($context);
+
+$helper->line();
+
+
+// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat#Using_options
+$source = /** @lang JavaScript 1.8 */
+    <<<HEREDOC
+var number = 123456.789;
+
+// request a currency format
+console.log(new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(number));
+// → 123.456,79 €
+
+// the Japanese yen doesn't use a minor unit
+console.log(new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(number));
+// → ￥123,457
+
+// limit to three significant digits
+console.log(new Intl.NumberFormat('en-IN', { maximumSignificantDigits: 3 }).format(number));
+// → 1,23,000
+HEREDOC;
+
+(new \V8\Script($context, new \V8\StringValue($isolate, $source)))->Run($context);
+
+
+?>
+--EXPECT--
+123.456,789
+١٢٣٬٤٥٦٫٧٨٩
+1,23,456.789
+一二三,四五六.七八九
+123.456,789
+
+123.456,79 €
+￥123,457
+1,23,000

--- a/tests/V8ArrayObject.phpt
+++ b/tests/V8ArrayObject.phpt
@@ -129,7 +129,7 @@ V8\ArrayObject::CreationContext() matches expected value
 Converters:
 -----------
 V8\ArrayObject(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#91 (1) {
+    object(V8\BooleanValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -145,7 +145,7 @@ V8\ArrayObject(V8\Value)->ToBoolean():
       }
     }
 V8\ArrayObject(V8\Value)->ToNumber():
-    object(V8\NumberValue)#91 (1) {
+    object(V8\NumberValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -161,7 +161,7 @@ V8\ArrayObject(V8\Value)->ToNumber():
       }
     }
 V8\ArrayObject(V8\Value)->ToString():
-    object(V8\StringValue)#91 (1) {
+    object(V8\StringValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -177,7 +177,7 @@ V8\ArrayObject(V8\Value)->ToString():
       }
     }
 V8\ArrayObject(V8\Value)->ToDetailString():
-    object(V8\StringValue)#91 (1) {
+    object(V8\StringValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -246,7 +246,7 @@ V8\ArrayObject(V8\Value)->ToObject():
       }
     }
 V8\ArrayObject(V8\Value)->ToInteger():
-    object(V8\NumberValue)#91 (1) {
+    object(V8\NumberValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -262,7 +262,7 @@ V8\ArrayObject(V8\Value)->ToInteger():
       }
     }
 V8\ArrayObject(V8\Value)->ToUint32():
-    object(V8\NumberValue)#91 (1) {
+    object(V8\NumberValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -278,7 +278,7 @@ V8\ArrayObject(V8\Value)->ToUint32():
       }
     }
 V8\ArrayObject(V8\Value)->ToInt32():
-    object(V8\NumberValue)#91 (1) {
+    object(V8\NumberValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8FunctionObject.phpt
+++ b/tests/V8FunctionObject.phpt
@@ -114,7 +114,7 @@ Should output Hello World string
 string(11) "Script done"
 
 v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
-    object(V8\ScriptOrigin)#105 (6) {
+    object(V8\ScriptOrigin)#107 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(0) ""
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -122,7 +122,7 @@ v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#106 (3) {
+      object(V8\ScriptOriginOptions)#108 (3) {
         ["is_embedder_debug_script":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>

--- a/tests/V8Isolate_limit_time.phpt
+++ b/tests/V8Isolate_limit_time.phpt
@@ -29,7 +29,7 @@ if ($helper->need_more_time()) {
   // On travis when valgrind active it takes more time to complete all operations so we just increase initial limits
   $time_limit = 5.0;
   $low_range = 4.5;
-  $high_range = 10.0;
+  $high_range = 20.0;
 } else {
   $time_limit = 1.5;
   $low_range = 1.45;

--- a/tests/V8Isolate_limit_time_nested.phpt
+++ b/tests/V8Isolate_limit_time_nested.phpt
@@ -61,7 +61,7 @@ if ($helper->need_more_time()) {
     // On travis when valgrind active it takes more time to complete all operations so we just increase initial limits
     $time_limit = 5.0;
     $low_range = 4.5;
-    $high_range = 10.0;
+    $high_range = 20.0;
 } else {
     $time_limit = 1.5;
     $low_range = 1.45;

--- a/tests/V8Isolate_limit_time_set_during_execution.phpt
+++ b/tests/V8Isolate_limit_time_set_during_execution.phpt
@@ -21,7 +21,7 @@ if ($helper->need_more_time()) {
     // On travis when valgrind active it takes more time to complete all operations so we just increase initial limits
     $time_limit = 5.0;
     $low_range = 4.5;
-    $high_range = 10.0;
+    $high_range = 20.0;
 } else {
     $time_limit = 1.5;
     $low_range = 1.45;

--- a/tests/V8ObjectValue.phpt
+++ b/tests/V8ObjectValue.phpt
@@ -114,7 +114,7 @@ V8\ObjectValue->GetIdentityHash(): int(%d)
 Converters:
 -----------
 V8\ObjectValue(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#88 (1) {
+    object(V8\BooleanValue)#90 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -130,7 +130,7 @@ V8\ObjectValue(V8\Value)->ToBoolean():
       }
     }
 V8\ObjectValue(V8\Value)->ToNumber():
-    object(V8\NumberValue)#88 (1) {
+    object(V8\NumberValue)#90 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -146,7 +146,7 @@ V8\ObjectValue(V8\Value)->ToNumber():
       }
     }
 V8\ObjectValue(V8\Value)->ToString():
-    object(V8\StringValue)#88 (1) {
+    object(V8\StringValue)#90 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -162,7 +162,7 @@ V8\ObjectValue(V8\Value)->ToString():
       }
     }
 V8\ObjectValue(V8\Value)->ToDetailString():
-    object(V8\StringValue)#88 (1) {
+    object(V8\StringValue)#90 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -231,7 +231,7 @@ V8\ObjectValue(V8\Value)->ToObject():
       }
     }
 V8\ObjectValue(V8\Value)->ToInteger():
-    object(V8\NumberValue)#88 (1) {
+    object(V8\NumberValue)#90 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -247,7 +247,7 @@ V8\ObjectValue(V8\Value)->ToInteger():
       }
     }
 V8\ObjectValue(V8\Value)->ToUint32():
-    object(V8\NumberValue)#88 (1) {
+    object(V8\NumberValue)#90 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -263,7 +263,7 @@ V8\ObjectValue(V8\Value)->ToUint32():
       }
     }
 V8\ObjectValue(V8\Value)->ToInt32():
-    object(V8\NumberValue)#88 (1) {
+    object(V8\NumberValue)#90 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8StringObject.phpt
+++ b/tests/V8StringObject.phpt
@@ -127,7 +127,7 @@ StringObject extends ObjectValue: ok
 Getters:
 --------
 V8\StringObject->ValueOf():
-    object(V8\StringValue)#91 (1) {
+    object(V8\StringValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8SymbolObject.phpt
+++ b/tests/V8SymbolObject.phpt
@@ -130,7 +130,7 @@ SymbolObject extends ObjectValue: ok
 Getters:
 --------
 V8\SymbolObject->ValueOf():
-    object(V8\SymbolValue)#91 (1) {
+    object(V8\SymbolValue)#93 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>


### PR DESCRIPTION
This PR removes deprecated or soon to be deprecated API calls.

**BC breaking changes**: 
- `V8\ObjectValue::ForceSet()` removed in a favor of `V8\ObjectValue::DefineOwnProperty()`, `V8\ObjectValue::CreateDataProperty()` and `V8\ObjectValue::CreateDataPropertyIndex()`.