### PR TITLE
Refactor callbacks and add external allocated memory notification

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -187,6 +187,7 @@ if test "$PHP_V8" != "no"; then
     v8.cc                                                 \
     src/php_v8_a.cc                                       \
     src/php_v8_exception.cc                               \
+    src/php_v8_ext_mem_interface.cc                       \
     src/php_v8_try_catch.cc                               \
     src/php_v8_message.cc                                 \
     src/php_v8_stack_frame.cc                             \

--- a/php_v8.h
+++ b/php_v8.h
@@ -69,8 +69,7 @@ ZEND_TSRMLS_CACHE_EXTERN();
 
 ZEND_EXTERN_MODULE_GLOBALS(v8);
 
-#endif	/* PHP_V8_H */
-
+#endif //PHP_V8_H
 
 /*
  * Local variables:

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -36,14 +36,14 @@
 namespace phpv8 {
 
     Callback::Callback(zend_fcall_info fci, zend_fcall_info_cache fci_cache) : fci_(fci), fci_cache_(fci_cache) {
-        if (fci.size) {
-            Z_ADDREF(fci.function_name);
+        if (fci_.size) {
+            Z_ADDREF(fci_.function_name);
 
-            if (fci.object) {
-                ZVAL_OBJ(&object, fci.object);
-                Z_ADDREF(object);
+            if (fci_.object) {
+                ZVAL_OBJ(&object_, fci_.object);
+                Z_ADDREF(object_);
             } else {
-                ZVAL_UNDEF(&object);
+                ZVAL_UNDEF(&object_);
             }
         }
     }
@@ -52,8 +52,8 @@ namespace phpv8 {
         if (fci_.size) {
             zval_ptr_dtor(&fci_.function_name);
 
-            if (!Z_ISUNDEF(object)) {
-                zval_ptr_dtor(&object);
+            if (!Z_ISUNDEF(object_)) {
+                zval_ptr_dtor(&object_);
             }
         }
     }
@@ -64,7 +64,7 @@ namespace phpv8 {
         if (fci_.size) {
             size += 1;
 
-            if (!Z_ISUNDEF(object)) {
+            if (!Z_ISUNDEF(object_)) {
                 size += 1;
             }
         }
@@ -76,8 +76,8 @@ namespace phpv8 {
         if (fci_.size) {
             ZVAL_COPY_VALUE(zv++, &fci_.function_name);
 
-            if (!Z_ISUNDEF(object)) {
-                ZVAL_COPY_VALUE(zv++, &object);
+            if (!Z_ISUNDEF(object_)) {
+                ZVAL_COPY_VALUE(zv++, &object_);
             }
         }
     }

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -155,6 +155,24 @@ namespace phpv8 {
 
         return bucket.get();
     }
+
+    int64_t PersistentData::calculateSize() {
+        int64_t size = sizeof(*this);
+
+        for (auto const &item : buckets) {
+            size += sizeof(std::shared_ptr<CallbacksBucket>);
+            size += item.first.capacity();
+            size += item.second->calculateSize();
+        }
+
+        return size;
+    }
+
+    int64_t PersistentData::adjustSize(int64_t change_in_bytes) {
+        adjusted_size_ += change_in_bytes;
+        assert(adjusted_size_ >= 0);
+        return adjusted_size_;
+    }
 }
 
 void php_v8_callbacks_gc(phpv8::PersistentData *data, zval **gc_data, int * gc_data_count, zval **table, int *n) {

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -32,6 +32,7 @@
 #include "php_v8_value.h"
 #include "php_v8_isolate.h"
 #include <string>
+#include <algorithm>
 
 namespace phpv8 {
 
@@ -169,8 +170,7 @@ namespace phpv8 {
     }
 
     int64_t PersistentData::adjustSize(int64_t change_in_bytes) {
-        adjusted_size_ += change_in_bytes;
-        assert(adjusted_size_ >= 0);
+        adjusted_size_ = std::max(static_cast<int64_t>(0), adjusted_size_ + change_in_bytes);
         return adjusted_size_;
     }
 }

--- a/src/php_v8_callbacks.h
+++ b/src/php_v8_callbacks.h
@@ -85,7 +85,7 @@ namespace phpv8 {
         }
 
     private:
-        zval object;
+        zval object_;
         zend_fcall_info fci_;
         zend_fcall_info_cache fci_cache_;
     };

--- a/src/php_v8_exceptions.cc
+++ b/src/php_v8_exceptions.cc
@@ -231,9 +231,9 @@ PHP_MINIT_FUNCTION(php_v8_exceptions) {
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS "\\Exceptions", "TryCatchException", php_v8_try_catch_exception_methods);
     php_v8_try_catch_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_generic_exception_class_entry);
 
-    zend_declare_property_null(php_v8_try_catch_exception_class_entry, ZEND_STRL("isolate"),	ZEND_ACC_PRIVATE);
-    zend_declare_property_null(php_v8_try_catch_exception_class_entry, ZEND_STRL("context"),	ZEND_ACC_PRIVATE);
-    zend_declare_property_null(php_v8_try_catch_exception_class_entry, ZEND_STRL("try_catch"),	ZEND_ACC_PRIVATE);
+    zend_declare_property_null(php_v8_try_catch_exception_class_entry, ZEND_STRL("isolate"),    ZEND_ACC_PRIVATE);
+    zend_declare_property_null(php_v8_try_catch_exception_class_entry, ZEND_STRL("context"),    ZEND_ACC_PRIVATE);
+    zend_declare_property_null(php_v8_try_catch_exception_class_entry, ZEND_STRL("try_catch"),    ZEND_ACC_PRIVATE);
 
 
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS "\\Exceptions", "TerminationException", php_v8_termination_exception_methods);

--- a/src/php_v8_ext_mem_interface.cc
+++ b/src/php_v8_ext_mem_interface.cc
@@ -1,0 +1,130 @@
+/*
+  +----------------------------------------------------------------------+
+  | This file is part of the pinepain/php-v8 PHP extension.              |
+  |                                                                      |
+  | Copyright (c) 2015-2016 Bogdan Padalko <pinepain@gmail.com>          |
+  |                                                                      |
+  | Licensed under the MIT license: http://opensource.org/licenses/MIT   |
+  |                                                                      |
+  | For the full copyright and license information, please view the      |
+  | LICENSE file that was distributed with this source or visit          |
+  | http://opensource.org/licenses/MIT                                   |
+  +----------------------------------------------------------------------+
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php_v8_ext_mem_interface.h"
+#include "php_v8_object_template.h"
+#include "php_v8_function_template.h"
+#include "php_v8_value.h"
+#include "php_v8.h"
+
+zend_class_entry *php_v8_ext_mem_interface_ce;
+#define this_ce php_v8_ext_mem_interface_ce
+
+void php_v8_ext_mem_interface_value_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS) {
+    zend_long change_in_bytes;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &change_in_bytes) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_VALUE_FETCH_INTO(getThis(), php_v8_value);
+
+    RETURN_LONG(php_v8_value->persistent_data->adjustSize(change_in_bytes));
+}
+
+void php_v8_ext_mem_interface_value_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS) {
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_VALUE_FETCH_INTO(getThis(), php_v8_value);
+
+    RETURN_LONG(php_v8_value->persistent_data->getAdjustedSize());
+}
+
+
+void php_v8_ext_mem_interface_function_template_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS) {
+    zend_long change_in_bytes;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &change_in_bytes) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_OBJECT_TEMPLATE_FETCH_INTO(getThis(), php_v8_object_template);
+
+    RETURN_LONG(php_v8_object_template->persistent_data->adjustSize(change_in_bytes));
+}
+
+void php_v8_ext_mem_interface_function_template_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS) {
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_OBJECT_TEMPLATE_FETCH_INTO(getThis(), php_v8_object_template);
+
+    RETURN_LONG(php_v8_object_template->persistent_data->getAdjustedSize());
+}
+
+
+void php_v8_ext_mem_interface_object_template_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS) {
+    zend_long change_in_bytes;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &change_in_bytes) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FUNCTION_TEMPLATE_FETCH_INTO(getThis(), php_v8_function_template);
+
+    RETURN_LONG(php_v8_function_template->persistent_data->adjustSize(change_in_bytes));
+}
+
+void php_v8_ext_mem_interface_object_template_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS) {
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FUNCTION_TEMPLATE_FETCH_INTO(getThis(), php_v8_function_template);
+
+    RETURN_LONG(php_v8_function_template->persistent_data->getAdjustedSize());
+}
+
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_php_v8_ext_mem_interface_AdjustExternalAllocatedMemory, ZEND_RETURN_VALUE, 1, IS_LONG, NULL, 0)
+                ZEND_ARG_TYPE_INFO(0, change_in_bytes, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_php_v8_ext_mem_interface_GetExternalAllocatedMemory, ZEND_RETURN_VALUE, 0, IS_LONG, NULL, 0)
+ZEND_END_ARG_INFO()
+
+
+static const zend_function_entry php_v8_ext_mem_interface_methods[] = {
+        PHP_ABSTRACT_ME(V8AdjustableExternalMemoryInterface, AdjustExternalAllocatedMemory, arginfo_php_v8_ext_mem_interface_AdjustExternalAllocatedMemory)
+        PHP_ABSTRACT_ME(V8AdjustableExternalMemoryInterface, GetExternalAllocatedMemory, arginfo_php_v8_ext_mem_interface_GetExternalAllocatedMemory)
+
+        PHP_FE_END
+};
+
+PHP_MINIT_FUNCTION (php_v8_ext_mem_interface) {
+    zend_class_entry ce;
+
+    INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "AdjustableExternalMemoryInterface", php_v8_ext_mem_interface_methods);
+    this_ce = zend_register_internal_interface(&ce);
+
+    return SUCCESS;
+}
+
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/php_v8_ext_mem_interface.h
+++ b/src/php_v8_ext_mem_interface.h
@@ -1,0 +1,51 @@
+/*
+  +----------------------------------------------------------------------+
+  | This file is part of the pinepain/php-v8 PHP extension.              |
+  |                                                                      |
+  | Copyright (c) 2015-2016 Bogdan Padalko <pinepain@gmail.com>          |
+  |                                                                      |
+  | Licensed under the MIT license: http://opensource.org/licenses/MIT   |
+  |                                                                      |
+  | For the full copyright and license information, please view the      |
+  | LICENSE file that was distributed with this source or visit          |
+  | http://opensource.org/licenses/MIT                                   |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef PHP_V8_EXT_MEM_INTERFACE_H
+#define PHP_V8_EXT_MEM_INTERFACE_H
+
+
+extern "C" {
+#include "php.h"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+}
+
+
+extern zend_class_entry* php_v8_ext_mem_interface_ce;
+
+
+extern void php_v8_ext_mem_interface_value_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS);
+extern void php_v8_ext_mem_interface_value_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS);
+
+extern void php_v8_ext_mem_interface_function_template_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS);
+extern void php_v8_ext_mem_interface_function_template_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS);
+
+extern void php_v8_ext_mem_interface_object_template_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS);
+extern void php_v8_ext_mem_interface_object_template_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAMETERS);
+
+PHP_MINIT_FUNCTION(php_v8_ext_mem_interface);
+
+#endif //PHP_V8_EXT_MEM_INTERFACE_H
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/src/php_v8_function.cc
+++ b/src/php_v8_function.cc
@@ -146,10 +146,10 @@ static PHP_METHOD(V8Function, __construct) {
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
     if (fci.size) {
-        php_v8_callbacks_bucket_t *bucket = php_v8_callback_get_or_create_bucket(1, "", false, "callback", php_v8_value->callbacks);
+        phpv8::CallbacksBucket *bucket = php_v8_value->persistent_data->bucket("callback");
         data = v8::External::New(isolate, bucket);
 
-        php_v8_callback_add(0, fci, fci_cache, bucket);
+        bucket->add(0, fci, fci_cache);
 
         callback = php_v8_callback_function;
     }

--- a/src/php_v8_function_template.cc
+++ b/src/php_v8_function_template.cc
@@ -23,6 +23,7 @@
 #include "php_v8_object.h"
 #include "php_v8_value.h"
 #include "php_v8_context.h"
+#include "php_v8_ext_mem_interface.h"
 #include "php_v8.h"
 
 zend_class_entry *php_v8_function_template_class_entry;
@@ -437,6 +438,16 @@ static PHP_METHOD(V8FunctionTemplate, HasInstance) {
     RETURN_BOOL(local_template->HasInstance(local_obj));
 }
 
+/* Non-standard, implementations of AdjustableExternalMemoryInterface::AdjustExternalAllocatedMemory */
+static PHP_METHOD(V8FunctionTemplate, AdjustExternalAllocatedMemory) {
+    php_v8_ext_mem_interface_function_template_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+/* Non-standard, implementations of AdjustableExternalMemoryInterface::GetExternalAllocatedMemory */
+static PHP_METHOD(V8FunctionTemplate, GetExternalAllocatedMemory) {
+    php_v8_ext_mem_interface_function_template_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_function_template___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
                 ZEND_ARG_OBJ_INFO(0, isolate, V8\\Isolate, 0)
@@ -525,6 +536,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_template_HasInstance
                 ZEND_ARG_OBJ_INFO(0, object, V8\\ObjectValue, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_template_AdjustExternalAllocatedMemory, ZEND_RETURN_VALUE, 1, IS_LONG, NULL, 0)
+                ZEND_ARG_TYPE_INFO(0, change_in_bytes, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_template_GetExternalAllocatedMemory, ZEND_RETURN_VALUE, 0, IS_LONG, NULL, 0)
+ZEND_END_ARG_INFO()
+
 
 static const zend_function_entry php_v8_function_template_methods[] = {
         PHP_ME(V8FunctionTemplate, __construct,             arginfo_v8_function_template___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -547,6 +566,9 @@ static const zend_function_entry php_v8_function_template_methods[] = {
         PHP_ME(V8FunctionTemplate, RemovePrototype,         arginfo_v8_function_template_RemovePrototype,       ZEND_ACC_PUBLIC)
         PHP_ME(V8FunctionTemplate, HasInstance,             arginfo_v8_function_template_HasInstance,           ZEND_ACC_PUBLIC)
 
+        PHP_ME(V8FunctionTemplate, AdjustExternalAllocatedMemory,   arginfo_v8_function_template_AdjustExternalAllocatedMemory, ZEND_ACC_PUBLIC)
+        PHP_ME(V8FunctionTemplate, GetExternalAllocatedMemory,      arginfo_v8_function_template_GetExternalAllocatedMemory, ZEND_ACC_PUBLIC)
+
         PHP_FE_END
 };
 
@@ -556,6 +578,7 @@ PHP_MINIT_FUNCTION (php_v8_function_template) {
 
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "FunctionTemplate", php_v8_function_template_methods);
     this_ce = zend_register_internal_class_ex(&ce, php_v8_template_ce);
+    zend_class_implements(this_ce, 1, php_v8_ext_mem_interface_ce);
     this_ce->create_object = php_v8_function_template_ctor;
 
     memcpy(&php_v8_function_template_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));

--- a/src/php_v8_function_template.cc
+++ b/src/php_v8_function_template.cc
@@ -87,7 +87,7 @@ static void php_v8_function_template_free(zend_object *object) {
      * unmarked as week? Note, that the only action on weak handler callback is Reset()ing persistent handler.
      *
      * */
-    if (!CG(unclean_shutdown) && php_v8_function_template->persistent_data && !php_v8_function_template->persistent_data->empty()) {
+    if (zend_is_executing() && !CG(unclean_shutdown) && php_v8_function_template->persistent_data && !php_v8_function_template->persistent_data->empty()) {
         php_v8_function_template_make_weak(php_v8_function_template);
     }
 

--- a/src/php_v8_function_template.h
+++ b/src/php_v8_function_template.h
@@ -57,7 +57,7 @@ struct _php_v8_function_template_t {
 
     bool is_weak;
     v8::Persistent<v8::FunctionTemplate> *persistent;
-    php_v8_callbacks_t *callbacks;
+    phpv8::PersistentData *persistent_data;
 
     zval *gc_data;
     int gc_data_count;

--- a/src/php_v8_indexed_property_handler_configuration.cc
+++ b/src/php_v8_indexed_property_handler_configuration.cc
@@ -42,7 +42,7 @@ static void php_v8_indexed_property_handler_configuration_free(zend_object *obje
     php_v8_indexed_property_handler_configuration_t *php_v8_handler = php_v8_indexed_property_handler_configuration_fetch_object(object);
 
     if (php_v8_handler->bucket) {
-        php_v8_callback_destroy_bucket(php_v8_handler->bucket);
+        delete php_v8_handler->bucket;
         php_v8_handler->bucket = NULL;
     }
 
@@ -62,6 +62,8 @@ static zend_object * php_v8_indexed_property_handler_configuration_ctor(zend_cla
 
     zend_object_std_init(&php_v8_handler->std, ce);
     object_properties_init(&php_v8_handler->std, ce);
+
+    php_v8_handler->bucket = new phpv8::CallbacksBucket();
 
     php_v8_handler->std.handlers = &php_v8_indexed_property_handler_configuration_object_handlers;
 
@@ -99,28 +101,26 @@ static PHP_METHOD (V8IndexedPropertyHandlerConfiguration, __construct) {
 
     PHP_V8_INDEXED_PROPERTY_HANDLER_FETCH_INTO(getThis(), php_v8_handlers);
 
-    php_v8_handlers->bucket = php_v8_callback_create_bucket(5);
-
-    php_v8_callback_add(0, fci_getter, fci_cache_getter, php_v8_handlers->bucket);
+    php_v8_handlers->bucket->add(0, fci_getter, fci_cache_getter);
     php_v8_handlers->getter = php_v8_callback_indexed_property_getter;
 
     if (fci_setter.size) {
-        php_v8_callback_add(1, fci_setter, fci_cache_setter, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(1, fci_setter, fci_cache_setter);
         php_v8_handlers->setter = php_v8_callback_indexed_property_setter;
     }
 
     if (fci_query.size) {
-        php_v8_callback_add(2, fci_query, fci_cache_query, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(2, fci_query, fci_cache_query);
         php_v8_handlers->query = php_v8_callback_indexed_property_query;
     }
 
     if (fci_deleter.size) {
-        php_v8_callback_add(3, fci_deleter, fci_cache_deleter, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(3, fci_deleter, fci_cache_deleter);
         php_v8_handlers->deleter = php_v8_callback_indexed_property_deleter;
     }
 
     if (fci_enumerator.size) {
-        php_v8_callback_add(4, fci_enumerator, fci_cache_enumerator, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(4, fci_enumerator, fci_cache_enumerator);
         php_v8_handlers->enumerator = php_v8_callback_indexed_property_enumerator;
     }
 

--- a/src/php_v8_indexed_property_handler_configuration.h
+++ b/src/php_v8_indexed_property_handler_configuration.h
@@ -55,7 +55,8 @@ typedef struct _php_v8_indexed_property_handler_configuration_t {
 
     long flags;
 
-    php_v8_callbacks_bucket_t *bucket;
+    //php_v8_callbacks_bucket_t *bucket;
+    phpv8::CallbacksBucket *bucket;
 
     zval *gc_data;
     int   gc_data_count;

--- a/src/php_v8_isolate.h
+++ b/src/php_v8_isolate.h
@@ -71,13 +71,13 @@ extern php_v8_isolate_t * php_v8_isolate_fetch_object(zend_object *obj);
     v8::Isolate *isolate = (php_v8_isolate)->isolate;
 
 #define PHP_V8_ISOLATE_ENTER(isolate) \
-	v8::Locker locker(isolate); \
-	v8::Isolate::Scope isolate_scope(isolate); \
-	v8::HandleScope handle_scope(isolate);
+    v8::Locker locker(isolate); \
+    v8::Isolate::Scope isolate_scope(isolate); \
+    v8::HandleScope handle_scope(isolate);
 
 #define PHP_V8_ENTER_ISOLATE(php_v8_isolate) \
-	PHP_V8_DECLARE_ISOLATE(php_v8_isolate); \
-	PHP_V8_ISOLATE_ENTER(isolate); \
+    PHP_V8_DECLARE_ISOLATE(php_v8_isolate); \
+    PHP_V8_ISOLATE_ENTER(isolate); \
 
 #define PHP_V8_ENTER_STORED_ISOLATE(stored) PHP_V8_ENTER_ISOLATE((stored)->php_v8_isolate);
 

--- a/src/php_v8_isolate.h
+++ b/src/php_v8_isolate.h
@@ -121,9 +121,9 @@ struct _php_v8_isolate_t {
     v8::Isolate *isolate;
     v8::Isolate::CreateParams *create_params;
 
-    std::map<v8::Persistent<v8::FunctionTemplate>*, php_v8_callbacks_t *> *weak_function_templates;
-    std::map<v8::Persistent<v8::ObjectTemplate>*, php_v8_callbacks_t *> *weak_object_templates;
-    std::map<v8::Persistent<v8::Value>*, php_v8_callbacks_t *> *weak_values;
+    phpv8::PersistentCollection<v8::FunctionTemplate> *weak_function_templates;
+    phpv8::PersistentCollection<v8::ObjectTemplate> *weak_object_templates;
+    phpv8::PersistentCollection<v8::Value> *weak_values;
 
     uint32_t isolate_handle;
     php_v8_isolate_limits_t limits;

--- a/src/php_v8_isolate_limits.cc
+++ b/src/php_v8_isolate_limits.cc
@@ -22,8 +22,9 @@
 #define PHP_V8_TIME_SLEEP_MILLISECONDS 10
 
 //#define PHP_V8_DEBUG_EXECUTION 1
-
-#define mb(sz) ((sz)/1024/1024.0)
+#define one_mb (1024.0 * 1024.0)
+#define kb(sz) ((sz)/1024.0)
+#define mb(sz) (kb(sz)/1024.0)
 #define has(v, str) (v ? "has " str : "no " str)
 #define is(v) (v ? "yes" : "no")
 

--- a/src/php_v8_named_property_handler_configuration.cc
+++ b/src/php_v8_named_property_handler_configuration.cc
@@ -41,7 +41,7 @@ static void php_v8_named_property_handler_configuration_free(zend_object *object
     php_v8_named_property_handler_configuration_t *php_v8_handler = php_v8_named_property_handler_configuration_fetch_object(object);
 
     if (php_v8_handler->bucket) {
-        php_v8_callback_destroy_bucket(php_v8_handler->bucket);
+        delete php_v8_handler->bucket;
         php_v8_handler->bucket = NULL;
     }
 
@@ -61,6 +61,8 @@ static zend_object * php_v8_named_property_handler_configuration_ctor(zend_class
 
     zend_object_std_init(&php_v8_handler->std, ce);
     object_properties_init(&php_v8_handler->std, ce);
+
+    php_v8_handler->bucket = new phpv8::CallbacksBucket();
 
     php_v8_handler->std.handlers = &php_v8_named_property_handler_configuration_object_handlers;
 
@@ -99,28 +101,26 @@ static PHP_METHOD (V8NamedPropertyHandlerConfiguration, __construct) {
 
     PHP_V8_NAMED_PROPERTY_HANDLER_FETCH_INTO(getThis(), php_v8_handlers);
 
-    php_v8_handlers->bucket = php_v8_callback_create_bucket(5);
-
-    php_v8_callback_add(0, fci_getter, fci_cache_getter, php_v8_handlers->bucket);
+    php_v8_handlers->bucket->add(0, fci_getter, fci_cache_getter);
     php_v8_handlers->getter = php_v8_callback_generic_named_property_getter;
 
     if (fci_setter.size) {
-        php_v8_callback_add(1, fci_setter, fci_cache_setter, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(1, fci_setter, fci_cache_setter);
         php_v8_handlers->setter = php_v8_callback_generic_named_property_setter;
     }
 
     if (fci_query.size) {
-        php_v8_callback_add(2, fci_query, fci_cache_query, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(2, fci_query, fci_cache_query);
         php_v8_handlers->query = php_v8_callback_generic_named_property_query;
     }
 
     if (fci_deleter.size) {
-        php_v8_callback_add(3, fci_deleter, fci_cache_deleter, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(3, fci_deleter, fci_cache_deleter);
         php_v8_handlers->deleter = php_v8_callback_generic_named_property_deleter;
     }
 
     if (fci_enumerator.size) {
-        php_v8_callback_add(4, fci_enumerator, fci_cache_enumerator, php_v8_handlers->bucket);
+        php_v8_handlers->bucket->add(4, fci_enumerator, fci_cache_enumerator);
         php_v8_handlers->enumerator = php_v8_callback_generic_named_property_enumerator;
     }
 

--- a/src/php_v8_named_property_handler_configuration.h
+++ b/src/php_v8_named_property_handler_configuration.h
@@ -58,7 +58,7 @@ typedef struct _php_v8_named_property_handler_configuration_t {
 
   long flags;
 
-  php_v8_callbacks_bucket_t *bucket;
+  phpv8::CallbacksBucket *bucket;
 
   zval *gc_data;
   int   gc_data_count;

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -28,6 +28,7 @@
 #include "php_v8_name.h"
 #include "php_v8_value.h"
 #include "php_v8_context.h"
+#include "php_v8_ext_mem_interface.h"
 #include "php_v8.h"
 
 
@@ -1437,6 +1438,17 @@ static PHP_METHOD(V8Object, CallAsConstructor) {
 //static PHP_METHOD(V8Object, Cast) {
 //}
 
+/* Non-standard, implementations of AdjustableExternalMemoryInterface::AdjustExternalAllocatedMemory */
+static PHP_METHOD(V8Object, AdjustExternalAllocatedMemory) {
+    php_v8_ext_mem_interface_value_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+/* Non-standard, implementations of AdjustableExternalMemoryInterface::GetExternalAllocatedMemory */
+static PHP_METHOD(V8Object, GetExternalAllocatedMemory) {
+    php_v8_ext_mem_interface_value_GetExternalAllocatedMemory(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_object___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
 ZEND_END_ARG_INFO()
@@ -1645,6 +1657,14 @@ ZEND_END_ARG_INFO()
 //                ZEND_ARG_OBJ_INFO(0, persistent, V8\\Value, 0)
 //ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_object_AdjustExternalAllocatedMemory, ZEND_RETURN_VALUE, 1, IS_LONG, NULL, 0)
+                ZEND_ARG_TYPE_INFO(0, change_in_bytes, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_object_GetExternalAllocatedMemory, ZEND_RETURN_VALUE, 0, IS_LONG, NULL, 0)
+ZEND_END_ARG_INFO()
+
 
 static const zend_function_entry php_v8_object_methods[] = {
         PHP_ME(V8Object, __construct, arginfo_v8_object___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -1696,15 +1716,19 @@ static const zend_function_entry php_v8_object_methods[] = {
 
         // NOTE: Not supported yet
         //PHP_ME(V8Object, Cast, arginfo_v8_object_Cast, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+
+        PHP_ME(V8Object, AdjustExternalAllocatedMemory, arginfo_v8_object_AdjustExternalAllocatedMemory, ZEND_ACC_PUBLIC)
+        PHP_ME(V8Object, GetExternalAllocatedMemory, arginfo_v8_object_GetExternalAllocatedMemory, ZEND_ACC_PUBLIC)
+
         PHP_FE_END
 };
-
 
 
 PHP_MINIT_FUNCTION(php_v8_object) {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "ObjectValue", php_v8_object_methods);
     this_ce = zend_register_internal_class_ex(&ce, php_v8_value_class_entry);
+    zend_class_implements(this_ce, 1, php_v8_ext_mem_interface_ce);
 
     zend_declare_property_null(this_ce, ZEND_STRL("context"), ZEND_ACC_PRIVATE);
 

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -670,14 +670,15 @@ static PHP_METHOD(V8Object, SetAccessor) {
     v8::AccessorNameSetterCallback setter = 0;
     v8::Local<v8::External> data;
 
-    php_v8_callbacks_bucket_t *bucket = php_v8_callback_get_or_create_bucket(2, "accessor_", local_name->IsSymbol(), name, php_v8_value->callbacks);
+
+    phpv8::CallbacksBucket *bucket = php_v8_value->persistent_data->bucket("accessor_", local_name->IsSymbol(), name);
     data = v8::External::New(isolate, bucket);
 
-    php_v8_callback_add(0, getter_fci, getter_fci_cache, bucket);
+    bucket->add(0, getter_fci, getter_fci_cache);
     getter = php_v8_callback_accessor_name_getter;
 
     if (setter_fci.size) {
-        php_v8_callback_add(1, setter_fci, setter_fci_cache, bucket);
+        bucket->add(1, setter_fci, setter_fci_cache);
         setter = php_v8_callback_accessor_name_setter;
     }
 

--- a/src/php_v8_object_template.cc
+++ b/src/php_v8_object_template.cc
@@ -81,7 +81,7 @@ static HashTable * php_v8_object_template_gc(zval *object, zval **table, int *n)
 static void php_v8_object_template_free(zend_object *object) {
     php_v8_object_template_t *php_v8_object_template = php_v8_object_template_fetch_object(object);
 
-    if (!CG(unclean_shutdown) && php_v8_object_template->persistent_data && !php_v8_object_template->persistent_data->empty()) {
+    if (zend_is_executing() && !CG(unclean_shutdown) && php_v8_object_template->persistent_data && !php_v8_object_template->persistent_data->empty()) {
         php_v8_object_template_make_weak(php_v8_object_template);
     }
 

--- a/src/php_v8_object_template.cc
+++ b/src/php_v8_object_template.cc
@@ -45,13 +45,17 @@ static void php_v8_object_template_weak_callback(const v8::WeakCallbackInfo<v8::
     v8::Isolate *isolate = data.GetIsolate();
     php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
-    php_v8_isolate->weak_object_templates->remove(data.GetParameter());
+    phpv8::PersistentData *persistent_data = php_v8_isolate->weak_object_templates->get(data.GetParameter());
+
+    if (persistent_data != nullptr) {
+        // Tell v8 that we release external allocated memory
+        php_v8_debug_external_mem("Free allocated external memory (obj tpl: %p): -%" PRId64 "\n", persistent_data, persistent_data->getTotalSize())
+        isolate->AdjustAmountOfExternalAllocatedMemory(-persistent_data->getTotalSize());
+        php_v8_isolate->weak_object_templates->remove(data.GetParameter());
+    }
 
     data.GetParameter()->Reset();
     delete data.GetParameter();
-
-    // Tell v8 that we release external allocated memory
-    isolate->AdjustAmountOfExternalAllocatedMemory(-1024 * 1024 * 1024);
 }
 
 
@@ -61,7 +65,9 @@ static void php_v8_object_template_make_weak(php_v8_object_template_t *php_v8_ob
     php_v8_object_template->is_weak = true;
     php_v8_object_template->persistent->SetWeak(php_v8_object_template->persistent, php_v8_object_template_weak_callback, v8::WeakCallbackType::kParameter);
 
-    php_v8_object_template->php_v8_isolate->isolate->AdjustAmountOfExternalAllocatedMemory(1024 * 1024 * 1024);
+    // Tell v8 that we allocated external memory
+    php_v8_debug_external_mem("Allocate external memory (obj tpl: %p):  %" PRId64 "\n", php_v8_object_template->persistent_data, php_v8_object_template->persistent_data->getTotalSize())
+    php_v8_object_template->php_v8_isolate->isolate->AdjustAmountOfExternalAllocatedMemory(php_v8_object_template->persistent_data->getTotalSize());
 }
 
 static HashTable * php_v8_object_template_gc(zval *object, zval **table, int *n) {

--- a/src/php_v8_object_template.h
+++ b/src/php_v8_object_template.h
@@ -61,7 +61,7 @@ struct _php_v8_object_template_t {
 
     bool is_weak;
     v8::Persistent<v8::ObjectTemplate> *persistent;
-    php_v8_callbacks_t *callbacks;
+    phpv8::PersistentData *persistent_data;
 
     zval *gc_data;
     int gc_data_count;

--- a/src/php_v8_template.cc
+++ b/src/php_v8_template.cc
@@ -249,14 +249,14 @@ void php_v8_template_SetNativeDataProperty(v8::Isolate *isolate, v8::Local<T> lo
 
     PHP_V8_CONVERT_FROM_V8_STRING_TO_STRING(name, local_name);
 
-    php_v8_callbacks_bucket_t *bucket = php_v8_callback_get_or_create_bucket(2, "native_data_property_", local_name->IsSymbol(), name, php_v8_template->callbacks);
+    phpv8::CallbacksBucket *bucket = php_v8_template->persistent_data->bucket("native_data_property_", local_name->IsSymbol(), name);
     data = v8::External::New(isolate, bucket);
 
-    php_v8_callback_add(0, getter_fci, getter_fci_cache, bucket);
+    bucket->add(0, getter_fci, getter_fci_cache);
     getter = php_v8_callback_accessor_name_getter;
 
     if (setter_fci.size) {
-        php_v8_callback_add(1, setter_fci, setter_fci_cache, bucket);
+        bucket->add(1, setter_fci, setter_fci_cache);
         setter = php_v8_callback_accessor_name_setter;
     }
 

--- a/src/php_v8_template.cc
+++ b/src/php_v8_template.cc
@@ -308,6 +308,7 @@ PHP_MINIT_FUNCTION (php_v8_template) {
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "Template", php_v8_template_methods);
+    //zend_class_implements()
     this_ce = zend_register_internal_class_ex(&ce, php_v8_data_class_entry);
 
     zend_declare_property_null(this_ce, ZEND_STRL("isolate"), ZEND_ACC_PRIVATE);

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -133,7 +133,7 @@ static void php_v8_value_free(zend_object *object) {
 
 
     // TODO: making weak makes sense for objects only
-    if (!CG(unclean_shutdown) && php_v8_value->persistent_data && !php_v8_value->persistent_data->empty()) {
+    if (zend_is_executing() && !CG(unclean_shutdown) && php_v8_value->persistent_data && !php_v8_value->persistent_data->empty()) {
         php_v8_value_make_weak(php_v8_value); // TODO: refactor logic for make weak to include checking whether it can be weak -> maybe_make_weak
     }
 

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -62,13 +62,9 @@ static void php_v8_value_weak_callback(const v8::WeakCallbackInfo<v8::Persistent
     v8::Isolate *isolate = data.GetIsolate();
     php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
-    php_v8_callbacks_t *callbacks = (*php_v8_isolate->weak_values)[data.GetParameter()];
-    php_v8_callbacks_cleanup(callbacks);
-    php_v8_isolate->weak_values->erase(data.GetParameter());
+    php_v8_isolate->weak_values->remove(data.GetParameter());
 
     data.GetParameter()->Reset();
-
-    delete callbacks;
     delete data.GetParameter();
 
     // Tell v8 that we release external allocated memory
@@ -79,7 +75,7 @@ static void php_v8_value_make_weak(php_v8_value_t *php_v8_value) {
     // TODO: maybe week: if it already week, if has no isolate, if no callbacks or empty callbacks
     assert(!php_v8_value->is_weak);
 
-    (*php_v8_value->php_v8_isolate->weak_values)[php_v8_value->persistent] = php_v8_value->callbacks;
+    php_v8_value->php_v8_isolate->weak_values->add(php_v8_value->persistent, php_v8_value->persistent_data);
 
     php_v8_value->is_weak = true;
     php_v8_value->persistent->SetWeak(php_v8_value->persistent, php_v8_value_weak_callback, v8::WeakCallbackType::kParameter);
@@ -90,7 +86,7 @@ static void php_v8_value_make_weak(php_v8_value_t *php_v8_value) {
 static HashTable * php_v8_value_gc(zval *object, zval **table, int *n) {
     PHP_V8_VALUE_FETCH_INTO(object, php_v8_value);
 
-    php_v8_callbacks_gc(php_v8_value->callbacks, &php_v8_value->gc_data, &php_v8_value->gc_data_count, table, n);
+    php_v8_callbacks_gc(php_v8_value->persistent_data, &php_v8_value->gc_data, &php_v8_value->gc_data_count, table, n);
 
     return zend_std_get_properties(object);
 }
@@ -128,16 +124,16 @@ static void php_v8_value_free(zend_object *object) {
 
 
     // TODO: making weak makes sense for objects only
-    if (!CG(unclean_shutdown) && php_v8_value->callbacks && !php_v8_value->callbacks->empty()) {
+    if (!CG(unclean_shutdown) && php_v8_value->persistent_data && !php_v8_value->persistent_data->empty()) {
         php_v8_value_make_weak(php_v8_value); // TODO: refactor logic for make weak to include checking whether it can be weak -> maybe_make_weak
     }
 
     // NOTE: is weak check can be made in this way:
     //if (!php_v8_value->persistent || !php_v8_value->persistent->IsWeak()) {
     if (!php_v8_value->is_weak) {
-        if (php_v8_value->callbacks) {
-            php_v8_callbacks_cleanup(php_v8_value->callbacks);
-            delete php_v8_value->callbacks;
+        if (php_v8_value->persistent_data) {
+            delete php_v8_value->persistent_data;
+            php_v8_value->persistent_data = NULL;
         }
 
         if (php_v8_value->persistent) {
@@ -162,7 +158,7 @@ static zend_object * php_v8_value_ctor(zend_class_entry *ce) {
     object_properties_init(&php_v8_value->std, ce);
 
     php_v8_value->persistent = new v8::Persistent<v8::Value>();
-    php_v8_value->callbacks = new php_v8_callbacks_t();
+    php_v8_value->persistent_data = new phpv8::PersistentData();
 
     php_v8_value->std.handlers = &php_v8_value_object_handlers;
 

--- a/src/php_v8_value.h
+++ b/src/php_v8_value.h
@@ -115,7 +115,7 @@ struct _php_v8_value_t {
 
     bool is_weak;
     v8::Persistent<v8::Value> *persistent;
-    php_v8_callbacks_t *callbacks;
+    phpv8::PersistentData *persistent_data;
 
     zval *gc_data;
     int   gc_data_count;

--- a/stubs/src/AdjustableExternalMemoryInterface.php
+++ b/stubs/src/AdjustableExternalMemoryInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+  +----------------------------------------------------------------------+
+  | This file is part of the pinepain/php-v8 PHP extension.              |
+  |                                                                      |
+  | Copyright (c) 2015-2016 Bogdan Padalko <pinepain@gmail.com>          |
+  |                                                                      |
+  | Licensed under the MIT license: http://opensource.org/licenses/MIT   |
+  |                                                                      |
+  | For the full copyright and license information, please view the      |
+  | LICENSE file that was distributed with this source or visit          |
+  | http://opensource.org/licenses/MIT                                   |
+  +----------------------------------------------------------------------+
+*/
+
+
+namespace V8;
+
+
+interface AdjustableExternalMemoryInterface
+{
+    /**
+     *
+     * Adjusts the amount of registered external memory. Used to give V8 an
+     * indication of the amount of externally allocated memory that is kept alive
+     * by JavaScript object. V8 uses this to decide when to perform global
+     * garbage collections. Registering externally allocated memory will trigger
+     * global garbage collections more often than it would otherwise in an attempt
+     * to garbage collect the JavaScript objects that keep the externally
+     * allocated memory alive.
+     *
+     * NOTE: this is non-standard method. It is adapted v8::Isolate::AdjustAmountOfExternalAllocatedMemory() method idea
+     *       for PHP V8 ObjectValue, FunctionTemplate and ObjectTemplate objects. Such object may hold some external
+     *       data associated with them and that data can be hold by V8 after PHP object death when object/template
+     *       becomes weak. It is mainly useful to give a V8 a hint about that extra data, thought, it should be used
+     *       carefully while large ExternalAllocatedMemory will lead to more frequent GC triggering, which hurts
+     *       performance. The rule of thumb is not to use this method unless you fully understand what
+     *       v8::Isolate::AdjustAmountOfExternalAllocatedMemory() does. There is an underlying php-v8 mechanism which
+     *       will notify V8 about some basic memory hold by object/template which may be enough in most cases to keep
+     *       balance between performance and resources usage.
+     *
+     * @param int $change_in_bytes the change in externally allocated memory that is kept alive by JavaScript objects.
+     *
+     * @return int the adjusted value.
+     *
+     * NOTE: returned adjusted value can't be less then zero.
+     */
+    public function AdjustExternalAllocatedMemory(int $change_in_bytes) : int;
+
+    /**
+     * Get external allocated memory hint value.
+     *
+     * @return int
+     */
+    public function GetExternalAllocatedMemory() : int;
+}

--- a/stubs/src/FunctionTemplate.php
+++ b/stubs/src/FunctionTemplate.php
@@ -114,7 +114,7 @@ namespace V8;
  * \endcode
  */
 //class FunctionTemplateInterface extends TemplateInterface
-class FunctionTemplate extends Template
+class FunctionTemplate extends Template implements AdjustableExternalMemoryInterface
 {
     private $isolate;
 
@@ -248,6 +248,20 @@ class FunctionTemplate extends Template
      * @return bool
      */
     public function HasInstance(Value $object) : bool
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function AdjustExternalAllocatedMemory(int $change_in_bytes) : int
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function GetExternalAllocatedMemory() : int
     {
     }
 }

--- a/stubs/src/IndexedPropertyHandlerConfiguration.php
+++ b/stubs/src/IndexedPropertyHandlerConfiguration.php
@@ -21,11 +21,11 @@ namespace V8;
 class IndexedPropertyHandlerConfiguration
 {
     /**
-     * @param callable $getter
-     * @param callable $setter
-     * @param callable $query
-     * @param callable $deleter
-     * @param callable $enumerator
+     * @param callable $getter The callback to invoke when getting a property.
+     * @param callable $setter The callback to invoke when setting a property.
+     * @param callable $query The callback to invoke to check if an object has a property.
+     * @param callable $deleter The callback to invoke when deleting a property.
+     * @param callable $enumerator The callback to invoke to enumerate all the indexed properties of an object.
      * @param int $flags One of \v8\PropertyHandlerFlags constants
      */
     public function __construct(callable $getter,

--- a/stubs/src/NamedPropertyHandlerConfiguration.php
+++ b/stubs/src/NamedPropertyHandlerConfiguration.php
@@ -21,11 +21,11 @@ namespace V8;
 class NamedPropertyHandlerConfiguration
 {
     /**
-     * @param callable $getter
-     * @param callable $setter
-     * @param callable $query
-     * @param callable $deleter
-     * @param callable $enumerator
+     * @param callable $getter The callback to invoke when getting a property.
+     * @param callable $setter The callback to invoke when setting a property.
+     * @param callable $query The callback to invoke to check if a property is present, and if present, get its attributes.
+     * @param callable $deleter The callback to invoke when deleting a property.
+     * @param callable $enumerator The callback to invoke to enumerate all the named properties of an object.
      * @param int $flags One of \v8\PropertyHandlerFlags constants
      */
     public function __construct(callable $getter,

--- a/stubs/src/ObjectTemplate.php
+++ b/stubs/src/ObjectTemplate.php
@@ -24,7 +24,7 @@ namespace V8;
  * Properties added to an ObjectTemplate are added to each object
  * created from the ObjectTemplate.
  */
-class ObjectTemplate extends Template
+class ObjectTemplate extends Template implements AdjustableExternalMemoryInterface
 {
     public function __construct(Isolate $isolate, FunctionTemplate $constructor = null)
     {
@@ -167,4 +167,18 @@ class ObjectTemplate extends Template
     //public function SetAccessCheckCallback(callable $callback)
     //{
     //}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function AdjustExternalAllocatedMemory(int $change_in_bytes) : int
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function GetExternalAllocatedMemory() : int
+    {
+    }
 }

--- a/stubs/src/ObjectTemplate.php
+++ b/stubs/src/ObjectTemplate.php
@@ -102,20 +102,29 @@ class ObjectTemplate extends Template
     /**
      * Sets a named property handler on the object template.
      *
+     * Whenever a property whose name is a string or a symbol is accessed on
+     * objects created from this object template, the provided callback is
+     * invoked instead of accessing the property directly on the JavaScript
+     * object.
+     *
      * See \v8\NamedPropertyHandlerConfiguration constructor argument description for details
      *
-     * @param \v8\NamedPropertyHandlerConfiguration
+     * @param \v8\NamedPropertyHandlerConfiguration The NamedPropertyHandlerConfiguration that defines the callbacks to invoke when accessing a property.
      */
     public function SetHandlerForNamedProperty(NamedPropertyHandlerConfiguration $configuration)
     {
     }
 
     /**
-     * Sets a indexed property handler on the object template.
+     * Sets an indexed property handler on the object template.
+     *
+     * Whenever an indexed property is accessed on objects created from
+     * this object template, the provided callback is invoked instead of
+     * accessing the property directly on the JavaScript object.
      *
      * See \v8\IndexedPropertyHandlerConfiguration constructor argument description for details
      *
-     * @param \V8\IndexedPropertyHandlerConfiguration $configuration
+     * @param \V8\IndexedPropertyHandlerConfiguration $configuration The IndexedPropertyHandlerConfiguration that defines the callbacks to invoke when accessing a property.
      */
     public function SetHandlerForIndexedProperty(IndexedPropertyHandlerConfiguration $configuration)
     {

--- a/stubs/src/ObjectValue.php
+++ b/stubs/src/ObjectValue.php
@@ -21,7 +21,7 @@ namespace V8;
 /**
  * A JavaScript object (ECMA-262, 4.3.3)
  */
-class ObjectValue extends Value
+class ObjectValue extends Value implements AdjustableExternalMemoryInterface
 {
     public function __construct(Context $context)
     {
@@ -528,6 +528,20 @@ class ObjectValue extends Value
      * @return \V8\Value
      */
     public function CallAsConstructor(Context $context, array $arguments = []) : Value
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function AdjustExternalAllocatedMemory(int $change_in_bytes) : int
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function GetExternalAllocatedMemory() : int
     {
     }
 }

--- a/tests/005-V8FunctionTemplate_external_memory.phpt
+++ b/tests/005-V8FunctionTemplate_external_memory.phpt
@@ -1,0 +1,32 @@
+--TEST--
+V8\FunctionTemplate - external memory
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+// Tests:
+
+$isolate = new \V8\Isolate();
+
+$value = new \V8\FunctionTemplate($isolate);
+
+$helper->inline('Adjusted external memory size by default', $value->GetExternalAllocatedMemory());
+$helper->inline('After adjusting from zero to 1kb', $value->AdjustExternalAllocatedMemory(1024));
+$helper->inline('After adjusting from 1kb to 2kb', $value->AdjustExternalAllocatedMemory(1024));
+$helper->inline('After adjusting down from 2kb to 1kb', $value->AdjustExternalAllocatedMemory(-1024));
+$helper->inline('After adjusting down to more that was adjusted initially', $value->AdjustExternalAllocatedMemory(-9999999999));
+$helper->line();
+
+?>
+--EXPECT--
+Adjusted external memory size by default: 0
+After adjusting from zero to 1kb: 1024
+After adjusting from 1kb to 2kb: 2048
+After adjusting down from 2kb to 1kb: 1024
+After adjusting down to more that was adjusted initially: 0

--- a/tests/005-V8ObjectTemplate_external_memory.phpt
+++ b/tests/005-V8ObjectTemplate_external_memory.phpt
@@ -1,0 +1,32 @@
+--TEST--
+V8\ObjectTemplate - external memory
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+// Tests:
+
+$isolate = new \V8\Isolate();
+
+$value = new \V8\ObjectTemplate($isolate);
+
+$helper->inline('Adjusted external memory size by default', $value->GetExternalAllocatedMemory());
+$helper->inline('After adjusting from zero to 1kb', $value->AdjustExternalAllocatedMemory(1024));
+$helper->inline('After adjusting from 1kb to 2kb', $value->AdjustExternalAllocatedMemory(1024));
+$helper->inline('After adjusting down from 2kb to 1kb', $value->AdjustExternalAllocatedMemory(-1024));
+$helper->inline('After adjusting down to more that was adjusted initially', $value->AdjustExternalAllocatedMemory(-9999999999));
+$helper->line();
+
+?>
+--EXPECT--
+Adjusted external memory size by default: 0
+After adjusting from zero to 1kb: 1024
+After adjusting from 1kb to 2kb: 2048
+After adjusting down from 2kb to 1kb: 1024
+After adjusting down to more that was adjusted initially: 0

--- a/tests/005-V8ObjectValue_external_memory.phpt
+++ b/tests/005-V8ObjectValue_external_memory.phpt
@@ -1,0 +1,32 @@
+--TEST--
+V8\ObjectValue - external memory
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+// Tests:
+
+$isolate = new \V8\Isolate();
+$context = new \V8\Context($isolate);
+$value = new \V8\ObjectValue($context);
+
+$helper->inline('Adjusted external memory size by default', $value->GetExternalAllocatedMemory());
+$helper->inline('After adjusting from zero to 1kb', $value->AdjustExternalAllocatedMemory(1024));
+$helper->inline('After adjusting from 1kb to 2kb', $value->AdjustExternalAllocatedMemory(1024));
+$helper->inline('After adjusting down from 2kb to 1kb', $value->AdjustExternalAllocatedMemory(-1024));
+$helper->inline('After adjusting down to more that was adjusted initially', $value->AdjustExternalAllocatedMemory(-9999999999));
+$helper->line();
+
+?>
+--EXPECT--
+Adjusted external memory size by default: 0
+After adjusting from zero to 1kb: 1024
+After adjusting from 1kb to 2kb: 2048
+After adjusting down from 2kb to 1kb: 1024
+After adjusting down to more that was adjusted initially: 0

--- a/tests/V8ArrayObject.phpt
+++ b/tests/V8ArrayObject.phpt
@@ -129,7 +129,7 @@ V8\ArrayObject::CreationContext() matches expected value
 Converters:
 -----------
 V8\ArrayObject(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#96 (1) {
+    object(V8\BooleanValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -145,7 +145,7 @@ V8\ArrayObject(V8\Value)->ToBoolean():
       }
     }
 V8\ArrayObject(V8\Value)->ToNumber():
-    object(V8\NumberValue)#96 (1) {
+    object(V8\NumberValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -161,7 +161,7 @@ V8\ArrayObject(V8\Value)->ToNumber():
       }
     }
 V8\ArrayObject(V8\Value)->ToString():
-    object(V8\StringValue)#96 (1) {
+    object(V8\StringValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -177,7 +177,7 @@ V8\ArrayObject(V8\Value)->ToString():
       }
     }
 V8\ArrayObject(V8\Value)->ToDetailString():
-    object(V8\StringValue)#96 (1) {
+    object(V8\StringValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -246,7 +246,7 @@ V8\ArrayObject(V8\Value)->ToObject():
       }
     }
 V8\ArrayObject(V8\Value)->ToInteger():
-    object(V8\NumberValue)#96 (1) {
+    object(V8\NumberValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -262,7 +262,7 @@ V8\ArrayObject(V8\Value)->ToInteger():
       }
     }
 V8\ArrayObject(V8\Value)->ToUint32():
-    object(V8\NumberValue)#96 (1) {
+    object(V8\NumberValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -278,7 +278,7 @@ V8\ArrayObject(V8\Value)->ToUint32():
       }
     }
 V8\ArrayObject(V8\Value)->ToInt32():
-    object(V8\NumberValue)#96 (1) {
+    object(V8\NumberValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8Exception_CreateMessage.phpt
+++ b/tests/V8Exception_CreateMessage.phpt
@@ -71,6 +71,7 @@ $helper->line();
 
 $v8_helper->run_checks($res);
 ?>
+EOF
 --EXPECTF--
 Can create message when out of context: ok
 
@@ -180,3 +181,6 @@ V8\ObjectValue(V8\Value)->IsStringObject(): bool(false)
 V8\ObjectValue(V8\Value)->IsSymbolObject(): bool(false)
 V8\ObjectValue(V8\Value)->IsNativeError(): bool(false)
 V8\ObjectValue(V8\Value)->IsRegExp(): bool(false)
+
+
+EOF

--- a/tests/V8FunctionObject.phpt
+++ b/tests/V8FunctionObject.phpt
@@ -34,6 +34,7 @@ $helper->dump($func);
 $helper->space();
 
 $helper->assert('FunctionObject extends ObjectValue', $func instanceof \V8\ObjectValue);
+$helper->assert('FunctionObject implements AdjustableExternalMemoryInterface', $func instanceof \V8\AdjustableExternalMemoryInterface);
 $helper->line();
 
 $v8_helper->run_checks($func, 'Checkers');
@@ -113,6 +114,7 @@ object(v8Tests\TrackingDtors\FunctionObject)#6 (2) {
 
 
 FunctionObject extends ObjectValue: ok
+FunctionObject implements AdjustableExternalMemoryInterface: ok
 
 Checkers:
 ---------
@@ -149,7 +151,7 @@ Should output Hello World string
 string(11) "Script done"
 
 v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
-    object(V8\ScriptOrigin)#111 (6) {
+    object(V8\ScriptOrigin)#113 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(0) ""
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -157,7 +159,7 @@ v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#112 (3) {
+      object(V8\ScriptOriginOptions)#114 (3) {
         ["is_embedder_debug_script":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>

--- a/tests/V8FunctionTemplate.phpt
+++ b/tests/V8FunctionTemplate.phpt
@@ -29,6 +29,8 @@ $helper->dump($function_template);
 $helper->space();
 
 $helper->assert('FunctionTemplate extends Template', $function_template instanceof \V8\Template);
+$helper->assert('FunctionTemplate implements AdjustableExternalMemoryInterface', $function_template instanceof \V8\AdjustableExternalMemoryInterface);
+
 $helper->line();
 
 $print_func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
@@ -162,6 +164,7 @@ object(V8\FunctionTemplate)#5 (1) {
 
 
 FunctionTemplate extends Template: ok
+FunctionTemplate implements AdjustableExternalMemoryInterface: ok
 
 Object representation:
 ----------------------

--- a/tests/V8FunctionTemplate_callback_weakness.phpt
+++ b/tests/V8FunctionTemplate_callback_weakness.phpt
@@ -1,0 +1,88 @@
+--TEST--
+V8\FunctionTemplate - callback weakness
+--SKIPIF--
+<?php if (!extension_loaded("v8")) {
+    print "skip";
+} ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new V8\Isolate();
+
+$f1 = function () {};
+$f2 = function () {};
+
+$helper->header('Functions before setting as a callback');
+debug_zval_dump($f1);
+debug_zval_dump($f2);
+
+$fnc = new \V8\FunctionTemplate($isolate, $f1);
+
+$helper->header('Functions after f1 was set as a callback');
+debug_zval_dump($f1);
+debug_zval_dump($f2);
+
+$fnc->SetCallHandler($f2);
+
+$helper->header('Functions after f2 was set as a callback');
+debug_zval_dump($f1);
+debug_zval_dump($f2);
+
+$fnc = null;
+$helper->header('Functions after function template was destroyed');
+
+debug_zval_dump($f1);
+debug_zval_dump($f2);
+
+$isolate = null;
+//for($i = 0; $i<1000; $i++) {
+//  $isolate->LowMemoryNotification();
+//}
+$helper->header('Functions after isolate was destroyed');
+
+debug_zval_dump($f1);
+debug_zval_dump($f2);
+
+
+echo 'We are done for now', PHP_EOL;
+
+?>
+--EXPECT--
+Functions before setting as a callback:
+---------------------------------------
+object(Closure)#4 (0) refcount(2){
+}
+object(Closure)#5 (0) refcount(2){
+}
+Functions after f1 was set as a callback:
+-----------------------------------------
+object(Closure)#4 (0) refcount(3){
+}
+object(Closure)#5 (0) refcount(2){
+}
+Functions after f2 was set as a callback:
+-----------------------------------------
+object(Closure)#4 (0) refcount(2){
+}
+object(Closure)#5 (0) refcount(3){
+}
+Functions after function template was destroyed:
+------------------------------------------------
+object(Closure)#4 (0) refcount(2){
+}
+object(Closure)#5 (0) refcount(3){
+}
+Functions after isolate was destroyed:
+--------------------------------------
+object(Closure)#4 (0) refcount(2){
+}
+object(Closure)#5 (0) refcount(2){
+}
+We are done for now

--- a/tests/V8ObjectTemplate.phpt
+++ b/tests/V8ObjectTemplate.phpt
@@ -21,6 +21,7 @@ $helper->dump($value);
 $helper->space();
 
 $helper->assert('ObjectTemplate extends Template', $value instanceof \V8\Template);
+$helper->assert('ObjectTemplate implements AdjustableExternalMemoryInterface', $value instanceof \V8\AdjustableExternalMemoryInterface);
 $helper->line();
 
 $helper->header('Accessors');
@@ -64,6 +65,7 @@ object(V8\ObjectTemplate)#4 (1) {
 
 
 ObjectTemplate extends Template: ok
+ObjectTemplate implements AdjustableExternalMemoryInterface: ok
 
 Accessors:
 ----------

--- a/tests/V8ObjectValue.phpt
+++ b/tests/V8ObjectValue.phpt
@@ -26,6 +26,7 @@ $helper->space();
 
 $helper->assert('ObjectValue extends Value', $value instanceof \V8\Value);
 $helper->assert('ObjectValue does not extend PrimitiveValue', !($value instanceof \V8\PrimitiveValue));
+$helper->assert('ObjectValue implements AdjustableExternalMemoryInterface', $value instanceof \V8\AdjustableExternalMemoryInterface);
 $helper->line();
 
 $helper->header('Accessors');
@@ -103,6 +104,7 @@ object(V8\ObjectValue)#6 (2) {
 
 ObjectValue extends Value: ok
 ObjectValue does not extend PrimitiveValue: ok
+ObjectValue implements AdjustableExternalMemoryInterface: ok
 
 Accessors:
 ----------
@@ -149,7 +151,7 @@ V8\ObjectValue(V8\Value)->IsRegExp(): bool(false)
 Converters:
 -----------
 V8\ObjectValue(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#93 (1) {
+    object(V8\BooleanValue)#95 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -165,7 +167,7 @@ V8\ObjectValue(V8\Value)->ToBoolean():
       }
     }
 V8\ObjectValue(V8\Value)->ToNumber():
-    object(V8\NumberValue)#93 (1) {
+    object(V8\NumberValue)#95 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -181,7 +183,7 @@ V8\ObjectValue(V8\Value)->ToNumber():
       }
     }
 V8\ObjectValue(V8\Value)->ToString():
-    object(V8\StringValue)#93 (1) {
+    object(V8\StringValue)#95 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -197,7 +199,7 @@ V8\ObjectValue(V8\Value)->ToString():
       }
     }
 V8\ObjectValue(V8\Value)->ToDetailString():
-    object(V8\StringValue)#93 (1) {
+    object(V8\StringValue)#95 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -266,7 +268,7 @@ V8\ObjectValue(V8\Value)->ToObject():
       }
     }
 V8\ObjectValue(V8\Value)->ToInteger():
-    object(V8\NumberValue)#93 (1) {
+    object(V8\NumberValue)#95 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -282,7 +284,7 @@ V8\ObjectValue(V8\Value)->ToInteger():
       }
     }
 V8\ObjectValue(V8\Value)->ToUint32():
-    object(V8\NumberValue)#93 (1) {
+    object(V8\NumberValue)#95 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -298,7 +300,7 @@ V8\ObjectValue(V8\Value)->ToUint32():
       }
     }
 V8\ObjectValue(V8\Value)->ToInt32():
-    object(V8\NumberValue)#93 (1) {
+    object(V8\NumberValue)#95 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8StringObject.phpt
+++ b/tests/V8StringObject.phpt
@@ -127,7 +127,7 @@ StringObject extends ObjectValue: ok
 Getters:
 --------
 V8\StringObject->ValueOf():
-    object(V8\StringValue)#96 (1) {
+    object(V8\StringValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8SymbolObject.phpt
+++ b/tests/V8SymbolObject.phpt
@@ -130,7 +130,7 @@ SymbolObject extends ObjectValue: ok
 Getters:
 --------
 V8\SymbolObject->ValueOf():
-    object(V8\SymbolValue)#96 (1) {
+    object(V8\SymbolValue)#98 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/v8.cc
+++ b/v8.cc
@@ -98,71 +98,71 @@ PHP_INI_END()
  */
 PHP_MINIT_FUNCTION(v8)
 {
-	PHP_MINIT(php_v8_exceptions)(INIT_FUNC_ARGS_PASSTHRU);	/* Exceptions */
-    PHP_MINIT(php_v8_ext_mem_interface)(INIT_FUNC_ARGS_PASSTHRU);	/* AdjustableExternalMemoryInterface */
+    PHP_MINIT(php_v8_exceptions)(INIT_FUNC_ARGS_PASSTHRU);    /* Exceptions */
+    PHP_MINIT(php_v8_ext_mem_interface)(INIT_FUNC_ARGS_PASSTHRU);    /* AdjustableExternalMemoryInterface */
 
-	PHP_MINIT(php_v8_heap_statistics)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_startup_data)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_isolate)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_context)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_script)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_heap_statistics)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_startup_data)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_isolate)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_context)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_script)(INIT_FUNC_ARGS_PASSTHRU);
 
-	PHP_MINIT(php_v8_exception)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_try_catch)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_message)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_stack_frame)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_stack_trace)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_script_origin_options)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_script_origin)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_exception)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_try_catch)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_message)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_stack_frame)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_stack_trace)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_script_origin_options)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_script_origin)(INIT_FUNC_ARGS_PASSTHRU);
 
-	PHP_MINIT(php_v8_data)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_value)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_primitive)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_null)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_boolean)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_name)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_string)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_symbol)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_number)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_integer)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_int32)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_uint32)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_integrity_level)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_object)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_function)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_array)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_date)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_regexp)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_data)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_value)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_primitive)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_null)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_boolean)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_name)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_string)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_symbol)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_number)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_integer)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_int32)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_uint32)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_integrity_level)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_object)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_function)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_array)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_date)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_regexp)(INIT_FUNC_ARGS_PASSTHRU);
 
