### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
   - sudo add-apt-repository ppa:pinepain/libv8-${V8} -y
   - sudo apt-get update -q
   - sudo apt-get install -y libv8-${V8}-dev
+  - php -i
+  - php-config || true
 
 before_script:
   - echo 'variables_order = "EGPCS"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/tests/V8Int32Value.phpt
+++ b/tests/V8Int32Value.phpt
@@ -54,7 +54,7 @@ $helper->space();
 
 
 $helper->header('Test negative value in constructor');
-$value = new V8\Int32Value($isolate, -123.456);
+$value = new V8\Int32Value($isolate, -123);
 $helper->method_export($value, 'Value');
 $helper->method_export($value, 'BooleanValue', [$context]);
 $helper->method_export($value, 'NumberValue', [$context]);

--- a/tests/V8IntegerValue.phpt
+++ b/tests/V8IntegerValue.phpt
@@ -54,7 +54,7 @@ $helper->space();
 
 
 $helper->header('Test negative value in constructor');
-$value = new V8\IntegerValue($isolate, -123.456);
+$value = new V8\IntegerValue($isolate, -123);
 $helper->method_export($value, 'Value');
 $helper->method_export($value, 'BooleanValue', [$context]);
 $helper->method_export($value, 'NumberValue', [$context]);

--- a/tests/V8StringValue.phpt
+++ b/tests/V8StringValue.phpt
@@ -13,7 +13,6 @@ $v8_helper = new PhpV8Helpers($helper);
 
 // Tests:
 
-
 $isolate = new V8\Isolate();
 
 $default = new V8\StringValue($isolate);
@@ -87,7 +86,6 @@ foreach (['Hello, world!', 'Привет, мир!', 'こんにちは世界'] as 
   $helper->method_export($value, 'ContainsOnlyOneByte');
 
   $helper->function_export('strlen', [$value->Value()]);
-  $helper->function_export('mb_strlen', [$value->Value()]);
   $helper->space();
 }
 
@@ -207,7 +205,6 @@ V8\StringValue->Utf8Length(): int(13)
 V8\StringValue->IsOneByte(): bool(true)
 V8\StringValue->ContainsOnlyOneByte(): bool(true)
 strlen(): 13
-mb_strlen(): 13
 
 
 V8\StringValue->Value(): string(21) "Привет, мир!"
@@ -216,7 +213,6 @@ V8\StringValue->Utf8Length(): int(21)
 V8\StringValue->IsOneByte(): bool(false)
 V8\StringValue->ContainsOnlyOneByte(): bool(false)
 strlen(): 21
-mb_strlen(): 12
 
 
 V8\StringValue->Value(): string(21) "こんにちは世界"
@@ -225,4 +221,3 @@ V8\StringValue->Utf8Length(): int(21)
 V8\StringValue->IsOneByte(): bool(false)
 V8\StringValue->ContainsOnlyOneByte(): bool(false)
 strlen(): 21
-mb_strlen(): 7


### PR DESCRIPTION
This PR:
 - fix arguments type mismatch in `V8\IntegerValue` and it children tests (#16);
 - remove `mbstring` extension dependency as it may not be always available by default;
 - display php info in Travis CI builds.