-	PHP_MINIT(php_v8_number_object)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_boolean_object)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_string_object)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_symbol_object)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_number_object)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_boolean_object)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_string_object)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_symbol_object)(INIT_FUNC_ARGS_PASSTHRU);
 
-	PHP_MINIT(php_v8_template)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_object_template)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_function_template)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_template)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_object_template)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_function_template)(INIT_FUNC_ARGS_PASSTHRU);
 
 
-	PHP_MINIT(php_v8_property_attribute)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants for v8 internals similarity/compatibility */
-	PHP_MINIT(php_v8_access_control)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants */
-	PHP_MINIT(php_v8_return_value)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_property_attribute)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants for v8 internals similarity/compatibility */
+    PHP_MINIT(php_v8_access_control)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants */
+    PHP_MINIT(php_v8_return_value)(INIT_FUNC_ARGS_PASSTHRU);
 
-	PHP_MINIT(php_v8_callback_info)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_property_callback_info)(INIT_FUNC_ARGS_PASSTHRU); /* PropertyCallbackInfo inherits CallbackInfo */
-	PHP_MINIT(php_v8_function_callback_info)(INIT_FUNC_ARGS_PASSTHRU); /* FunctionCallbackInfo inherits CallbackInfo */
+    PHP_MINIT(php_v8_callback_info)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_property_callback_info)(INIT_FUNC_ARGS_PASSTHRU); /* PropertyCallbackInfo inherits CallbackInfo */
+    PHP_MINIT(php_v8_function_callback_info)(INIT_FUNC_ARGS_PASSTHRU); /* FunctionCallbackInfo inherits CallbackInfo */
 
-	PHP_MINIT(php_v8_property_handler_flags)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants */
-	PHP_MINIT(php_v8_named_property_handler_configuration)(INIT_FUNC_ARGS_PASSTHRU);
-	PHP_MINIT(php_v8_indexed_property_handler_configuration)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_property_handler_flags)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants */
+    PHP_MINIT(php_v8_named_property_handler_configuration)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_indexed_property_handler_configuration)(INIT_FUNC_ARGS_PASSTHRU);
 
-	PHP_MINIT(php_v8_access_type)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants */
+    PHP_MINIT(php_v8_access_type)(INIT_FUNC_ARGS_PASSTHRU); /* Helper class, holds constants */
 
-	/* If you have INI entries, uncomment these lines
-	REGISTER_INI_ENTRIES();
-	*/
+    /* If you have INI entries, uncomment these lines
+    REGISTER_INI_ENTRIES();
+    */
 
-	return SUCCESS;
+    return SUCCESS;
 }
 /* }}} */
 
@@ -170,10 +170,10 @@ PHP_MINIT_FUNCTION(v8)
  */
 PHP_MSHUTDOWN_FUNCTION(v8)
 {
-	/* uncomment this line if you have INI entries
-	UNREGISTER_INI_ENTRIES();
-	*/
-	return SUCCESS;
+    /* uncomment this line if you have INI entries
+    UNREGISTER_INI_ENTRIES();
+    */
+    return SUCCESS;
 }
 /* }}} */
 
@@ -182,7 +182,7 @@ PHP_MSHUTDOWN_FUNCTION(v8)
  */
 PHP_RINIT_FUNCTION(v8)
 {
-	return SUCCESS;
+    return SUCCESS;
 }
 /* }}} */
 
@@ -191,7 +191,7 @@ PHP_RINIT_FUNCTION(v8)
  */
 PHP_RSHUTDOWN_FUNCTION(v8)
 {
-	return SUCCESS;
+    return SUCCESS;
 }
 /* }}} */
 
@@ -199,21 +199,21 @@ PHP_RSHUTDOWN_FUNCTION(v8)
  */
 PHP_MINFO_FUNCTION(v8)
 {
-	php_info_print_table_start();
-	php_info_print_table_header(2, "V8 support", "enabled");
-	php_info_print_table_row(2, "Version", PHP_V8_VERSION);
-	php_info_print_table_row(2, "Revision", PHP_V8_REVISION);
-	php_info_print_table_row(2, "Compiled", __DATE__ " @ "  __TIME__);
-	php_info_print_table_end();
+    php_info_print_table_start();
+    php_info_print_table_header(2, "V8 support", "enabled");
+    php_info_print_table_row(2, "Version", PHP_V8_VERSION);
+    php_info_print_table_row(2, "Revision", PHP_V8_REVISION);
+    php_info_print_table_row(2, "Compiled", __DATE__ " @ "  __TIME__);
+    php_info_print_table_end();
 
-	php_info_print_table_start();
-	php_info_print_table_row(2, "V8 Engine Compiled Version", PHP_V8_LIBV8_VERSION);
-	php_info_print_table_row(2, "V8 Engine Linked Version", v8::V8::GetVersion());
-	php_info_print_table_end();
+    php_info_print_table_start();
+    php_info_print_table_row(2, "V8 Engine Compiled Version", PHP_V8_LIBV8_VERSION);
+    php_info_print_table_row(2, "V8 Engine Linked Version", v8::V8::GetVersion());
+    php_info_print_table_end();
 
-	/* Remove comments if you have entries in php.ini
-	DISPLAY_INI_ENTRIES();
-	*/
+    /* Remove comments if you have entries in php.ini
+    DISPLAY_INI_ENTRIES();
+    */
 }
 /* }}} */
 
@@ -223,9 +223,9 @@ PHP_MINFO_FUNCTION(v8)
 static PHP_GINIT_FUNCTION(v8)
 {
 #if defined(COMPILE_DL_V8) && defined(ZTS)
-	ZEND_TSRMLS_CACHE_UPDATE();
+    ZEND_TSRMLS_CACHE_UPDATE();
 #endif
-	v8_globals->v8_initialized = false;
+    v8_globals->v8_initialized = false;
 }
 /* }}} */
 
@@ -243,27 +243,27 @@ static PHP_GSHUTDOWN_FUNCTION(v8)
  * Every user visible function must have an entry in php_v8_functions[].
  */
 const zend_function_entry php_v8_functions[] = {
-	PHP_FE_END	/* Must be the last line in php_v8_functions[] */
+    PHP_FE_END    /* Must be the last line in php_v8_functions[] */
 };
 /* }}} */
 
 /* {{{ php_v8_module_entry
  */
 zend_module_entry php_v8_module_entry = {
-	STANDARD_MODULE_HEADER,
-	"v8",
-	php_v8_functions,
-	PHP_MINIT(v8),
-	PHP_MSHUTDOWN(v8),
-	PHP_RINIT(v8),		/* Replace with NULL if there's nothing to do at request start */
-	PHP_RSHUTDOWN(v8),	/* Replace with NULL if there's nothing to do at request end */
-	PHP_MINFO(v8),
-	PHP_V8_VERSION,
-	PHP_MODULE_GLOBALS(v8),
-	PHP_GINIT(v8),
-	PHP_GSHUTDOWN(v8),
-	NULL,
-	STANDARD_MODULE_PROPERTIES_EX
+    STANDARD_MODULE_HEADER,
+    "v8",
+    php_v8_functions,
+    PHP_MINIT(v8),
+    PHP_MSHUTDOWN(v8),
+    PHP_RINIT(v8),        /* Replace with NULL if there's nothing to do at request start */
+    PHP_RSHUTDOWN(v8),    /* Replace with NULL if there's nothing to do at request end */
+    PHP_MINFO(v8),
+    PHP_V8_VERSION,
+    PHP_MODULE_GLOBALS(v8),
+    PHP_GINIT(v8),
+    PHP_GSHUTDOWN(v8),
+    NULL,
+    STANDARD_MODULE_PROPERTIES_EX
 
 };
 /* }}} */

--- a/v8.cc
+++ b/v8.cc
@@ -67,6 +67,7 @@
 
 #include "php_v8_value.h"
 #include "php_v8_data.h"
+#include "php_v8_ext_mem_interface.h"
 
 #include <v8.h>
 
@@ -98,6 +99,7 @@ PHP_INI_END()
 PHP_MINIT_FUNCTION(v8)
 {
 	PHP_MINIT(php_v8_exceptions)(INIT_FUNC_ARGS_PASSTHRU);	/* Exceptions */
+    PHP_MINIT(php_v8_ext_mem_interface)(INIT_FUNC_ARGS_PASSTHRU);	/* AdjustableExternalMemoryInterface */
 
 	PHP_MINIT(php_v8_heap_statistics)(INIT_FUNC_ARGS_PASSTHRU);
 	PHP_MINIT(php_v8_startup_data)(INIT_FUNC_ARGS_PASSTHRU);


### PR DESCRIPTION
In this PR new methods added and some internal logic refactored

In this PR:
 - add `V8\AdjustableExternalMemoryInterface` interface;
 - add `V8\ObjectValue::AdjustExternalAllocatedMemory()` method;
 - add `V8\ObjectValue::GetExternalAllocatedMemory()` method;
 - add `V8\FunctionTemplate::AdjustExternalAllocatedMemory()` method;
 - add `V8\FunctionTemplate::GetExternalAllocatedMemory()` method;
 - add `V8\ObjectTemplate::AdjustExternalAllocatedMemory()` method;
 - add `V8\ObjectTemplate::GetExternalAllocatedMemory()` method;
 - rewrite callbacks structures to use std containers;
 - use realistic external allocated memory value to notify isolate about based on callbacks structures size and optionally specified by user value.  
