### PR TITLE
Add missed features, cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
     - NO_INTERACTION=1
     - TEST_TIMEOUT=120
   matrix:
-    - V8=5.7
-    - V8=5.7 TEST_PHP_ARGS=-m
+    - V8=5.8
+    - V8=5.8 TEST_PHP_ARGS=-m
 
 before_install:
   - sudo add-apt-repository ppa:pinepain/libv8-${V8} -y

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(php_v8)
 
 # NOTE: This CMake file is just for syntax highlighting in CLion
 
-include_directories(/usr/local/opt/v8@5.7/include)
-include_directories(/usr/local/opt/v8@5.7/include/libplatform)
+include_directories(/usr/local/opt/v8@5.8/include)
+include_directories(/usr/local/opt/v8@5.8/include/libplatform)
 
 include_directories(/usr/local/include/php)
 include_directories(/usr/local/include/php/TSRM)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ in your IDE and other code-analysis tools.
 ### Requirements
 
 #### V8
-You will need a recent v8 Google JavaScript engine version installed. At this time the extension is tested on 5.7.514.
+You will need a recent v8 Google JavaScript engine version installed. At this time the extension is tested on 5.8.168.
 
 #### PHP
 This extension is PHP7-only. It works and tested with both PHP 7.0 and PHP 7.1.
@@ -96,7 +96,7 @@ $ php --ri v8
 
 While [pinepain/php](https://launchpad.net/~pinepain/+archive/ubuntu/php) PPA targets to contain all necessary
 extensions with dependencies, you may find
-[pinepain/libv8-5.7](https://launchpad.net/~pinepain/+archive/ubuntu/libv8-5.7),
+[pinepain/libv8-5.8](https://launchpad.net/~pinepain/+archive/ubuntu/libv8-5.8),
 [pinepain/libv8-experimental](https://launchpad.net/~pinepain/+archive/ubuntu/libv8-experimental) and
 [pinepain/php-v8](https://launchpad.net/~pinepain/+archive/ubuntu/php-v8) standalone PPAs useful.
 
@@ -108,7 +108,7 @@ $ brew tap homebrew/dupes
 $ brew tap homebrew/php
 $ brew tap pinepain/devtools
 $ brew install php70 
-$ brew install v8@5.7
+$ brew install v8@5.8
 $ brew install php70-v8
 $ php --ri v8
 ```

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ $ sudo make install
  - to be able to customize some tests make sure you have `variables_order = "EGPCS"` in your php.ini
  - `export DEV_TESTS=1` allows to run tests that are made for development reasons (e.g. test some weird behavior or for debugging)
  - To prevent the test suite from asking you to send results to the PHP QA team do `export NO_INTERACTION=1`
+ - To run tests with memory leaaks check, install `valgrind` and do `export TEST_PHP_ARGS="-m"`
 
  - To track memory usage you may want to use `smem`, `pmem` or even `lsof` to see what shared object are loaded
    and `free` to display free and used memory in the system.

--- a/config.m4
+++ b/config.m4
@@ -170,6 +170,7 @@ if test "$PHP_V8" != "no"; then
     src/php_v8_unbound_script.cc                          \
     src/php_v8_cached_data.cc                             \
     src/php_v8_compile_options.cc                         \
+    src/php_v8_script_compiler.cc                         \
     src/php_v8_source.cc                                  \
     src/php_v8_data.cc                                    \
     src/php_v8_value.cc                                   \

--- a/config.m4
+++ b/config.m4
@@ -170,6 +170,7 @@ if test "$PHP_V8" != "no"; then
     src/php_v8_unbound_script.cc                          \
     src/php_v8_cached_data.cc                             \
     src/php_v8_compile_options.cc                         \
+    src/php_v8_source.cc                                  \
     src/php_v8_data.cc                                    \
     src/php_v8_value.cc                                   \
     src/php_v8_primitive.cc                               \

--- a/config.m4
+++ b/config.m4
@@ -185,6 +185,7 @@ if test "$PHP_V8" != "no"; then
     src/php_v8_object_template.cc                         \
     src/php_v8_function_template.cc                       \
     src/php_v8_script.cc                                  \
+    src/php_v8_unbound_script.cc                          \
     src/php_v8_data.cc                                    \
     src/php_v8_value.cc                                   \
     src/php_v8_primitive.cc                               \

--- a/config.m4
+++ b/config.m4
@@ -169,6 +169,7 @@ if test "$PHP_V8" != "no"; then
     src/php_v8_script.cc                                  \
     src/php_v8_unbound_script.cc                          \
     src/php_v8_cached_data.cc                             \
+    src/php_v8_compile_options.cc                         \
     src/php_v8_data.cc                                    \
     src/php_v8_value.cc                                   \
     src/php_v8_primitive.cc                               \

--- a/config.m4
+++ b/config.m4
@@ -168,6 +168,7 @@ if test "$PHP_V8" != "no"; then
     src/php_v8_function_template.cc                       \
     src/php_v8_script.cc                                  \
     src/php_v8_unbound_script.cc                          \
+    src/php_v8_cached_data.cc                             \
     src/php_v8_data.cc                                    \
     src/php_v8_value.cc                                   \
     src/php_v8_primitive.cc                               \

--- a/config.m4
+++ b/config.m4
@@ -8,7 +8,7 @@ if test "$PHP_V8" != "no"; then
   SEARCH_PATH="/usr/local /usr"
   SEARCH_FOR="include/v8.h"
 
-  V8_MIN_API_VERSION_STR=5.7.514
+  V8_MIN_API_VERSION_STR=5.8.168
 
   DESIRED_V8_VERSION=`echo "${V8_MIN_API_VERSION_STR}" | $AWK 'BEGIN { FS = "."; } { printf "%s.%s", [$]1, [$]2;}'`
 
@@ -127,7 +127,7 @@ if test "$PHP_V8" != "no"; then
   #     php/Zend/zend_operators.h:128:18: warning: 'finite' is deprecated: first deprecated in macOS 10.9 [-Wdeprecated-declarations]
   # but as we want to track also deprecated methods from v8 we won't ignore -Wdeprecated-declarations warnings
   # We want to make building log cleaner, so let's suppress only -Wdeprecated-register warning
-  PHP_V8_COMPILER_OPTIONS="-Wno-deprecated-register"
+  PHP_V8_COMPILER_OPTIONS="-Wno-deprecated-register -Wno-unicode"
   #PHP_V8_COMPILER_OPTIONS="-Wno-deprecated-register -Wno-deprecated-declarations"
 
   AC_DEFINE([V8_DEPRECATION_WARNINGS], [1], [Enable compiler warnings when using V8_DEPRECATED apis.])

--- a/php_v8.h
+++ b/php_v8.h
@@ -29,8 +29,8 @@ extern "C" {
 extern zend_module_entry php_v8_module_entry;
 #define phpext_v8_ptr &php_v8_module_entry
 
-#ifndef PHP_V8_LIB_DIR
-#define PHP_V8_LIB_DIR NULL
+#ifndef PHP_V8_ICU_DATA_DIR
+#define PHP_V8_ICU_DATA_DIR NULL
 #endif
 
 #ifndef PHP_V8_VERSION

--- a/src/php_v8_a.cc
+++ b/src/php_v8_a.cc
@@ -27,7 +27,7 @@ void php_v8_init()
         return;
     }
 
-    v8::V8::InitializeICUDefaultLocation(PHP_V8_LIB_DIR);
+    v8::V8::InitializeICUDefaultLocation(PHP_V8_ICU_DATA_DIR);
 
     // NOTE: if we use snapshot and extenal startup data then we have to initialize it (see https://codereview.chromium.org/315033002/)
     // v8::V8::InitializeExternalStartupData(NULL);

--- a/src/php_v8_cached_data.cc
+++ b/src/php_v8_cached_data.cc
@@ -1,0 +1,146 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php_v8_cached_data.h"
+#include "php_v8_string.h"
+#include "php_v8.h"
+
+
+zend_class_entry * php_v8_cached_data_class_entry;
+#define this_ce php_v8_cached_data_class_entry
+
+static zend_object_handlers php_v8_cached_data_object_handlers;
+
+php_v8_cached_data_t * php_v8_cached_data_fetch_object(zend_object *obj) {
+    return (php_v8_cached_data_t *)((char *)obj - XtOffsetOf(php_v8_cached_data_t, std));
+}
+
+php_v8_cached_data_t * php_v8_create_cached_data(zval *return_value, const v8::ScriptCompiler::CachedData *cached_data) {
+
+    object_init_ex(return_value, this_ce);
+    PHP_V8_FETCH_CACHED_DATA_INTO(return_value, php_v8_cached_data);
+
+    int length = cached_data->length;
+    uint8_t* data = new uint8_t[length];
+    memcpy(data, cached_data->data, static_cast<size_t>(length));
+
+    php_v8_cached_data->cached_data = new v8::ScriptCompiler::CachedData(data, length, v8::ScriptCompiler::CachedData::BufferPolicy::BufferOwned);
+
+    return php_v8_cached_data;
+}
+
+static void php_v8_cached_data_free(zend_object *object)
+{
+    php_v8_cached_data_t *php_v8_cached_data = php_v8_cached_data_fetch_object(object);
+
+    if (php_v8_cached_data->cached_data) {
+        delete php_v8_cached_data->cached_data;
+    }
+
+    zend_object_std_dtor(&php_v8_cached_data->std);
+}
+
+static zend_object * php_v8_cached_data_ctor(zend_class_entry *ce)
+{
+    php_v8_cached_data_t *php_v8_cached_data;
+
+    php_v8_cached_data = (php_v8_cached_data_t *) ecalloc(1, sizeof(php_v8_cached_data_t) + zend_object_properties_size(ce));
+
+    zend_object_std_init(&php_v8_cached_data->std, ce);
+    object_properties_init(&php_v8_cached_data->std, ce);
+
+    php_v8_cached_data->std.handlers = &php_v8_cached_data_object_handlers;
+
+    return &php_v8_cached_data->std;
+}
+
+static PHP_METHOD(V8CachedData, __construct)
+{
+    zend_string *string = NULL;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &string) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_CHECK_CACHE_DATA_STRING_RANGE(string, "CachedData data string is too long");
+
+    PHP_V8_FETCH_CACHED_DATA_INTO(getThis(), php_v8_cached_data);
+
+    int length = static_cast<int>(MAYBE_ZSTR_LEN(string));
+    uint8_t* data = new uint8_t[length];
+    memcpy(data, MAYBE_ZSTR_VAL(string), static_cast<size_t>(length));
+
+    php_v8_cached_data->cached_data = new v8::ScriptCompiler::CachedData(data, length, v8::ScriptCompiler::CachedData::BufferPolicy::BufferOwned);
+}
+
+static PHP_METHOD(V8CachedData, GetData)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_CACHED_DATA_WITH_CHECK(getThis(), php_v8_cached_data);
+
+    RETVAL_STRINGL(reinterpret_cast<const char*>(php_v8_cached_data->cached_data->data), php_v8_cached_data->cached_data->length);
+}
+
+static PHP_METHOD(V8CachedData, IsRejected)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_CACHED_DATA_WITH_CHECK(getThis(), php_v8_cached_data);
+
+    RETVAL_BOOL(php_v8_cached_data->cached_data->rejected);
+}
+
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_cached_data___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
+                ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_cached_data_GetData, ZEND_RETURN_VALUE, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_cached_data_IsRejected, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+
+static const zend_function_entry php_v8_cached_data_methods[] = {
+    PHP_ME(V8CachedData, __construct,   arginfo_v8_cached_data___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(V8CachedData, GetData,       arginfo_v8_cached_data_GetData,     ZEND_ACC_PUBLIC)
+    PHP_ME(V8CachedData, IsRejected,    arginfo_v8_cached_data_IsRejected,  ZEND_ACC_PUBLIC)
+
+    PHP_FE_END
+};
+
+
+PHP_MINIT_FUNCTION(php_v8_cached_data)
+{
+    zend_class_entry ce;
+
+    INIT_NS_CLASS_ENTRY(ce, "V8\\ScriptCompiler", "CachedData", php_v8_cached_data_methods);
+    this_ce = zend_register_internal_class(&ce);
+    this_ce->create_object = php_v8_cached_data_ctor;
+
+    memcpy(&php_v8_cached_data_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+
+    php_v8_cached_data_object_handlers.offset = XtOffsetOf(php_v8_cached_data_t, std);
+    php_v8_cached_data_object_handlers.free_obj = php_v8_cached_data_free;
+
+    return SUCCESS;
+}

--- a/src/php_v8_cached_data.h
+++ b/src/php_v8_cached_data.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifndef PHP_V8_CACHED_DATA_H
+#define PHP_V8_CACHED_DATA_H
+
+typedef struct _php_v8_cached_data_t php_v8_cached_data_t;
+
+#include "php_v8_exceptions.h"
+#include <v8.h>
+
+extern "C" {
+#include "php.h"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+}
+
+extern zend_class_entry *php_v8_cached_data_class_entry;
+
+extern php_v8_cached_data_t * php_v8_cached_data_fetch_object(zend_object *obj);
+extern php_v8_cached_data_t * php_v8_create_cached_data(zval *return_value, const v8::ScriptCompiler::CachedData *cached_data);
+
+
+#define PHP_V8_FETCH_CACHED_DATA(zv) php_v8_cached_data_fetch_object(Z_OBJ_P(zv))
+#define PHP_V8_FETCH_CACHED_DATA_INTO(pzval, into) php_v8_cached_data_t *(into) = PHP_V8_FETCH_CACHED_DATA((pzval))
+
+#define PHP_V8_EMPTY_CACHED_DATA_MSG "CachedData" PHP_V8_EMPTY_HANDLER_MSG_PART
+#define PHP_V8_CHECK_EMPTY_CACHED_DATA_HANDLER(val) if (NULL == (val)->cached_data) { PHP_V8_THROW_EXCEPTION( PHP_V8_EMPTY_CACHED_DATA_MSG); return; }
+
+
+#define PHP_V8_FETCH_CACHED_DATA_WITH_CHECK(pzval, into) \
+    PHP_V8_FETCH_CACHED_DATA_INTO(pzval, into); \
+    PHP_V8_CHECK_EMPTY_CACHED_DATA_HANDLER(into);
+
+
+#define PHP_V8_CHECK_CACHE_DATA_STRING_RANGE(str, message) \
+    if (MAYBE_ZSTR_LEN(str) > INT_MAX) { \
+        PHP_V8_THROW_VALUE_EXCEPTION(message); \
+        return; \
+    }
+
+
+struct _php_v8_cached_data_t {
+    v8::ScriptCompiler::CachedData *cached_data;
+
+  zend_object std;
+};
+
+PHP_MINIT_FUNCTION(php_v8_cached_data);
+
+#endif //PHP_V8_CACHED_DATA_H

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -268,7 +268,7 @@ void php_v8_callback_call_from_bucket_with_zargs(size_t index, v8::Local<v8::Val
         ZVAL_ZVAL(retval, fci.retval, 1, 1);
     }
 
-    // TODO: what about exceptions? - we let user handle any case of exceptions for themself
+    // TODO: what about exceptions? - we let user handle any case of exceptions for themselves
 
     /* Clean up our mess */
     zend_fcall_info_args_clear(&fci, 1);

--- a/src/php_v8_compile_options.cc
+++ b/src/php_v8_compile_options.cc
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php_v8_compile_options.h"
+#include "php_v8.h"
+
+zend_class_entry* php_v8_compile_options_class_entry;
+#define this_ce php_v8_compile_options_class_entry
+
+
+static const zend_function_entry php_v8_compile_options_methods[] = {
+        PHP_FE_END
+};
+
+PHP_MINIT_FUNCTION(php_v8_compile_options) {
+    zend_class_entry ce;
+    INIT_NS_CLASS_ENTRY(ce, "V8\\ScriptCompiler", "CompileOptions", php_v8_compile_options_methods);
+    this_ce = zend_register_internal_class(&ce);
+
+    zend_declare_class_constant_long(this_ce, ZEND_STRL("kNoCompileOptions"), v8::ScriptCompiler::CompileOptions::kNoCompileOptions);
+    zend_declare_class_constant_long(this_ce, ZEND_STRL("kProduceParserCache"), v8::ScriptCompiler::CompileOptions::kProduceParserCache);
+    zend_declare_class_constant_long(this_ce, ZEND_STRL("kConsumeParserCache"), v8::ScriptCompiler::CompileOptions::kConsumeParserCache);
+    zend_declare_class_constant_long(this_ce, ZEND_STRL("kProduceCodeCache"), v8::ScriptCompiler::CompileOptions::kProduceCodeCache);
+    zend_declare_class_constant_long(this_ce, ZEND_STRL("kConsumeCodeCache"), v8::ScriptCompiler::CompileOptions::kConsumeCodeCache);
+
+    return SUCCESS;
+}

--- a/src/php_v8_compile_options.h
+++ b/src/php_v8_compile_options.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifndef PHP_V8_COMPILE_OPTIONS_H
+#define PHP_V8_COMPILE_OPTIONS_H
+
+#include "php_v8_exceptions.h"
+#include <v8.h>
+
+extern "C" {
+#include "php.h"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+}
+
+extern zend_class_entry* php_v8_compile_options_class_entry;
+
+#define PHP_V8_CHECK_COMPILER_OPTIONS_RANGE(options, message) \
+    if (options < static_cast<zend_long>(v8::ScriptCompiler::CompileOptions::kNoCompileOptions) \
+         || options > static_cast<zend_long>(v8::ScriptCompiler::CompileOptions::kConsumeCodeCache)) { \
+        PHP_V8_THROW_VALUE_EXCEPTION(message); \
+        return; \
+    }
+
+PHP_MINIT_FUNCTION (php_v8_compile_options);
+
+
+#endif //PHP_V8_COMPILE_OPTIONS_H

--- a/src/php_v8_context.cc
+++ b/src/php_v8_context.cc
@@ -89,7 +89,6 @@ php_v8_context_t * php_v8_context_get_reference(v8::Local<v8::Context> context) 
 static PHP_METHOD(V8Context, __construct)
 {
     zval *php_v8_isolate_zv;
-    zval *extensions_zv = NULL;
     zval *php_v8_global_template_zv = NULL;
     zval *php_v8_global_object_zv = NULL;
 
@@ -97,7 +96,7 @@ static PHP_METHOD(V8Context, __construct)
     v8::Local<v8::ObjectTemplate> global_template;
     v8::Local<v8::Value> global_object;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o|a!o!o!", &php_v8_isolate_zv, &extensions_zv, &php_v8_global_template_zv, &php_v8_global_object_zv) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o|o!o!", &php_v8_isolate_zv, &php_v8_global_template_zv, &php_v8_global_object_zv) == FAILURE) {
         return;
     }
 
@@ -108,18 +107,8 @@ static PHP_METHOD(V8Context, __construct)
     PHP_V8_STORE_POINTER_TO_ISOLATE(php_v8_context, php_v8_isolate);
     PHP_V8_ENTER_ISOLATE(php_v8_isolate);
 
-    if (extensions_zv) {
-        zend_update_property(this_ce, getThis(), ZEND_STRL("extensions"), extensions_zv);
-    }
-
     if (php_v8_global_template_zv) {
         zend_update_property(this_ce, getThis(), ZEND_STRL("global_template"), php_v8_global_template_zv);
-    }
-
-    // TODO: implement extensions, note this feature is controversial, it also requires v8::RegisterExtension()
-    // TODO: store registered extensions somewhere and validate them by name before setting?
-    if (extensions_zv && zend_array_count(Z_ARRVAL_P(extensions_zv)) > 0) {
-        zend_error(E_WARNING, "Extensions are not supported yet");
     }
 
     if (php_v8_global_template_zv && Z_TYPE_P(php_v8_global_template_zv) != IS_NULL) {
@@ -308,7 +297,6 @@ static PHP_METHOD(V8Context, EstimatedSize)
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_context___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
     ZEND_ARG_OBJ_INFO(0, isolate, V8\\Isolate, 0)
-    ZEND_ARG_ARRAY_INFO(0, extensions, 1)
     ZEND_ARG_OBJ_INFO(0, global_template, V8\\ObjectTemplate, 1)
     ZEND_ARG_OBJ_INFO(0, global_object, V8\\ObjectValue, 1)
 ZEND_END_ARG_INFO()
@@ -383,7 +371,6 @@ PHP_MINIT_FUNCTION(php_v8_context)
     this_ce->create_object = php_v8_context_ctor;
 
     zend_declare_property_null(this_ce, ZEND_STRL("isolate"), ZEND_ACC_PRIVATE);
-    zend_declare_property_null(this_ce, ZEND_STRL("extensions"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(this_ce, ZEND_STRL("global_template"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(this_ce, ZEND_STRL("global_object"), ZEND_ACC_PRIVATE);
 

--- a/src/php_v8_exceptions.h
+++ b/src/php_v8_exceptions.h
@@ -108,6 +108,7 @@ extern void php_v8_throw_try_catch_exception(php_v8_context_t *php_v8_context, v
 //#define PHP_V8_CHECK_EMPTY_HANDLER(val, message) if (NULL == (val)->php_v8_isolate || (val)->persistent->IsEmpty()) { PHP_V8_THROW_EXCEPTION(message); return; }
 // we check handler to be !IsEmpty() in constructors and before value creations, so unless we didn't check that by mistacke, IsEmpty() check may be skipped
 #define PHP_V8_CHECK_EMPTY_HANDLER(val, message) if (NULL == (val)->php_v8_isolate) { PHP_V8_THROW_EXCEPTION(message); return; }
+#define PHP_V8_CHECK_EMPTY_HANDLER_RET(val, message, ret) if (NULL == (val)->php_v8_isolate) { PHP_V8_THROW_EXCEPTION(message); return (ret); }
 
 
 PHP_MINIT_FUNCTION(php_v8_exceptions);

--- a/src/php_v8_function.h
+++ b/src/php_v8_function.h
@@ -27,7 +27,10 @@ extern "C" {
 extern zend_class_entry* php_v8_function_class_entry;
 
 extern v8::Local<v8::Function> php_v8_value_get_function_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-extern bool php_v8_function_unpack_args(zval* arguments_zv, zval *this_ptr, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::Value> **argv);
+extern bool
+php_v8_function_unpack_args(zval *arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::Value> **argv);
+extern bool php_v8_function_unpack_string_args(zval* arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::String> **argv);
+extern bool php_v8_function_unpack_object_args(zval* arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::Object> **argv);
 
 #define PHP_V8_CHECK_FUNCTION_LENGTH_RANGE(val, message) \
     if ((val) > INT_MAX || (val) < INT_MIN) { \

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -1196,7 +1196,7 @@ static PHP_METHOD(V8Object, CallAsFunction) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    if (!php_v8_function_unpack_args(arguments_zv, getThis(), 3, isolate, &argc, &argv)) {
+    if (!php_v8_function_unpack_args(arguments_zv, 3, isolate, &argc, &argv)) {
         return;
     }
 
@@ -1239,7 +1239,7 @@ static PHP_METHOD(V8Object, CallAsConstructor) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    if (!php_v8_function_unpack_args(arguments_zv, getThis(), 2, isolate, &argc, &argv)) {
+    if (!php_v8_function_unpack_args(arguments_zv, 2, isolate, &argc, &argv)) {
         return;
     }
 

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -215,37 +215,37 @@ static PHP_METHOD(V8Script, Run)
 }
 
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_source___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_script___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
     ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
     ZEND_ARG_OBJ_INFO(0, source, V8\\StringValue, 0)
     ZEND_ARG_OBJ_INFO(0, origin, V8\\ScriptOrigin, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_GetIsolate, ZEND_RETURN_VALUE, 0, V8\\Isolate, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_GetIsolate, ZEND_RETURN_VALUE, 0, V8\\Isolate, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_GetContext, ZEND_RETURN_VALUE, 0, V8\\Context, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_GetContext, ZEND_RETURN_VALUE, 0, V8\\Context, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_getSource, ZEND_RETURN_VALUE, 0, V8\\StringValue, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_getSource, ZEND_RETURN_VALUE, 0, V8\\StringValue, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_getOrigin, ZEND_RETURN_VALUE, 0, V8\\ScriptOrigin, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_getOrigin, ZEND_RETURN_VALUE, 0, V8\\ScriptOrigin, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_Run, ZEND_RETURN_VALUE, 0, V8\\Value, 1)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_Run, ZEND_RETURN_VALUE, 0, V8\\Value, 1)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
 ZEND_END_ARG_INFO()
 
 
 static const zend_function_entry php_v8_script_methods[] = {
-    PHP_ME(V8Script, __construct, arginfo_v8_source___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(V8Script, GetIsolate, arginfo_v8_source_GetIsolate, ZEND_ACC_PUBLIC)
-    PHP_ME(V8Script, GetContext, arginfo_v8_source_GetContext, ZEND_ACC_PUBLIC)
-    PHP_ME(V8Script, getSource, arginfo_v8_source_getSource, ZEND_ACC_PUBLIC)
-    PHP_ME(V8Script, getOrigin, arginfo_v8_source_getOrigin, ZEND_ACC_PUBLIC)
+    PHP_ME(V8Script, __construct, arginfo_v8_script___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(V8Script, GetIsolate, arginfo_v8_script_GetIsolate, ZEND_ACC_PUBLIC)
+    PHP_ME(V8Script, GetContext, arginfo_v8_script_GetContext, ZEND_ACC_PUBLIC)
+    PHP_ME(V8Script, getSource, arginfo_v8_script_getSource, ZEND_ACC_PUBLIC)
+    PHP_ME(V8Script, getOrigin, arginfo_v8_script_getOrigin, ZEND_ACC_PUBLIC)
 
-    PHP_ME(V8Script, Run, arginfo_v8_source_Run, ZEND_ACC_PUBLIC)
+    PHP_ME(V8Script, Run, arginfo_v8_script_Run, ZEND_ACC_PUBLIC)
 
     PHP_FE_END
 };

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -34,6 +34,23 @@ php_v8_script_t * php_v8_script_fetch_object(zend_object *obj) {
     return (php_v8_script_t *)((char *)obj - XtOffsetOf(php_v8_script_t, std));
 }
 
+php_v8_script_t *php_v8_create_script(zval *return_value, v8::Local<v8::Script> local_script, php_v8_context_t *php_v8_context) {
+    assert(!local_script.IsEmpty());
+
+    PHP_V8_DECLARE_ISOLATE(php_v8_context->php_v8_isolate);
+
+    object_init_ex(return_value, this_ce);
+
+    PHP_V8_FETCH_SCRIPT_INTO(return_value, php_v8_script);
+
+    PHP_V8_STORE_POINTER_TO_ISOLATE(php_v8_script, php_v8_context->php_v8_isolate);
+    PHP_V8_STORE_POINTER_TO_CONTEXT(php_v8_script, php_v8_context);
+
+    php_v8_script->persistent->Reset(isolate, local_script);
+
+    return php_v8_script;
+}
+
 static void php_v8_script_free(zend_object *object)
 {
     php_v8_script_t *php_v8_script = php_v8_script_fetch_object(object);
@@ -92,28 +109,16 @@ static PHP_METHOD(V8Script, __construct)
     PHP_V8_SCRIPT_STORE_CONTEXT(getThis(), php_v8_context_zv);
     PHP_V8_SCRIPT_STORE_ISOLATE(getThis(), PHP_V8_CONTEXT_READ_ISOLATE(php_v8_context_zv));
 
-    zend_update_property(this_ce, getThis(), ZEND_STRL("source"), php_v8_string_zv);
-
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_script);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_script);
 
-    if (php_v8_origin_zv == NULL) {
-        origin = new v8::ScriptOrigin(v8::Undefined(isolate));
-
-        zval origin_zv;
-        php_v8_create_script_origin(&origin_zv, context, *origin);
-        zend_update_property(this_ce, getThis(), ZEND_STRL("origin"), &origin_zv);
-
-        zval_ptr_dtor(&origin_zv);
-    } else {
+    if (php_v8_origin_zv != NULL) {
         origin = php_v8_create_script_origin_from_zval(php_v8_origin_zv, isolate);
 
         if (!origin) {
             /* exception was already thrown, here we just silently exit */
             return;
         }
-
-        zend_update_property(this_ce, getThis(), ZEND_STRL("origin"), php_v8_origin_zv);
     }
 
     v8::Local<v8::String> local_source =  php_v8_value_get_string_local(isolate, php_v8_string);
@@ -155,32 +160,6 @@ static PHP_METHOD(V8Script, GetContext)
     PHP_V8_FETCH_SCRIPT_WITH_CHECK(getThis(), php_v8_script);
 
     RETVAL_ZVAL(PHP_V8_SCRIPT_READ_CONTEXT(getThis()), 1, 0);
-}
-
-static PHP_METHOD(V8Script, getSource)
-{
-    zval rv;
-
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
-
-    PHP_V8_FETCH_SCRIPT_WITH_CHECK(getThis(), php_v8_script);
-
-    RETURN_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("source"), 0, &rv), 1, 0);
-}
-
-static PHP_METHOD(V8Script, getOrigin)
-{
-    zval rv;
-
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
-
-    PHP_V8_FETCH_SCRIPT_WITH_CHECK(getThis(), php_v8_script);
-
-    RETURN_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("origin"), 0, &rv), 1, 0);
 }
 
 static PHP_METHOD(V8Script, Run)
@@ -227,13 +206,7 @@ ZEND_END_ARG_INFO()
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_GetContext, ZEND_RETURN_VALUE, 0, V8\\Context, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_getSource, ZEND_RETURN_VALUE, 0, V8\\StringValue, 0)
-ZEND_END_ARG_INFO()
-
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_getOrigin, ZEND_RETURN_VALUE, 0, V8\\ScriptOrigin, 0)
-ZEND_END_ARG_INFO()
-
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_Run, ZEND_RETURN_VALUE, 0, V8\\Value, 1)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_Run, ZEND_RETURN_VALUE, 1, V8\\Value, 0)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
 ZEND_END_ARG_INFO()
 
@@ -242,8 +215,6 @@ static const zend_function_entry php_v8_script_methods[] = {
     PHP_ME(V8Script, __construct, arginfo_v8_script___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
     PHP_ME(V8Script, GetIsolate, arginfo_v8_script_GetIsolate, ZEND_ACC_PUBLIC)
     PHP_ME(V8Script, GetContext, arginfo_v8_script_GetContext, ZEND_ACC_PUBLIC)
-    PHP_ME(V8Script, getSource, arginfo_v8_script_getSource, ZEND_ACC_PUBLIC)
-    PHP_ME(V8Script, getOrigin, arginfo_v8_script_getOrigin, ZEND_ACC_PUBLIC)
 
     PHP_ME(V8Script, Run, arginfo_v8_script_Run, ZEND_ACC_PUBLIC)
 
@@ -261,8 +232,6 @@ PHP_MINIT_FUNCTION(php_v8_script)
 
     zend_declare_property_null(this_ce, ZEND_STRL("isolate"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(this_ce, ZEND_STRL("context"), ZEND_ACC_PRIVATE);
-    zend_declare_property_null(this_ce, ZEND_STRL("source"), ZEND_ACC_PRIVATE);
-    zend_declare_property_null(this_ce, ZEND_STRL("origin"), ZEND_ACC_PRIVATE);
 
     memcpy(&php_v8_script_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 

--- a/src/php_v8_script.h
+++ b/src/php_v8_script.h
@@ -64,19 +64,6 @@ struct _php_v8_script_t {
 };
 
 
-// Timer context
-//typedef struct _php_v8_limits_t
-//{
-//  long time_limit;
-//  long v8_memory_limit;
-//  long zend_memory_limit;
-//  std::chrono::time_point<std::chrono::high_resolution_clock> time_point;
-//  v8js_ctx *ctx;
-//  bool killed;
-//} php_v8_limits_t;
-
-
-
 PHP_MINIT_FUNCTION(php_v8_script);
 
 #endif //PHP_V8_SCRIPT_H

--- a/src/php_v8_script.h
+++ b/src/php_v8_script.h
@@ -32,7 +32,7 @@ extern zend_class_entry *php_v8_script_class_entry;
 
 extern v8::Local<v8::Script> php_v8_script_get_local(v8::Isolate *isolate, php_v8_script_t *php_v8_script);
 extern php_v8_script_t * php_v8_script_fetch_object(zend_object *obj);
-
+extern php_v8_script_t *php_v8_create_script(zval *return_value, v8::Local<v8::Script> local_script, php_v8_context_t *php_v8_context);
 
 #define PHP_V8_FETCH_SCRIPT(zv) php_v8_script_fetch_object(Z_OBJ_P(zv))
 #define PHP_V8_FETCH_SCRIPT_INTO(pzval, into) php_v8_script_t *(into) = PHP_V8_FETCH_SCRIPT((pzval))

--- a/src/php_v8_script_compiler.cc
+++ b/src/php_v8_script_compiler.cc
@@ -1,0 +1,289 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php_v8_script_compiler.h"
+#include "php_v8_compile_options.h"
+#include "php_v8_cached_data.h"
+#include "php_v8_script.h"
+#include "php_v8_script_origin.h"
+#include "php_v8_unbound_script.h"
+#include "php_v8_source.h"
+#include "php_v8_function.h"
+#include "php_v8_string.h"
+#include "php_v8_value.h"
+#include "php_v8_isolate.h"
+#include "php_v8.h"
+
+zend_class_entry* php_v8_script_compiler_class_entry;
+#define this_ce php_v8_script_compiler_class_entry
+
+
+static v8::ScriptCompiler::Source * php_v8_build_source(zval *source_string_zv, zval *origin_zv, zval *cached_data_zv, v8::Isolate *isolate) {
+    PHP_V8_VALUE_FETCH_INTO(source_string_zv, php_v8_source_string);
+
+    v8::Local<v8::String> local_source_string = php_v8_value_get_string_local(isolate, php_v8_source_string);
+
+    v8::ScriptOrigin *origin = NULL;
+
+    if (!ZVAL_IS_NULL(origin_zv)) {
+        origin = php_v8_create_script_origin_from_zval(origin_zv, isolate);
+    }
+
+    v8::ScriptCompiler::CachedData *cached_data = NULL;
+
+    if (!ZVAL_IS_NULL(cached_data_zv)) {
+        PHP_V8_FETCH_CACHED_DATA_INTO(cached_data_zv, php_v8_cached_data);
+        cached_data = php_v8_cached_data->cached_data;
+    }
+
+    v8::ScriptCompiler::Source *source;
+
+    if (origin) {
+        source = new v8::ScriptCompiler::Source(local_source_string, *origin, cached_data);
+    } else {
+        source = new v8::ScriptCompiler::Source(local_source_string, cached_data);
+    }
+
+    return source;
+}
+
+static PHP_METHOD(V8ScriptCompiler, CachedDataVersionTag)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    RETURN_LONG(static_cast<zend_long>(v8::ScriptCompiler::CachedDataVersionTag()));
+}
+
+static PHP_METHOD(V8ScriptCompiler, CompileUnboundScript)
+{
+    zval rv;
+
+    zval *php_v8_context_zv;
+    zval *php_v8_source_zv;
+    zend_long options = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "oo|l", &php_v8_context_zv, &php_v8_source_zv, &options) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_CHECK_COMPILER_OPTIONS_RANGE(options, "Invalid Script compiler options given. See V8\\ScriptCompiler\\CompileOptions class constants for available options.")
+
+    PHP_V8_CONTEXT_FETCH_INTO(php_v8_context_zv, php_v8_context);
+
+    zval *source_string_zv = PHP_V8_SOURCE_READ_SOURCE_STRING(php_v8_source_zv);
+    zval *origin_zv        = PHP_V8_SOURCE_READ_ORIGIN(php_v8_source_zv);
+    zval *cached_data_zv   = PHP_V8_SOURCE_READ_CACHED_DATA(php_v8_source_zv);
+
+    PHP_V8_VALUE_FETCH_WITH_CHECK(source_string_zv, php_v8_source_string);
+    PHP_V8_DATA_ISOLATES_CHECK(php_v8_source_string, php_v8_context);
+
+    if (!ZVAL_IS_NULL(cached_data_zv)) {
+        PHP_V8_FETCH_CACHED_DATA_WITH_CHECK(cached_data_zv, php_v8_cached_data);
+    }
+
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
+
+    v8::ScriptCompiler::Source * source = php_v8_build_source(source_string_zv, origin_zv, cached_data_zv, isolate);
+
+    if (source->GetResourceOptions().IsModule()) {
+        PHP_V8_THROW_EXCEPTION("Unable to compile module as unbound script")
+        return;
+    }
+
+    if (source->GetCachedData() == NULL && (options == v8::ScriptCompiler::CompileOptions::kConsumeParserCache || options == v8::ScriptCompiler::CompileOptions::kConsumeCodeCache)) {
+        PHP_V8_THROW_EXCEPTION("Unable to consume cache when it's not set");
+        return;
+    }
+
+    PHP_V8_TRY_CATCH(isolate);
+    PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);
+
+    v8::MaybeLocal<v8::UnboundScript> maybe_unbound_script = v8::ScriptCompiler::CompileUnboundScript(isolate, source, static_cast<v8::ScriptCompiler::CompileOptions>(options));
+
+    PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
+    PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(maybe_unbound_script, "Failed to compile unbound script");
+
+    v8::Local<v8::UnboundScript> local_unbound_script = maybe_unbound_script.ToLocalChecked();
+
+    php_v8_update_source_cached_data(php_v8_source_zv, source);
+    php_v8_create_unbound_script(return_value, php_v8_context->php_v8_isolate, local_unbound_script);
+}
+
+static PHP_METHOD(V8ScriptCompiler, Compile)
+{
+    zval rv;
+
+    zval *php_v8_context_zv;
+    zval *php_v8_source_zv;
+    zend_long options = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "oo|l", &php_v8_context_zv, &php_v8_source_zv, &options) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_CHECK_COMPILER_OPTIONS_RANGE(options, "Invalid Script compiler options given. See V8\\ScriptCompiler\\CompileOptions class constants for available options.")
+
+    PHP_V8_CONTEXT_FETCH_INTO(php_v8_context_zv, php_v8_context);
+
+    zval *source_string_zv = PHP_V8_SOURCE_READ_SOURCE_STRING(php_v8_source_zv);
+    zval *origin_zv        = PHP_V8_SOURCE_READ_ORIGIN(php_v8_source_zv);
+    zval *cached_data_zv   = PHP_V8_SOURCE_READ_CACHED_DATA(php_v8_source_zv);
+
+    PHP_V8_VALUE_FETCH_WITH_CHECK(source_string_zv, php_v8_source_string);
+    PHP_V8_DATA_ISOLATES_CHECK(php_v8_source_string, php_v8_context);
+
+    if (!ZVAL_IS_NULL(cached_data_zv)) {
+        PHP_V8_FETCH_CACHED_DATA_WITH_CHECK(cached_data_zv, php_v8_cached_data);
+    }
+
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
+
+    v8::ScriptCompiler::Source * source = php_v8_build_source(source_string_zv, origin_zv, cached_data_zv, isolate);
+
+    if (source->GetResourceOptions().IsModule()) {
+        PHP_V8_THROW_EXCEPTION("Unable to compile module as script")
+        return;
+    }
+
+    if (source->GetCachedData() == NULL && (options == v8::ScriptCompiler::CompileOptions::kConsumeParserCache || options == v8::ScriptCompiler::CompileOptions::kConsumeCodeCache)) {
+        PHP_V8_THROW_EXCEPTION("Unable to consume cache when it's not set");
+        return;
+    }
+
+    PHP_V8_TRY_CATCH(isolate);
+    PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);
+
+    v8::MaybeLocal<v8::Script> maybe_script = v8::ScriptCompiler::Compile(context, source, static_cast<v8::ScriptCompiler::CompileOptions>(options));
+
+    PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
+    PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(maybe_script, "Failed to compile script");
+
+    v8::Local<v8::Script> local_script = maybe_script.ToLocalChecked();
+
+    php_v8_update_source_cached_data(php_v8_source_zv, source);
+    php_v8_create_script(return_value, local_script, php_v8_context);
+}
+
+static PHP_METHOD(V8ScriptCompiler, CompileFunctionInContext)
+{
+    zval rv;
+
+    zval *php_v8_context_zv;
+    zval *php_v8_source_zv;
+    zval *arguments_zv = NULL;
+    zval *context_extensions_zv = NULL;
+
+    int arguments_count = 0;
+    v8::Local<v8::String> *arguments = NULL;
+    int context_extensions_count = 0;
+    v8::Local<v8::Object> *context_extensions = NULL;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "oo|aa", &php_v8_context_zv, &php_v8_source_zv, &arguments_zv, &context_extensions_zv) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_CONTEXT_FETCH_INTO(php_v8_context_zv, php_v8_context);
+
+    zval *source_string_zv = PHP_V8_SOURCE_READ_SOURCE_STRING(php_v8_source_zv);
+    zval *origin_zv        = PHP_V8_SOURCE_READ_ORIGIN(php_v8_source_zv);
+    zval *cached_data_zv   = PHP_V8_SOURCE_READ_CACHED_DATA(php_v8_source_zv);
+
+    PHP_V8_VALUE_FETCH_WITH_CHECK(source_string_zv, php_v8_source_string);
+    PHP_V8_DATA_ISOLATES_CHECK(php_v8_source_string, php_v8_context);
+
+    if (!ZVAL_IS_NULL(cached_data_zv)) {
+        PHP_V8_FETCH_CACHED_DATA_WITH_CHECK(cached_data_zv, php_v8_cached_data);
+    }
+
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
+
+    if (arguments_zv != NULL && !php_v8_function_unpack_string_args(arguments_zv, 3, isolate, &arguments_count, &arguments)) {
+        return;
+    }
+
+    if (context_extensions_zv != NULL && !php_v8_function_unpack_object_args(context_extensions_zv, 4, isolate, &context_extensions_count, &context_extensions)) {
+        return;
+    }
+
+    v8::ScriptCompiler::Source * source = php_v8_build_source(source_string_zv, origin_zv, cached_data_zv, isolate);
+
+    PHP_V8_TRY_CATCH(isolate);
+    PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);
+
+    v8::MaybeLocal<v8::Function> maybe_function;
+    maybe_function = v8::ScriptCompiler::CompileFunctionInContext(context,
+                                                                  source,
+                                                                  static_cast<size_t>(arguments_count),
+                                                                  arguments,
+                                                                  static_cast<size_t>(context_extensions_count),
+                                                                  context_extensions);
+
+    PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
+    PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(maybe_function, "Failed to compile function in context");
+
+    v8::Local<v8::Function> local_function = maybe_function.ToLocalChecked();
+
+    php_v8_get_or_create_value(return_value, local_function, isolate);
+}
+
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_script_compiler_CachedDataVersionTag, ZEND_RETURN_VALUE, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_compiler_CompileUnboundScript, ZEND_RETURN_VALUE, 2, V8\\UnboundScript, 0)
+                ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
+                ZEND_ARG_OBJ_INFO(0, source, V8\\ScriptCompiler\\Source, 0)
+                ZEND_ARG_TYPE_INFO(0, options, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_compiler_Compile, ZEND_RETURN_VALUE, 2, V8\\Script, 0)
+                ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
+                ZEND_ARG_OBJ_INFO(0, source, V8\\ScriptCompiler\\Source, 0)
+                ZEND_ARG_TYPE_INFO(0, options, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_script_compiler_CompileFunctionInContext, ZEND_RETURN_VALUE, 2, V8\\FunctionObject, 0)
+                ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
+                ZEND_ARG_OBJ_INFO(0, source, V8\\ScriptCompiler\\Source, 0)
+                ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
+                ZEND_ARG_TYPE_INFO(0, context_extensions, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+
+static const zend_function_entry php_v8_script_compiler_methods[] = {
+    PHP_ME(V8ScriptCompiler, CachedDataVersionTag,      arginfo_v8_script_compiler_CachedDataVersionTag,        ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(V8ScriptCompiler, CompileUnboundScript,      arginfo_v8_script_compiler_CompileUnboundScript,        ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(V8ScriptCompiler, Compile,                   arginfo_v8_script_compiler_Compile,                     ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(V8ScriptCompiler, CompileFunctionInContext,  arginfo_v8_script_compiler_CompileFunctionInContext,    ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+
+    PHP_FE_END
+};
+
+
+PHP_MINIT_FUNCTION(php_v8_script_compiler)
+{
+    zend_class_entry ce;
+
+    INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "ScriptCompiler", php_v8_script_compiler_methods);
+    this_ce = zend_register_internal_class(&ce);
+
+    return SUCCESS;
+}

--- a/src/php_v8_script_compiler.h
+++ b/src/php_v8_script_compiler.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifndef PHP_V8_SCRIPT_COMPILER_H
+#define PHP_V8_SCRIPT_COMPILER_H
+
+extern "C" {
+#include "php.h"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+}
+
+extern zend_class_entry *php_v8_script_compiler_class_entry;
+
+PHP_MINIT_FUNCTION(php_v8_script_compiler);
+
+#endif //PHP_V8_SCRIPT_COMPILER_H

--- a/src/php_v8_script_origin.cc
+++ b/src/php_v8_script_origin.cc
@@ -145,22 +145,28 @@ static PHP_METHOD(V8ScriptOrigin, __construct) {
     zend_long script_id = static_cast<zend_long>(v8::Message::kNoScriptIdInfo);
     zend_string *source_map_url = NULL;
     zend_bool resource_is_opaque = '\0';
+    zend_bool is_wasm = '\0';
+    zend_bool is_module = '\0';
 
     zval options_zv;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|SllblSb",
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|SllblSbbb",
                               &resource_name,
                               &resource_line_offset,
                               &resource_column_offset,
                               &resource_is_shared_cross_origin,
                               &script_id,
                               &source_map_url,
-                              &resource_is_opaque) == FAILURE) {
+                              &resource_is_opaque,
+                              &is_wasm,
+                              &is_module) == FAILURE) {
         return;
     }
 
     v8::ScriptOriginOptions options(static_cast<bool>(resource_is_shared_cross_origin),
-                                    static_cast<bool>(resource_is_opaque));
+                                    static_cast<bool>(resource_is_opaque),
+                                    static_cast<bool>(is_wasm),
+                                    static_cast<bool>(is_module));
 
     php_v8_create_script_origin_options(&options_zv, options);
 

--- a/src/php_v8_script_origin.cc
+++ b/src/php_v8_script_origin.cc
@@ -74,6 +74,8 @@ v8::ScriptOrigin *php_v8_create_script_origin_from_zval(zval *value, v8::Isolate
     v8::Local<v8::Integer> script_id = v8::Local<v8::Integer>();
     v8::Local<v8::Value> source_map_url = v8::Local<v8::Value>();
     v8::Local<v8::Boolean> resource_is_opaque = v8::Local<v8::Boolean>();
+    v8::Local<v8::Boolean> is_wasm = v8::Local<v8::Boolean>();
+    v8::Local<v8::Boolean> is_module = v8::Local<v8::Boolean>();
 
     zval *resource_name_zv = zend_read_property(this_ce, value, ZEND_STRL("resource_name"), 0, &rv); // string
 
@@ -123,9 +125,13 @@ v8::ScriptOrigin *php_v8_create_script_origin_from_zval(zval *value, v8::Isolate
     if (Z_TYPE_P(options_zv) == IS_OBJECT) {
         zval *is_shared_cross_origin_zv = zend_read_property(php_v8_script_origin_options_class_entry, options_zv, ZEND_STRL("is_shared_cross_origin"), 0, &rv);
         zval *is_opaque_zv = zend_read_property(php_v8_script_origin_options_class_entry, options_zv, ZEND_STRL("is_opaque"), 0, &rv);
+        zval *is_wasm_zv = zend_read_property(php_v8_script_origin_options_class_entry, options_zv, ZEND_STRL("is_wasm"), 0, &rv);
+        zval *is_module_zv = zend_read_property(php_v8_script_origin_options_class_entry, options_zv, ZEND_STRL("is_module"), 0, &rv);
 
         resource_is_shared_cross_origin = v8::Boolean::New(isolate, Z_TYPE_P(is_shared_cross_origin_zv) == IS_TRUE);
         resource_is_opaque = v8::Boolean::New(isolate, Z_TYPE_P(is_opaque_zv) == IS_TRUE);
+        is_wasm = v8::Boolean::New(isolate, Z_TYPE_P(is_wasm_zv) == IS_TRUE);
+        is_module = v8::Boolean::New(isolate, Z_TYPE_P(is_module_zv) == IS_TRUE);
     }
 
     return new v8::ScriptOrigin(resource_name,
@@ -134,7 +140,9 @@ v8::ScriptOrigin *php_v8_create_script_origin_from_zval(zval *value, v8::Isolate
                                 resource_is_shared_cross_origin,
                                 script_id,
                                 source_map_url,
-                                resource_is_opaque);
+                                resource_is_opaque,
+                                is_wasm,
+                                is_module);
 }
 
 static PHP_METHOD(V8ScriptOrigin, __construct) {

--- a/src/php_v8_script_origin_options.cc
+++ b/src/php_v8_script_origin_options.cc
@@ -26,15 +26,19 @@ void php_v8_create_script_origin_options(zval * return_value, v8::ScriptOriginOp
 
     zend_update_property_bool(this_ce, return_value, ZEND_STRL("is_shared_cross_origin"), static_cast<zend_bool>(options.IsSharedCrossOrigin()));
     zend_update_property_bool(this_ce, return_value, ZEND_STRL("is_opaque"), static_cast<zend_bool>(options.IsOpaque()));
+    zend_update_property_bool(this_ce, return_value, ZEND_STRL("is_wasm"), static_cast<zend_bool>(options.IsWasm()));
+    zend_update_property_bool(this_ce, return_value, ZEND_STRL("is_module"), static_cast<zend_bool>(options.IsModule()));
 }
 
 
 static PHP_METHOD(V8ScriptOriginOptions, __construct) {
     zend_bool is_shared_cross_origin = '\0';
     zend_bool is_opaque = '\0';
+    zend_bool is_wasm = '\0';
+    zend_bool is_module = '\0';
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|bb",
-                              &is_shared_cross_origin, &is_opaque) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|bbbb",
+                              &is_shared_cross_origin, &is_opaque, &is_wasm, &is_module) == FAILURE) {
         return;
     }
 
@@ -63,10 +67,32 @@ static PHP_METHOD(V8ScriptOriginOptions, IsOpaque) {
     RETVAL_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("is_opaque"), 0, &rv), 1, 0);
 }
 
+static PHP_METHOD(V8ScriptOriginOptions, IsWasm) {
+    zval rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    RETVAL_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("is_wasm"), 0, &rv), 1, 0);
+}
+
+static PHP_METHOD(V8ScriptOriginOptions, IsModule) {
+    zval rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    RETVAL_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("is_module"), 0, &rv), 1, 0);
+}
+
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_script_origin_options___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
                 ZEND_ARG_TYPE_INFO(0, is_shared_cross_origin, _IS_BOOL, 0)
                 ZEND_ARG_TYPE_INFO(0, is_opaque, _IS_BOOL, 0)
+                ZEND_ARG_TYPE_INFO(0, is_wasm, _IS_BOOL, 0)
+                ZEND_ARG_TYPE_INFO(0, is_module, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 
@@ -76,12 +102,20 @@ ZEND_END_ARG_INFO()
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_script_origin_options_IsOpaque, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_script_origin_options_IsWasm, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_script_origin_options_IsModule, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
 
 static const zend_function_entry php_v8_script_origin_options_methods[] = {
         PHP_ME(V8ScriptOriginOptions, __construct, arginfo_v8_script_origin_options___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
 
         PHP_ME(V8ScriptOriginOptions, IsSharedCrossOrigin, arginfo_v8_script_origin_options_IsSharedCrossOrigin, ZEND_ACC_PUBLIC)
         PHP_ME(V8ScriptOriginOptions, IsOpaque, arginfo_v8_script_origin_options_IsOpaque, ZEND_ACC_PUBLIC)
+        PHP_ME(V8ScriptOriginOptions, IsWasm, arginfo_v8_script_origin_options_IsWasm, ZEND_ACC_PUBLIC)
+        PHP_ME(V8ScriptOriginOptions, IsModule, arginfo_v8_script_origin_options_IsModule, ZEND_ACC_PUBLIC)
 
         PHP_FE_END
 };
@@ -94,6 +128,8 @@ PHP_MINIT_FUNCTION(php_v8_script_origin_options) {
 
     zend_declare_property_bool(this_ce, ZEND_STRL("is_shared_cross_origin"), static_cast<zend_bool>(false), ZEND_ACC_PRIVATE);
     zend_declare_property_bool(this_ce, ZEND_STRL("is_opaque"), static_cast<zend_bool>(false), ZEND_ACC_PRIVATE);
+    zend_declare_property_bool(this_ce, ZEND_STRL("is_wasm"), static_cast<zend_bool>(false), ZEND_ACC_PRIVATE);
+    zend_declare_property_bool(this_ce, ZEND_STRL("is_module"), static_cast<zend_bool>(false), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/php_v8_source.cc
+++ b/src/php_v8_source.cc
@@ -1,0 +1,139 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php_v8_source.h"
+#include "php_v8_cached_data.h"
+#include "php_v8_string.h"
+#include "php_v8.h"
+
+zend_class_entry* php_v8_source_class_entry;
+#define this_ce php_v8_source_class_entry
+
+void php_v8_update_source_cached_data(zval *src_zv, v8::ScriptCompiler::Source *source) {
+    if (!source->GetCachedData()) {
+        return;
+    }
+
+    zval tmp;
+    zval rv;
+
+    zval *cached_data_zv = zend_read_property(this_ce, src_zv, ZEND_STRL("cached_data"), 0, &rv);
+
+    if (!ZVAL_IS_NULL(cached_data_zv)) {
+        return;
+    }
+
+    php_v8_create_cached_data(&tmp, source->GetCachedData());
+
+    zend_update_property(this_ce, src_zv, ZEND_STRL("cached_data"), &tmp);
+}
+
+static PHP_METHOD(V8Source, __construct)
+{
+    zval *source_string_zv = NULL;
+    zval *origin_zv = NULL;
+    zval *cached_data_zv = NULL;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o|o!o!", &source_string_zv, &origin_zv, &cached_data_zv) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_VALUE_FETCH_WITH_CHECK(source_string_zv, php_v8_string);
+
+    zend_update_property(this_ce, getThis(), ZEND_STRL("source_string"), source_string_zv);
+
+    if (origin_zv != NULL) {
+        zend_update_property(this_ce, getThis(), ZEND_STRL("origin"), origin_zv);
+    }
+
+    if (cached_data_zv != NULL) {
+        zend_update_property(this_ce, getThis(), ZEND_STRL("cached_data"), cached_data_zv);
+    }
+}
+
+static PHP_METHOD(V8Source, GetSourceString)
+{
+    zval rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    RETVAL_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("source_string"), 0, &rv), 1, 0);
+}
+
+static PHP_METHOD(V8Source, GetScriptOrigin)
+{
+    zval rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    RETVAL_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("origin"), 0, &rv), 1, 0);
+}
+
+static PHP_METHOD(V8Source, GetCachedData)
+{
+    zval rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    RETVAL_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("cached_data"), 0, &rv), 1, 0);
+}
+
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_source___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 1)
+                ZEND_ARG_OBJ_INFO(0, source_string, V8\\StringValue, 0)
+                ZEND_ARG_OBJ_INFO(0, origin, V8\\ScriptOrigin, 1)
+                ZEND_ARG_OBJ_INFO(0, cached_data, V8\\ScriptCompiler\\CachedData, 1)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_GetSourceString, ZEND_RETURN_VALUE, 0, V8\\StringValue, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_GetScriptOrigin, ZEND_RETURN_VALUE, 0, V8\\ScriptOrigin, 1)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_source_GetCachedData, ZEND_RETURN_VALUE, 0, V8\\ScriptCompiler\\CachedData, 1)
+ZEND_END_ARG_INFO()
+
+
+static const zend_function_entry php_v8_source_methods[] = {
+    PHP_ME(V8Source, __construct,       arginfo_v8_source___construct,      ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(V8Source, GetSourceString,   arginfo_v8_source_GetSourceString,  ZEND_ACC_PUBLIC)
+    PHP_ME(V8Source, GetScriptOrigin,   arginfo_v8_source_GetScriptOrigin,  ZEND_ACC_PUBLIC)
+    PHP_ME(V8Source, GetCachedData,     arginfo_v8_source_GetCachedData,    ZEND_ACC_PUBLIC)
+
+    PHP_FE_END
+};
+
+
+PHP_MINIT_FUNCTION(php_v8_source)
+{
+    zend_class_entry ce;
+
+    INIT_NS_CLASS_ENTRY(ce, "V8\\ScriptCompiler", "Source", php_v8_source_methods);
+    this_ce = zend_register_internal_class(&ce);
+
+    zend_declare_property_null(this_ce, ZEND_STRL("source_string"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("origin"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("cached_data"), ZEND_ACC_PRIVATE);
+
+    return SUCCESS;
+}

--- a/src/php_v8_source.h
+++ b/src/php_v8_source.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifndef PHP_V8_SOURCE_H
+#define PHP_V8_SOURCE_H
+
+
+#include "php_v8_exception.h"
+#include "php_v8_context.h"
+#include "php_v8_isolate.h"
+#include <v8.h>
+
+extern "C" {
+#include "php.h"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+}
+
+extern zend_class_entry *php_v8_source_class_entry;
+
+extern void php_v8_update_source_cached_data(zval *src_zv, v8::ScriptCompiler::Source *source);
+
+#define PHP_V8_SOURCE_READ_SOURCE_STRING(from_zval) zend_read_property(php_v8_source_class_entry, (from_zval), ZEND_STRL("source_string"), 0, &rv)
+#define PHP_V8_SOURCE_READ_ORIGIN(from_zval) zend_read_property(php_v8_source_class_entry, (from_zval), ZEND_STRL("origin"), 0, &rv)
+#define PHP_V8_SOURCE_READ_CACHED_DATA(from_zval) zend_read_property(php_v8_source_class_entry, (from_zval), ZEND_STRL("cached_data"), 0, &rv)
+
+PHP_MINIT_FUNCTION(php_v8_source);
+
+#endif //PHP_V8_SOURCE_H

--- a/src/php_v8_symbol.cc
+++ b/src/php_v8_symbol.cc
@@ -156,6 +156,24 @@ static PHP_METHOD(V8Symbol, GetUnscopables)
     php_v8_get_or_create_value(return_value, local_symbol, isolate);
 }
 
+static PHP_METHOD(V8Symbol, GetToPrimitive)
+{
+    zval *php_v8_isolate_zv;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &php_v8_isolate_zv) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_ISOLATE_FETCH_WITH_CHECK(php_v8_isolate_zv, php_v8_isolate);
+    PHP_V8_ENTER_ISOLATE(php_v8_isolate);
+
+    v8::Local<v8::Symbol> local_symbol = v8::Symbol::GetToPrimitive(isolate);
+
+    PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
+
+    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+}
+
 static PHP_METHOD(V8Symbol, GetToStringTag)
 {
     zval *php_v8_isolate_zv;
@@ -219,6 +237,10 @@ PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_symbol_GetUnscopables, 
                 ZEND_ARG_OBJ_INFO(0, isolate, V8\\Isolate, 0)
 ZEND_END_ARG_INFO()
 
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_symbol_GetToPrimitive, ZEND_RETURN_VALUE, 1, V8\\SymbolValue, 0)
+                ZEND_ARG_OBJ_INFO(0, isolate, V8\\Isolate, 0)
+ZEND_END_ARG_INFO()
+
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_symbol_GetToStringTag, ZEND_RETURN_VALUE, 1, V8\\SymbolValue, 0)
                 ZEND_ARG_OBJ_INFO(0, isolate, V8\\Isolate, 0)
 ZEND_END_ARG_INFO()
@@ -238,6 +260,7 @@ static const zend_function_entry php_v8_symbol_methods[] = {
 
     PHP_ME(V8Symbol, GetIterator,           arginfo_v8_symbol_GetIterator, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(V8Symbol, GetUnscopables,        arginfo_v8_symbol_GetUnscopables, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(V8Symbol, GetToPrimitive,        arginfo_v8_symbol_GetToPrimitive, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(V8Symbol, GetToStringTag,        arginfo_v8_symbol_GetToStringTag, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(V8Symbol, GetIsConcatSpreadable, arginfo_v8_symbol_GetIsConcatSpreadable, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 

--- a/src/php_v8_unbound_script.cc
+++ b/src/php_v8_unbound_script.cc
@@ -1,0 +1,260 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php_v8_unbound_script.h"
+#include "php_v8_script.h"
+#include "php_v8_string.h"
+#include "php_v8_value.h"
+#include "php_v8_context.h"
+#include "php_v8.h"
+
+zend_class_entry* php_v8_unbound_script_class_entry;
+#define this_ce php_v8_unbound_script_class_entry
+
+static zend_object_handlers php_v8_unbound_script_object_handlers;
+
+
+v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(v8::Isolate *isolate, php_v8_unbound_script_t *php_v8_unbound_script) {
+    return v8::Local<v8::UnboundScript>::New(isolate, *php_v8_unbound_script->persistent);
+}
+
+php_v8_unbound_script_t * php_v8_unbound_script_fetch_object(zend_object *obj) {
+    return (php_v8_unbound_script_t *)((char *)obj - XtOffsetOf(php_v8_unbound_script_t, std));
+}
+
+php_v8_unbound_script_t * php_v8_create_unbound_script(zval *return_value, php_v8_isolate_t *php_v8_isolate, v8::Local<v8::UnboundScript> unbound_script) {
+    assert(!unbound_script.IsEmpty());
+
+    object_init_ex(return_value, this_ce);
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_INTO(return_value, php_v8_unbound_script);
+    PHP_V8_UNBOUND_SCRIPT_STORE_ISOLATE(return_value, &php_v8_isolate->this_ptr)
+    PHP_V8_STORE_POINTER_TO_ISOLATE(php_v8_unbound_script, php_v8_isolate);
+
+    php_v8_unbound_script->persistent->Reset(php_v8_isolate->isolate, unbound_script);
+
+    return php_v8_unbound_script;
+}
+
+
+static void php_v8_unbound_script_free(zend_object *object)
+{
+    php_v8_unbound_script_t *php_v8_unbound_script = php_v8_unbound_script_fetch_object(object);
+
+    if (php_v8_unbound_script->persistent) {
+        if (PHP_V8_ISOLATE_HAS_VALID_HANDLE(php_v8_unbound_script)) {
+            php_v8_unbound_script->persistent->Reset();
+        }
+        delete php_v8_unbound_script->persistent;
+    }
+
+    zend_object_std_dtor(&php_v8_unbound_script->std);
+}
+
+static zend_object * php_v8_unbound_script_ctor(zend_class_entry *ce)
+{
+    php_v8_unbound_script_t *php_v8_unbound_script;
+
+    php_v8_unbound_script = (php_v8_unbound_script_t *) ecalloc(1, sizeof(php_v8_unbound_script_t) + zend_object_properties_size(ce));
+
+    zend_object_std_init(&php_v8_unbound_script->std, ce);
+    object_properties_init(&php_v8_unbound_script->std, ce);
+
+    php_v8_unbound_script->persistent = new v8::Persistent<v8::UnboundScript>();
+
+    php_v8_unbound_script->std.handlers = &php_v8_unbound_script_object_handlers;
+
+    return &php_v8_unbound_script->std;
+}
+
+static PHP_METHOD(V8UnboundScript, __construct)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_THROW_EXCEPTION("V8\\UnboundScript::__construct() should not be called. Use other methods which yield V8\\UnboundScript object.")
+}
+
+static PHP_METHOD(V8UnboundScript, GetIsolate)
+{
+    zval rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
+
+    RETVAL_ZVAL(PHP_V8_UNBOUND_SCRIPT_READ_ISOLATE(getThis()), 1, 0);
+}
+
+static PHP_METHOD(V8UnboundScript, BindToContext)
+{
+    zval *php_v8_context_zv;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &php_v8_context_zv) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
+    PHP_V8_CONTEXT_FETCH_WITH_CHECK(php_v8_context_zv, php_v8_context);
+
+    PHP_V8_DATA_ISOLATES_CHECK(php_v8_unbound_script, php_v8_context);
+
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
+
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+    v8::Local<v8::Script> local_script = local_unbound_script->BindToCurrentContext();
+
+    php_v8_create_script(return_value, local_script, php_v8_context);
+}
+
+static PHP_METHOD(V8UnboundScript, GetId)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
+
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+
+    RETURN_LONG(static_cast<zend_long>(local_unbound_script->GetId()));
+}
+
+static PHP_METHOD(V8UnboundScript, GetScriptName)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
+
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+
+    php_v8_get_or_create_value(return_value, local_unbound_script->GetScriptName(), isolate);
+}
+
+static PHP_METHOD(V8UnboundScript, GetSourceURL)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
+
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+
+    php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceURL(), isolate);
+}
+
+static PHP_METHOD(V8UnboundScript, GetSourceMappingURL)
+{
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
+
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+
+    php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceMappingURL(), isolate);
+}
+
+static PHP_METHOD(V8UnboundScript, GetLineNumber)
+{
+    zend_long code_pos = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &code_pos) == FAILURE) {
+        return;
+    }
+
+    PHP_V8_CHECK_CODE_POS_RANGE(code_pos, "Value is out of range");
+
+    PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
+
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+
+    RETURN_LONG(static_cast<zend_long>(local_unbound_script->GetLineNumber(static_cast<int>(code_pos))));
+}
+
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_unbound_script___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_unbound_script_GetIsolate, ZEND_RETURN_VALUE, 0, V8\\Isolate, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_unbound_script_BindToContext, ZEND_RETURN_VALUE, 1, V8\\Script, 0)
+                ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_unbound_script_GetId, ZEND_RETURN_VALUE, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_unbound_script_GetScriptName, ZEND_RETURN_VALUE, 0, V8\\Value, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_unbound_script_GetSourceURL, ZEND_RETURN_VALUE, 0, V8\\Value, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_unbound_script_GetSourceMappingURL, ZEND_RETURN_VALUE, 0, V8\\Value, 0)
+ZEND_END_ARG_INFO()
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_unbound_script_GetLineNumber, ZEND_RETURN_VALUE, 1, IS_LONG, 0)
+                ZEND_ARG_TYPE_INFO(0, code_pos, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+
+static const zend_function_entry php_v8_unbound_script_methods[] = {
+    PHP_ME(V8UnboundScript, __construct,            arginfo_v8_unbound_script___construct,          ZEND_ACC_PRIVATE | ZEND_ACC_CTOR)
+    PHP_ME(V8UnboundScript, GetIsolate,             arginfo_v8_unbound_script_GetIsolate,           ZEND_ACC_PUBLIC)
+    PHP_ME(V8UnboundScript, BindToContext,          arginfo_v8_unbound_script_BindToContext,        ZEND_ACC_PUBLIC)
+    PHP_ME(V8UnboundScript, GetId,                  arginfo_v8_unbound_script_GetId,                ZEND_ACC_PUBLIC)
+    PHP_ME(V8UnboundScript, GetScriptName,          arginfo_v8_unbound_script_GetScriptName,        ZEND_ACC_PUBLIC)
+    PHP_ME(V8UnboundScript, GetSourceURL,           arginfo_v8_unbound_script_GetSourceURL,         ZEND_ACC_PUBLIC)
+    PHP_ME(V8UnboundScript, GetSourceMappingURL,    arginfo_v8_unbound_script_GetSourceMappingURL,  ZEND_ACC_PUBLIC)
+    PHP_ME(V8UnboundScript, GetLineNumber,          arginfo_v8_unbound_script_GetLineNumber,        ZEND_ACC_PUBLIC)
+
+    PHP_FE_END
+};
+
+
+PHP_MINIT_FUNCTION(php_v8_unbound_script)
+{
+    zend_class_entry ce;
+
+    INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "UnboundScript", php_v8_unbound_script_methods);
+    this_ce = zend_register_internal_class(&ce);
+    this_ce->create_object = php_v8_unbound_script_ctor;
+
+    zend_declare_property_null(this_ce, ZEND_STRL("isolate"), ZEND_ACC_PRIVATE);
+    zend_declare_class_constant_long(this_ce, ZEND_STRL("kNoScriptId"), v8::UnboundScript::kNoScriptId);
+
+    memcpy(&php_v8_unbound_script_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+
+    php_v8_unbound_script_object_handlers.offset = XtOffsetOf(php_v8_unbound_script_t, std);
+    php_v8_unbound_script_object_handlers.free_obj = php_v8_unbound_script_free;
+
+    return SUCCESS;
+}

--- a/src/php_v8_unbound_script.h
+++ b/src/php_v8_unbound_script.h
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+#ifndef PHP_V8_UNBOUND_SCRIPT_H
+#define PHP_V8_UNBOUND_SCRIPT_H
+
+typedef struct _php_v8_unbound_script_t php_v8_unbound_script_t;
+
+#include "php_v8_exception.h"
+#include "php_v8_isolate.h"
+#include <v8.h>
+
+extern "C" {
+#include "php.h"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+}
+
+extern zend_class_entry *php_v8_unbound_script_class_entry;
+
+extern v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(v8::Isolate *isolate, php_v8_unbound_script_t *php_v8_unbound_script);
+extern php_v8_unbound_script_t * php_v8_unbound_script_fetch_object(zend_object *obj);
+extern php_v8_unbound_script_t * php_v8_create_unbound_script(zval *return_value, php_v8_isolate_t *php_v8_isolate, v8::Local<v8::UnboundScript> unbound_script);
+
+
+#define PHP_V8_FETCH_UNBOUND_SCRIPT(zv) php_v8_unbound_script_fetch_object(Z_OBJ_P(zv))
+#define PHP_V8_FETCH_UNBOUND_SCRIPT_INTO(pzval, into) php_v8_unbound_script_t *(into) = PHP_V8_FETCH_UNBOUND_SCRIPT((pzval))
+
+#define PHP_V8_EMPTY_UNBOUND_SCRIPT_MSG "UnboundScript" PHP_V8_EMPTY_HANDLER_MSG_PART
+#define PHP_V8_CHECK_EMPTY_UNBOUND_SCRIPT_HANDLER(val) PHP_V8_CHECK_EMPTY_HANDLER((val), PHP_V8_EMPTY_UNBOUND_SCRIPT_MSG)
+
+#define PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(pzval, into) \
+    PHP_V8_FETCH_UNBOUND_SCRIPT_INTO(pzval, into); \
+    PHP_V8_CHECK_EMPTY_UNBOUND_SCRIPT_HANDLER(into);
+
+
+#define PHP_V8_UNBOUND_SCRIPT_STORE_ISOLATE(to_zval, isolate_zv) zend_update_property(php_v8_unbound_script_class_entry, (to_zval), ZEND_STRL("isolate"), (isolate_zv));
+#define PHP_V8_UNBOUND_SCRIPT_READ_ISOLATE(from_zval) zend_read_property(php_v8_unbound_script_class_entry, (from_zval), ZEND_STRL("isolate"), 0, &rv)
+
+#define PHP_V8_CHECK_CODE_POS_RANGE(val, message) \
+    if ((val) > INT_MAX || (val) < INT_MIN) { \
+        PHP_V8_THROW_VALUE_EXCEPTION(message); \
+        return; \
+    }
+
+struct _php_v8_unbound_script_t {
+  php_v8_isolate_t *php_v8_isolate;
+  uint32_t isolate_handle;
+
+  v8::Persistent<v8::UnboundScript> *persistent;
+
+  zend_object std;
+};
+
+PHP_MINIT_FUNCTION(php_v8_unbound_script);
+
+#endif //PHP_V8_UNBOUND_SCRIPT_H

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -431,7 +431,6 @@ static PHP_V8_VALUE_IS_METHOD(V8Value, IsUint32Array)
 static PHP_V8_VALUE_IS_METHOD(V8Value, IsInt32Array)
 static PHP_V8_VALUE_IS_METHOD(V8Value, IsFloat32Array)
 static PHP_V8_VALUE_IS_METHOD(V8Value, IsFloat64Array)
-//static PHP_V8_VALUE_IS_METHOD(V8Value, IsFloat32x4)  // Experimental
 static PHP_V8_VALUE_IS_METHOD(V8Value, IsDataView)
 static PHP_V8_VALUE_IS_METHOD(V8Value, IsSharedArrayBuffer)
 static PHP_V8_VALUE_IS_METHOD(V8Value, IsProxy)
@@ -968,7 +967,6 @@ PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsUint32Array)
 PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsInt32Array)
 PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsFloat32Array)
 PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsFloat64Array)
-//PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsFloat32x4)  // Experimental
 PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsDataView)
 PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsSharedArrayBuffer)
 PHP_V8_VALUE_IS_METHOD_ARG_INFO(IsProxy)
@@ -1099,7 +1097,6 @@ static const zend_function_entry php_v8_value_methods[] = {
         PHP_ME(V8Value, IsInt32Array,                   arginfo_v8_value_IsInt32Array,                  ZEND_ACC_PUBLIC)
         PHP_ME(V8Value, IsFloat32Array,                 arginfo_v8_value_IsFloat32Array,                ZEND_ACC_PUBLIC)
         PHP_ME(V8Value, IsFloat64Array,                 arginfo_v8_value_IsFloat64Array,                ZEND_ACC_PUBLIC)
-//        PHP_ME(V8Value, IsFloat32x4,                    arginfo_v8_value_IsFloat32x4,                   ZEND_ACC_PUBLIC) // Experimental
         PHP_ME(V8Value, IsDataView,                     arginfo_v8_value_IsDataView,                    ZEND_ACC_PUBLIC)
         PHP_ME(V8Value, IsSharedArrayBuffer,            arginfo_v8_value_IsSharedArrayBuffer,           ZEND_ACC_PUBLIC)
         PHP_ME(V8Value, IsProxy,                        arginfo_v8_value_IsProxy,                       ZEND_ACC_PUBLIC)

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -262,19 +262,15 @@ zend_class_entry *php_v8_get_class_entry_from_value(v8::Local<v8::Value> value) 
         return php_v8_symbol_class_entry;
     }
 
-    /* currently we ignore detectind v8::Number sub-types */
-
-    /*
-    if (value->IsUint32()) {
-        return php_v8_uint32_class_entry;
-    }
-
-    if (value->IsInt32()) {
-        return php_v8_int32_class_entry;
-    }
-    */
-
     if (value->IsNumber()) {
+        if (value->IsInt32()) {
+            return php_v8_int32_class_entry;
+        }
+
+        if (value->IsUint32()) {
+            return php_v8_uint32_class_entry;
+        }
+
         return php_v8_number_class_entry;
     }
 

--- a/stubs/src/Context.php
+++ b/stubs/src/Context.php
@@ -32,9 +32,6 @@ class Context
      *
      * \param isolate The isolate in which to create the context.
      *
-     * \param extensions An optional extension configuration containing
-     * the extensions to be installed in the newly created context.
-     *
      * \param global_template An optional object template from which the
      * global object for the newly created context will be created.
      *
@@ -45,15 +42,13 @@ class Context
      * and only object identify will remain.
      *
      * @param \V8\Isolate             $isolate
-     * @param array|null              $extensions Currently unused as there are not extensions support
      * @param \V8\ObjectTemplate|null $global_template
      * @param \V8\ObjectValue|null    $global_object
+     *
+     * @internal param array|null $extensions Currently unused as there are not extensions support
      */
     public function __construct(
-        Isolate $isolate,
-        array $extensions = null,
-        ObjectTemplate $global_template = null,
-        ObjectValue $global_object = null
+        Isolate $isolate, ObjectTemplate $global_template = null, ObjectValue $global_object = null
     ) {
     }
 

--- a/stubs/src/Script.php
+++ b/stubs/src/Script.php
@@ -56,4 +56,13 @@ class Script
     public function Run(Context $context): Value
     {
     }
+
+    /**
+     * Returns the corresponding context-unbound script.
+     *
+     * @return \V8\UnboundScript
+     */
+    public function GetUnboundScript(): UnboundScript
+    {
+    }
 }

--- a/stubs/src/Script.php
+++ b/stubs/src/Script.php
@@ -16,10 +16,8 @@ namespace V8;
 
 class Script
 {
-    private $isolate;
+    //private $isolate;
     private $context;
-    private $source;
-    private $origin;
 
     /**
      * @param Context      $context
@@ -30,38 +28,20 @@ class Script
     {
         // $this->isolate = $context->isolate;
         $this->context = $context;
-        $this->source = $source;
-        $this->origin = $origin;
     }
 
     /**
      * @return Isolate
      */
-    public function GetIsolate() : Isolate
+    public function GetIsolate(): Isolate
     {
     }
 
     /**
      * @return \V8\Context
      */
-    public function GetContext() : Context
+    public function GetContext(): Context
     {
-    }
-
-    /**
-     * @return StringValue
-     */
-    public function getSource() : StringValue
-    {
-        return $this->source;
-    }
-
-    /**
-     * @return ScriptOrigin
-     */
-    public function getOrigin() : ScriptOrigin
-    {
-        return $this->origin;
     }
 
     /**
@@ -73,12 +53,7 @@ class Script
      *
      * @return BooleanValue|FunctionObject|NumberValue|ObjectValue|StringValue|Value
      */
-    public function Run(Context $context) : Value
+    public function Run(Context $context): Value
     {
     }
-
-    /**
-     * Returns the corresponding context-unbound script.
-     */
-    //Local<UnboundScript> GetUnboundScript();
 }

--- a/stubs/src/ScriptCompiler.php
+++ b/stubs/src/ScriptCompiler.php
@@ -1,0 +1,107 @@
+<?php
+
+
+namespace V8;
+
+use V8\ScriptCompiler\CompileOptions;
+use V8\ScriptCompiler\Source;
+
+
+/**
+ * For compiling scripts.
+ */
+class  ScriptCompiler
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Return a version tag for CachedData for the current V8 version & flags.
+     *
+     * This value is meant only for determining whether a previously generated
+     * CachedData instance is still valid; the tag has no other meaing.
+     *
+     * Background: The data carried by CachedData may depend on the exact
+     *   V8 version number or currently compiler flags. This means when
+     *   persisting CachedData, the embedder must take care to not pass in
+     *   data from another V8 version, or the same version with different
+     *   features enabled.
+     *
+     *   The easiest way to do so is to clear the embedder's cache on any
+     *   such change.
+     *
+     *   Alternatively, this tag can be stored alongside the cached data and
+     *   compared when it is being used.
+     *
+     * @return int
+     */
+    public static function CachedDataVersionTag(): int
+    {
+    }
+
+    /**
+     * Compiles the specified script (context-independent).
+     * Cached data as part of the source object can be optionally produced to be
+     * consumed later to speed up compilation of identical source scripts.
+     *
+     * Note that when producing cached data, the source must point to NULL for
+     * cached data. When consuming cached data, the cached data must have been
+     * produced by the same version of V8.
+     *
+     * \param source Script source code.
+     * \return Compiled script object (context independent; for running it must be
+     *   bound to a context).
+     *
+     * @param Context $context
+     * @param Source  $source
+     * @param int     $options
+     *
+     * @return UnboundScript
+     */
+    public static function CompileUnboundScript(Context $context, Source $source, int $options = CompileOptions::kNoCompileOptions): UnboundScript
+    {
+    }
+
+    /**
+     * Compiles the specified script (bound to current context).
+     *
+     * \param source Script source code.
+     * \param pre_data Pre-parsing data, as obtained by ScriptData::PreCompile()
+     *   using pre_data speeds compilation if it's done multiple times.
+     *   Owned by caller, no references are kept when this function returns.
+     * \return Compiled script object, bound to the context that was active
+     *   when this function was called. When run it will always use this
+     *   context.
+     *
+     * @param Context $context
+     * @param Source  $source
+     * @param int     $options
+     *
+     * @return Script
+     */
+    public static function Compile(Context $context, Source $source, int $options = CompileOptions::kNoCompileOptions): Script
+    {
+    }
+
+    /**
+     * Compile a function for a given context. This is equivalent to running
+     *
+     * with (obj) {
+     *   return function(args) { ... }
+     * }
+     *
+     * It is possible to specify multiple context extensions (obj in the above
+     * example).
+     *
+     * @param Context       $context
+     * @param Source        $source
+     * @param StringValue[] $arguments
+     * @param ObjectValue[] $context_extensions
+     *
+     * @return FunctionObject
+     */
+    public static function CompileFunctionInContext(Context $context, Source $source, array $arguments = [], array $context_extensions = []): FunctionObject
+    {
+    }
+}

--- a/stubs/src/ScriptCompiler/CachedData.php
+++ b/stubs/src/ScriptCompiler/CachedData.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace V8\ScriptCompiler;
+
+
+/**
+ * Compilation data that the embedder can cache and pass back to speed up
+ * future compilations. The data is produced if the CompilerOptions passed to
+ * the compilation functions in ScriptCompiler contains produce_data_to_cache
+ * = true. The data to cache can then can be retrieved from
+ * UnboundScript.
+ */
+class CachedData
+{
+    public function __construct(string $data)
+    {
+    }
+
+    public function getData(): string
+    {
+    }
+
+    // TODO: technically, we can use \strlen($this->getData()) when we need, though in PHP it's not necessary to get string length before fetching string itself
+    //public function getLength(): int
+    //{
+    //}
+
+    public function isRejected(): bool
+    {
+    }
+}

--- a/stubs/src/ScriptCompiler/CompileOptions.php
+++ b/stubs/src/ScriptCompiler/CompileOptions.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace V8\ScriptCompiler;
+
+
+class CompileOptions
+{
+    const kNoCompileOptions = 0;
+    const kProduceParserCache = 1;
+    const kConsumeParserCache = 2;
+    const kProduceCodeCache = 3;
+    const kConsumeCodeCache = 4;
+}

--- a/stubs/src/ScriptCompiler/Source.php
+++ b/stubs/src/ScriptCompiler/Source.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace V8\ScriptCompiler;
+
+use V8\ScriptOrigin;
+use V8\StringValue;
+
+
+/**
+ * Source code which can be then compiled to a UnboundScript or Script.
+ */
+class Source
+{
+    /**
+     * @var StringValue
+     */
+    private $source_string;
+    /**
+     * @var null|ScriptOrigin
+     */
+    private $origin;
+    /**
+     * @var null|CachedData
+     */
+    private $cached_data;
+
+    /**
+     * @param StringValue       $source_string
+     * @param ScriptOrigin|null $origin
+     * @param CachedData|null   $cached_data
+     */
+    public function __construct(StringValue $source_string, ScriptOrigin $origin = null, CachedData $cached_data = null)
+    {
+        $this->source_string = $source_string;
+        $this->origin        = $origin;
+        $this->cached_data   = $cached_data;
+    }
+
+    public function GetSourceString(): StringValue
+    {
+        return $this->source_string;
+    }
+
+    public function GetScriptOrigin(): ScriptOrigin
+    {
+        return $this->origin;
+    }
+
+    public function GetCachedData(): CachedData
+    {
+        return $this->cached_data;
+    }
+}

--- a/stubs/src/ScriptOrigin.php
+++ b/stubs/src/ScriptOrigin.php
@@ -55,6 +55,8 @@ class ScriptOrigin
      * @param int    $script_id
      * @param string $source_map_url
      * @param bool   $resource_is_opaque
+     * @param bool   $is_wasm
+     * @param bool   $is_module
      */
     public function __construct(string $resource_name,
                                 int $resource_line_offset = Message::kNoLineNumberInfo,
@@ -62,13 +64,15 @@ class ScriptOrigin
                                 bool $resource_is_shared_cross_origin = false,
                                 int $script_id = Message::kNoScriptIdInfo,
                                 string $source_map_url = '',
-                                bool $resource_is_opaque = false)
+                                bool $resource_is_opaque = false,
+                                bool $is_wasm = false,
+                                bool $is_module = false)
     {
         $this->resource_name = $resource_name;
         $this->resource_line_offset = $resource_line_offset;
         $this->resource_column_offset = $resource_column_offset;
 
-        $this->options = new ScriptOriginOptions($resource_is_shared_cross_origin, $resource_is_opaque);
+        $this->options = new ScriptOriginOptions($resource_is_shared_cross_origin, $resource_is_opaque, $is_wasm, $is_module);
 
         $this->script_id = $script_id;
         $this->source_map_url = $source_map_url;

--- a/stubs/src/ScriptOriginOptions.php
+++ b/stubs/src/ScriptOriginOptions.php
@@ -22,33 +22,69 @@ namespace V8;
 class ScriptOriginOptions
 {
     /**
-     * @var bool|bool
+     * @var bool
      */
     private $is_shared_cross_origin;
     /**
-     * @var bool|bool
+     * @var bool
      */
     private $is_opaque;
+    /**
+     * @var bool
+     */
+    private $is_wasm;
+    /**
+     * @var bool
+     */
+    private $is_module;
 
     /**
-     * @param bool $is_embedder_debug_script
      * @param bool $is_shared_cross_origin
      * @param bool $is_opaque
+     * @param bool $is_wasm
+     * @param bool $is_module
      */
     public function __construct(bool $is_shared_cross_origin = false,
-                                bool $is_opaque = false)
+                                bool $is_opaque = false,
+                                bool $is_wasm = false,
+                                bool $is_module = false
+                                )
     {
         $this->is_shared_cross_origin = $is_shared_cross_origin;
         $this->is_opaque = $is_opaque;
+        $this->is_wasm = $is_wasm;
+        $this->is_module = $is_module;
     }
 
+    /**
+     * @return bool
+     */
     public function IsSharedCrossOrigin() : bool
     {
         return $this->is_shared_cross_origin;
     }
 
+    /**
+     * @return bool
+     */
     public function IsOpaque() : bool
     {
         return $this->is_opaque;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIsWasm(): bool
+    {
+        return $this->is_wasm;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIsModule(): bool
+    {
+        return $this->is_module;
     }
 }

--- a/stubs/src/SymbolValue.php
+++ b/stubs/src/SymbolValue.php
@@ -99,6 +99,15 @@ class SymbolValue extends NameValue
      *
      * @return SymbolValue
      */
+    public static function GetToPrimitive(Isolate $isolate) : SymbolValue
+    {
+    }
+
+    /**
+     * @param Isolate $isolate
+     *
+     * @return SymbolValue
+     */
     public static function GetToStringTag(Isolate $isolate) : SymbolValue
     {
     }

--- a/stubs/src/UnboundScript.php
+++ b/stubs/src/UnboundScript.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace V8;
+
+/**
+ * A compiled JavaScript script, not yet tied to a Context.
+ */
+class UnboundScript
+{
+    const kNoScriptId = 0;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Binds the script to the currently entered context.
+     *
+     * @param Context $context
+     *
+     * @return Script
+     */
+    public function BindToContext(Context $context): Script
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function GetId(): int
+    {
+    }
+
+    /**
+     * @return Value
+     */
+    public function GetScriptName(): Value
+    {
+    }
+
+    /**
+     * Data read from magic sourceURL comments.
+     *
+     * @return Value
+     */
+    public function GetSourceURL(): Value
+    {
+    }
+
+    /**
+     * Data read from magic sourceMappingURL comments.
+     *
+     * @return Value
+     */
+    public function GetSourceMappingURL(): Value
+    {
+    }
+
+    /**
+     * Returns zero based line number of the code_pos location in the script.
+     * -1 will be returned if no information available.
+     *
+     * @param int $code_pos
+     *
+     * @return int
+     */
+    public function GetLineNumber(int $code_pos): int
+    {
+    }
+}

--- a/tests/.testsuite.php
+++ b/tests/.testsuite.php
@@ -197,6 +197,12 @@ class PhpV8Testsuite
             true), PHP_EOL;
     }
 
+    public function method_matches_with_dump($object, $method, $expected, array $args = [])
+    {
+        echo get_class($object), '::', $method, '()', ' ', ($expected === $object->$method(...$args) ? 'matches' : 'doesn\'t match'), ' expected ';
+        $this->dump($expected);
+    }
+
     public function method_dump($object, $method, array $args = [])
     {
         echo get_class($object), '::', $method, '()', ' ', var_export($object->$method(...$args), true), PHP_EOL;

--- a/tests/.testsuite.php
+++ b/tests/.testsuite.php
@@ -32,6 +32,11 @@ class PhpV8Testsuite
         echo str_repeat('-', strlen($title) + 1), PHP_EOL;
     }
 
+    public function message($message)
+    {
+        echo $message, PHP_EOL;
+    }
+
     public function inline($message, $value)
     {
         echo $message, ': ', $value, PHP_EOL;

--- a/tests/.testsuite.php
+++ b/tests/.testsuite.php
@@ -185,16 +185,21 @@ class PhpV8Testsuite
     }
 
 
-    public function method_matches_instanceof($object, $method, $expected)
+    public function method_matches_instanceof($object, $method, $expected, array $args = [])
     {
-        echo get_class($object), '::', $method, '() result', ($object->$method() instanceof $expected ? ' is' : ' not an'), ' instance of ', $expected, PHP_EOL;
+        echo get_class($object), '::', $method, '() result', ($object->$method(...$args) instanceof $expected ? ' is' : ' not an'), ' instance of ', $expected, PHP_EOL;
     }
 
 
-    public function method_matches_with_output($object, $method, $expected)
+    public function method_matches_with_output($object, $method, $expected, array $args = [])
     {
-        echo get_class($object), '::', $method, '()', ' ', ($expected === $object->$method() ? 'matches' : 'doesn\'t match'), ' expected ', var_export($expected,
+        echo get_class($object), '::', $method, '()', ' ', ($expected === $object->$method(...$args) ? 'matches' : 'doesn\'t match'), ' expected ', var_export($expected,
             true), PHP_EOL;
+    }
+
+    public function method_dump($object, $method, array $args = [])
+    {
+        echo get_class($object), '::', $method, '()', ' ', var_export($object->$method(...$args), true), PHP_EOL;
     }
 
     public function dump_object_constants($object)

--- a/tests/001-verify-method-parameters-type.phpt
+++ b/tests/001-verify-method-parameters-type.phpt
@@ -35,7 +35,7 @@ class Verifier
             return;
         }
 
-        if (!(class_exists($type))) {
+        if (!class_exists($type) && !interface_exists($type)) {
             $method_name = $parameter->getDeclaringClass()->getName() . '::' . $parameter->getDeclaringFunction()->getName();
             $param_name  = $parameter->getName();
 

--- a/tests/003-V8ObjectTemplate_recursive_global.phpt
+++ b/tests/003-V8ObjectTemplate_recursive_global.phpt
@@ -25,7 +25,7 @@ try {
     $helper->exception_export($e);
 }
 
-$context = new \V8\Context($isolate, [], $template);
+$context = new \V8\Context($isolate, $template);
 
 
 ?>

--- a/tests/V8AccessControl.phpt
+++ b/tests/V8AccessControl.phpt
@@ -1,0 +1,37 @@
+--TEST--
+V8\AccessControl
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+// Bootstraps:
+$obj = new V8\AccessControl();
+
+// Tests:
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+$helper->header('Object representation');
+$helper->dump($obj);
+$helper->space();
+
+
+$helper->header('Class constants');
+$helper->dump_object_constants($obj);
+$helper->space();
+
+?>
+--EXPECT--
+Object representation:
+----------------------
+object(V8\AccessControl)#1 (0) {
+}
+
+
+Class constants:
+----------------
+V8\AccessControl::DEFAULT_ACCESS = 0
+V8\AccessControl::ALL_CAN_READ = 1
+V8\AccessControl::ALL_CAN_WRITE = 2

--- a/tests/V8ArrayObject.phpt
+++ b/tests/V8ArrayObject.phpt
@@ -12,11 +12,10 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate);
 
 $global_template1->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate), \V8\PropertyAttribute::DontDelete);
-$context = new V8\Context($isolate, $extensions1, $global_template1);
+$context = new V8\Context($isolate, $global_template1);
 
 $value = new V8\ArrayObject($context);
 
@@ -81,7 +80,7 @@ object(V8\ArrayObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (4) {
+  object(V8\Context)#5 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -94,9 +93,6 @@ object(V8\ArrayObject)#6 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {
@@ -267,7 +263,7 @@ V8\ArrayObject(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (4) {
+      object(V8\Context)#5 (3) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -280,9 +276,6 @@ V8\ArrayObject(V8\Value)->ToObject():
           int(0)
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
-        }
-        ["extensions":"V8\Context":private]=>
-        array(0) {
         }
         ["global_template":"V8\Context":private]=>
         object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8ArrayObject.phpt
+++ b/tests/V8ArrayObject.phpt
@@ -204,7 +204,7 @@ V8\ArrayObject(V8\Value)->ToBoolean():
       }
     }
 V8\ArrayObject(V8\Value)->ToNumber():
-    object(V8\NumberValue)#118 (1) {
+    object(V8\Int32Value)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -305,7 +305,7 @@ V8\ArrayObject(V8\Value)->ToObject():
       }
     }
 V8\ArrayObject(V8\Value)->ToInteger():
-    object(V8\NumberValue)#118 (1) {
+    object(V8\Int32Value)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -321,7 +321,7 @@ V8\ArrayObject(V8\Value)->ToInteger():
       }
     }
 V8\ArrayObject(V8\Value)->ToUint32():
-    object(V8\NumberValue)#118 (1) {
+    object(V8\Int32Value)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -337,7 +337,7 @@ V8\ArrayObject(V8\Value)->ToUint32():
       }
     }
 V8\ArrayObject(V8\Value)->ToInt32():
-    object(V8\NumberValue)#118 (1) {
+    object(V8\Int32Value)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8ArrayObject_Length.phpt
+++ b/tests/V8ArrayObject_Length.phpt
@@ -9,10 +9,9 @@ V8\ArrayObject::Length
 $helper = require '.testsuite.php';
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $source1    = '
 [1,2,3]

--- a/tests/V8Boolean.phpt
+++ b/tests/V8Boolean.phpt
@@ -33,9 +33,8 @@ $helper->space();
 
 $v8_helper->run_checks($value, 'Checkers');
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $helper->header('Primitive converters');

--- a/tests/V8BooleanObject.phpt
+++ b/tests/V8BooleanObject.phpt
@@ -12,7 +12,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 // TODO: fix it, this cause segfault due to FunctionTemplate object destruction and all it internal structures cleanup
@@ -20,7 +19,7 @@ $global_template1 = new V8\ObjectTemplate($isolate1);
 $print_func_tpl = $v8_helper->getPrintFunctionTemplate($isolate1);
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $print_func_tpl, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $value = new V8\BooleanObject($context1, true);
 
@@ -73,7 +72,7 @@ object(V8\BooleanObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (4) {
+  object(V8\Context)#7 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -86,9 +85,6 @@ object(V8\BooleanObject)#8 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8CachedData.phpt
+++ b/tests/V8CachedData.phpt
@@ -1,0 +1,60 @@
+--TEST--
+V8\ScriptCompiler\CachedData
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+// Tests:
+
+$value = new \V8\ScriptCompiler\CachedData('');
+
+$helper->header('Object representation');
+$helper->dump($value);
+$helper->space();
+
+$helper->header('Methods');
+
+$data = [
+    '',
+    'test foo bar baz',
+    random_bytes(16),
+    random_bytes(31),
+    'Юникод',
+    '萬國碼、國際碼、統一碼、單一碼',
+    'یوونیکۆد',
+];
+
+foreach ($data as $d) {
+    $value = new \V8\ScriptCompiler\CachedData($d);
+    $helper->method_matches_with_dump($value, 'GetData', $d);
+}
+
+$helper->method_dump($value, 'IsRejected');
+
+
+
+?>
+--EXPECTF--
+Object representation:
+----------------------
+object(V8\ScriptCompiler\CachedData)#3 (0) {
+}
+
+
+Methods:
+--------
+V8\ScriptCompiler\CachedData::GetData() matches expected string(0) ""
+V8\ScriptCompiler\CachedData::GetData() matches expected string(16) "test foo bar baz"
+V8\ScriptCompiler\CachedData::GetData() matches expected string(16) "%r.{16}%r"
+V8\ScriptCompiler\CachedData::GetData() matches expected string(31) "%r.{31}%r"
+V8\ScriptCompiler\CachedData::GetData() matches expected string(12) "Юникод"
+V8\ScriptCompiler\CachedData::GetData() matches expected string(45) "萬國碼、國際碼、統一碼、單一碼"
+V8\ScriptCompiler\CachedData::GetData() matches expected string(16) "یوونیکۆد"
+V8\ScriptCompiler\CachedData::IsRejected() false

--- a/tests/V8CompileOptions.phpt
+++ b/tests/V8CompileOptions.phpt
@@ -1,0 +1,39 @@
+--TEST--
+V8\ScriptCompiler\CompileOptions
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+// Bootstraps:
+$obj = new V8\ScriptCompiler\CompileOptions();
+
+// Tests:
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+$helper->header('Object representation');
+$helper->dump($obj);
+$helper->space();
+
+
+$helper->header('Class constants');
+$helper->dump_object_constants($obj);
+$helper->space();
+
+?>
+--EXPECT--
+Object representation:
+----------------------
+object(V8\ScriptCompiler\CompileOptions)#1 (0) {
+}
+
+
+Class constants:
+----------------
+V8\ScriptCompiler\CompileOptions::kNoCompileOptions = 0
+V8\ScriptCompiler\CompileOptions::kProduceParserCache = 1
+V8\ScriptCompiler\CompileOptions::kConsumeParserCache = 2
+V8\ScriptCompiler\CompileOptions::kProduceCodeCache = 3
+V8\ScriptCompiler\CompileOptions::kConsumeCodeCache = 4

--- a/tests/V8Context.phpt
+++ b/tests/V8Context.phpt
@@ -12,15 +12,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
-//$global_template1 = new V8\ObjectTemplate($isolate1);
-//$global_template1->Set('print', $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
-
-try{
-    $context = new \V8\Context($isolate1, ['some', 'extensions']);
-} catch(Exception $e) {
-    $helper->exception_export($e);
-}
 
 $context = new \V8\Context($isolate1);
 $helper->pretty_dump('Estimated memory usage size by this context', $context->EstimatedSize());
@@ -50,7 +41,6 @@ $helper->pretty_dump('Estimated memory usage size by this context', $context->Es
 
 ?>
 --EXPECTF--
-ErrorException: Extensions are not supported yet
 Estimated memory usage size by this context: int(%d)
 V8\Context::GlobalObject() result is instance of V8\ObjectValue
 CHECK $global->SameValue($context->GlobalObject()): OK

--- a/tests/V8Context_GlobalObject.phpt
+++ b/tests/V8Context_GlobalObject.phpt
@@ -15,8 +15,6 @@ $v8_helper = new PhpV8Helpers($helper);
 require '.tracking_dtors.php';
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
-
 $context = new \V8\Context($isolate1);
 
 $helper->method_matches_instanceof($context, 'GlobalObject', \V8\ObjectValue::class);
@@ -31,7 +29,7 @@ $helper->assert('Global object on repeatable calls holds extra props', $global1-
 
 $context->DetachGlobal();
 
-$context2 = new \V8\Context($isolate1, null, null, $global2);
+$context2 = new \V8\Context($isolate1, null, $global2);
 $helper->method_matches_instanceof($context2, 'GlobalObject', \V8\ObjectValue::class);
 
 echo 'Global object passed from one context to another is ', ($global1 === $global2 ? 'the same' : 'not the same'), PHP_EOL;

--- a/tests/V8Context_weakness.phpt
+++ b/tests/V8Context_weakness.phpt
@@ -17,7 +17,6 @@ class Context extends V8\Context {
 }
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
@@ -25,7 +24,7 @@ $source1 = 'var obj = {}; obj';
 $file_name1 = 'test.js';
 
 $script1 = new \V8\Script(
-    new Context($isolate1, $extensions1, $global_template1),
+    new Context($isolate1, $global_template1),
     new \V8\StringValue($isolate1, $source1),
     new \V8\ScriptOrigin($file_name1)
 );

--- a/tests/V8DateObject.phpt
+++ b/tests/V8DateObject.phpt
@@ -18,7 +18,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 // TODO: fix it, this cause segfault due to FunctionTemplate object destruction and all it internal structures cleanup
@@ -26,7 +25,7 @@ $global_template1 = new V8\ObjectTemplate($isolate1);
 $print_func_tpl = $v8_helper->getPrintFunctionTemplate($isolate1);
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $print_func_tpl, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $test_time = 1445444940000.0;
 $value = new V8\DateObject($context1, $test_time);
@@ -131,7 +130,7 @@ object(V8\DateObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (4) {
+  object(V8\Context)#7 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -144,9 +143,6 @@ object(V8\DateObject)#8 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8Exception_CreateMessage.phpt
+++ b/tests/V8Exception_CreateMessage.phpt
@@ -93,10 +93,14 @@ V8\Message->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#18 (2) {
+      object(V8\ScriptOriginOptions)#18 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_wasm":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_module":"V8\ScriptOriginOptions":private]=>
         bool(false)
       }
       ["script_id":"V8\ScriptOrigin":private]=>
@@ -127,10 +131,14 @@ V8\Message->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#35 (2) {
+      object(V8\ScriptOriginOptions)#35 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_wasm":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_module":"V8\ScriptOriginOptions":private]=>
         bool(false)
       }
       ["script_id":"V8\ScriptOrigin":private]=>

--- a/tests/V8Exception_CreateMessage.phpt
+++ b/tests/V8Exception_CreateMessage.phpt
@@ -85,7 +85,7 @@ Message created from thrown value:
 V8\Message->Get(): string(18) "Uncaught #<Object>"
 V8\Message->GetSourceLine(): string(24) "        test(exception);"
 V8\Message->GetScriptOrigin():
-    object(V8\ScriptOrigin)#22 (6) {
+    object(V8\ScriptOrigin)#19 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(7) "test.js"
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -93,7 +93,7 @@ V8\Message->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#18 (4) {
+      object(V8\ScriptOriginOptions)#15 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>
@@ -123,7 +123,7 @@ Message created from created value:
 V8\Message->Get(): string(13) "Uncaught test"
 V8\Message->GetSourceLine(): string(24) "        test(exception);"
 V8\Message->GetScriptOrigin():
-    object(V8\ScriptOrigin)#36 (6) {
+    object(V8\ScriptOrigin)#33 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(7) "test.js"
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -131,7 +131,7 @@ V8\Message->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#35 (4) {
+      object(V8\ScriptOriginOptions)#32 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>

--- a/tests/V8Exception_CreateMessage.phpt
+++ b/tests/V8Exception_CreateMessage.phpt
@@ -45,7 +45,7 @@ $global_tpl = new \V8\ObjectTemplate($isolate);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 $global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_test_tpl);
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 
 $source = '

--- a/tests/V8Exception_Error.phpt
+++ b/tests/V8Exception_Error.phpt
@@ -55,7 +55,7 @@ $global_tpl->Set(new \V8\StringValue($isolate, 'e'), $func_tpl);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 $global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_test_tpl);
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 $v8_helper->CompileTryRun($context, 'test()');
 $v8_helper->CompileTryRun($context, 'e()');

--- a/tests/V8Exception_GetStackTrace.phpt
+++ b/tests/V8Exception_GetStackTrace.phpt
@@ -112,7 +112,7 @@ Stack trace created from thrown value:
 V8\StackTrace->getFrames():
     array(1) {
       [0]=>
-      object(V8\StackFrame)#20 (8) {
+      object(V8\StackFrame)#17 (8) {
         ["line_number":"V8\StackFrame":private]=>
         int(5)
         ["column":"V8\StackFrame":private]=>
@@ -133,7 +133,7 @@ V8\StackTrace->getFrames():
     }
 V8\StackTrace->GetFrameCount(): int(1)
 V8\StackTrace->AsArray():
-    object(V8\ArrayObject)#18 (2) {
+    object(V8\ArrayObject)#15 (2) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8Exception_GetStackTrace.phpt
+++ b/tests/V8Exception_GetStackTrace.phpt
@@ -58,7 +58,7 @@ $global_tpl = new \V8\ObjectTemplate($isolate);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 $global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_test_tpl);
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 
 $source = '
@@ -148,7 +148,7 @@ V8\StackTrace->AsArray():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#8 (4) {
+      object(V8\Context)#8 (3) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -161,9 +161,6 @@ V8\StackTrace->AsArray():
           int(0)
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
-        }
-        ["extensions":"V8\Context":private]=>
-        array(0) {
         }
         ["global_template":"V8\Context":private]=>
         object(V8\ObjectTemplate)#7 (1) {

--- a/tests/V8Exception_RangeError.phpt
+++ b/tests/V8Exception_RangeError.phpt
@@ -56,7 +56,7 @@ $global_tpl->Set(new \V8\StringValue($isolate, 'e'), $func_tpl);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 $global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_test_tpl);
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 $v8_helper->CompileTryRun($context, 'test()');
 $v8_helper->CompileTryRun($context, 'e()');

--- a/tests/V8Exception_ReferenceError.phpt
+++ b/tests/V8Exception_ReferenceError.phpt
@@ -56,7 +56,7 @@ $global_tpl->Set(new \V8\StringValue($isolate, 'e'), $func_tpl);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 $global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_test_tpl);
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 $v8_helper->CompileTryRun($context, 'test()');
 $v8_helper->CompileTryRun($context, 'e()');

--- a/tests/V8Exception_SyntaxError.phpt
+++ b/tests/V8Exception_SyntaxError.phpt
@@ -56,7 +56,7 @@ $global_tpl->Set(new \V8\StringValue($isolate, 'e'), $func_tpl);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 $global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_test_tpl);
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 $v8_helper->CompileTryRun($context, 'test()');
 $v8_helper->CompileTryRun($context, 'e()');

--- a/tests/V8Exception_TypeError.phpt
+++ b/tests/V8Exception_TypeError.phpt
@@ -56,7 +56,7 @@ $global_tpl->Set(new \V8\StringValue($isolate, 'e'), $func_tpl);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 $global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_test_tpl);
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 $v8_helper->CompileTryRun($context, 'test()');
 $v8_helper->CompileTryRun($context, 'e()');

--- a/tests/V8ExceptionsTryCatchException.phpt
+++ b/tests/V8ExceptionsTryCatchException.phpt
@@ -60,7 +60,7 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
     bool(false)
   }
   ["context":"V8\Exceptions\TryCatchException":private]=>
-  object(V8\Context)#3 (4) {
+  object(V8\Context)#3 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -74,8 +74,6 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["extensions":"V8\Context":private]=>
-    NULL
     ["global_template":"V8\Context":private]=>
     NULL
     ["global_object":"V8\Context":private]=>
@@ -97,7 +95,7 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
       bool(false)
     }
     ["context":"V8\TryCatch":private]=>
-    object(V8\Context)#3 (4) {
+    object(V8\Context)#3 (3) {
       ["isolate":"V8\Context":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -111,8 +109,6 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["extensions":"V8\Context":private]=>
-      NULL
       ["global_template":"V8\Context":private]=>
       NULL
       ["global_object":"V8\Context":private]=>

--- a/tests/V8FunctionCallbackInfo.phpt
+++ b/tests/V8FunctionCallbackInfo.phpt
@@ -81,7 +81,7 @@ echo 'We are done for now', PHP_EOL;
 Function called
 Object representation:
 ----------------------
-object(V8\FunctionCallbackInfo)#13 (0) {
+object(V8\FunctionCallbackInfo)#10 (0) {
 }
 
 
@@ -99,7 +99,7 @@ V8\Exceptions\GenericException: Attempt to use callback info object out of callb
 
 Object representation (outside of context):
 -------------------------------------------
-object(V8\FunctionCallbackInfo)#13 (0) {
+object(V8\FunctionCallbackInfo)#10 (0) {
 }
 
 

--- a/tests/V8FunctionCallbackInfo.phpt
+++ b/tests/V8FunctionCallbackInfo.phpt
@@ -13,11 +13,8 @@ $helper = require '.testsuite.php';
 require '.tracking_dtors.php';
 
 $isolate1 = new v8Tests\TrackingDtors\Isolate();
-$extensions1 = [];
-
 $global_template1 = new V8\ObjectTemplate($isolate1);
-
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 // TEST: Pass context instead of isolate to FunctionTemplate
 

--- a/tests/V8FunctionObject.phpt
+++ b/tests/V8FunctionObject.phpt
@@ -16,11 +16,8 @@ $v8_helper = new PhpV8Helpers($helper);
 require '.tracking_dtors.php';
 
 $isolate1 = new v8Tests\TrackingDtors\Isolate();
-$extensions1 = [];
-
 $global_template1 = new V8\ObjectTemplate($isolate1);
-
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 
 $func = new v8Tests\TrackingDtors\FunctionObject($context1, function (\V8\FunctionCallbackInfo $info) {
@@ -74,7 +71,7 @@ object(v8Tests\TrackingDtors\FunctionObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (4) {
+  object(V8\Context)#5 (3) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -87,9 +84,6 @@ object(v8Tests\TrackingDtors\FunctionObject)#6 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8FunctionObject.phpt
+++ b/tests/V8FunctionObject.phpt
@@ -184,10 +184,14 @@ v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#134 (2) {
+      object(V8\ScriptOriginOptions)#134 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_wasm":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_module":"V8\ScriptOriginOptions":private]=>
         bool(false)
       }
       ["script_id":"V8\ScriptOrigin":private]=>

--- a/tests/V8FunctionObject.phpt
+++ b/tests/V8FunctionObject.phpt
@@ -176,7 +176,7 @@ Should output Hello World string
 string(11) "Script done"
 
 v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
-    object(V8\ScriptOrigin)#133 (6) {
+    object(V8\ScriptOrigin)#127 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(0) ""
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -184,7 +184,7 @@ v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#134 (4) {
+      object(V8\ScriptOriginOptions)#131 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>

--- a/tests/V8FunctionObject_die.phpt
+++ b/tests/V8FunctionObject_die.phpt
@@ -13,11 +13,8 @@ $helper = require '.testsuite.php';
 require '.tracking_dtors.php';
 
 $isolate1 = new v8Tests\TrackingDtors\Isolate();
-$extensions1 = [];
-
 $global_template1 = new V8\ObjectTemplate($isolate1);
-
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 
 $func = new v8Tests\TrackingDtors\FunctionObject($context1, function (\V8\FunctionCallbackInfo $info) {

--- a/tests/V8FunctionObject_weakness_multiple.phpt
+++ b/tests/V8FunctionObject_weakness_multiple.phpt
@@ -16,12 +16,8 @@ $v8_helper = new PhpV8Helpers($helper);
 require '.tracking_dtors.php';
 
 $isolate1 = new v8Tests\TrackingDtors\Isolate();
-
-$extensions1 = [];
-
 $global_template1 = new V8\ObjectTemplate($isolate1);
-
-$context1 = new v8Tests\TrackingDtors\Context($isolate1, $extensions1, $global_template1);
+$context1 = new v8Tests\TrackingDtors\Context($isolate1, $global_template1);
 $global_template1 = null;
 
 $func = new v8Tests\TrackingDtors\FunctionObject($context1, function (\V8\FunctionCallbackInfo $info) {

--- a/tests/V8FunctionTemplate.phpt
+++ b/tests/V8FunctionTemplate.phpt
@@ -77,7 +77,6 @@ $instance_template_1 = $function_template->InstanceTemplate();
 
 $instance_template_2 = $function_template->InstanceTemplate();
 
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
 $value = new V8\StringValue($isolate, 'TEST VALUE 111');
@@ -87,7 +86,7 @@ $global_template->Set(new \V8\StringValue($isolate, 'func'), $function_template)
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $print_func_tpl, \V8\PropertyAttribute::DontDelete);
 
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 
 $source    = '

--- a/tests/V8FunctionTemplate_GetFunction.phpt
+++ b/tests/V8FunctionTemplate_GetFunction.phpt
@@ -11,7 +11,6 @@ V8\FunctionTemplate::GetFunction
 $helper = require '.testsuite.php';
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 
 
 $print_func_tpl = new \V8\FunctionTemplate($isolate1, function (\V8\FunctionCallbackInfo $info) {
@@ -20,8 +19,8 @@ $print_func_tpl = new \V8\FunctionTemplate($isolate1, function (\V8\FunctionCall
 
 
 $global_template1 = new V8\ObjectTemplate($isolate1);
-$context1 = new \V8\Context($isolate1, $extensions1, $global_template1);
-$context2 = new \V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new \V8\Context($isolate1, $global_template1);
+$context2 = new \V8\Context($isolate1, $global_template1);
 
 $func_1 = $print_func_tpl->GetFunction($context1);
 

--- a/tests/V8FunctionTemplate_SetCallHandler.phpt
+++ b/tests/V8FunctionTemplate_SetCallHandler.phpt
@@ -11,7 +11,6 @@ V8\FunctionTemplate::SetCallHandler
 $helper = require '.testsuite.php';
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 
 
 $test_func_tpl = new \V8\FunctionTemplate($isolate1, function () {echo 'callback 1', PHP_EOL;});
@@ -33,7 +32,7 @@ $global_template1 = new \V8\ObjectTemplate($isolate1);
 $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_func_tpl);
 $global_template1->Set(new \V8\StringValue($isolate1, 'change'), $change_func_tpl);
 
-$context1 = new \V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new \V8\Context($isolate1, $global_template1);
 
 
 $source1 = 'test(); change(); test(); "Script done"';

--- a/tests/V8FunctionTemplate_exception_in_php.phpt
+++ b/tests/V8FunctionTemplate_exception_in_php.phpt
@@ -11,7 +11,6 @@ V8\FunctionTemplate: exception in php thrown
 $helper = require '.testsuite.php';
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 
 $test_func_tpl = new \V8\FunctionTemplate($isolate1, function (\V8\FunctionCallbackInfo $info) {
     throw new Exception('Unexpected exception');
@@ -21,7 +20,7 @@ $test_func_tpl = new \V8\FunctionTemplate($isolate1, function (\V8\FunctionCallb
 $global_template1 = new V8\ObjectTemplate($isolate1);
 $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_func_tpl, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $source1 = 'test(); "Script done"';
 $file_name1 = 'test.js';

--- a/tests/V8FunctionTemplate_require_implementation.phpt
+++ b/tests/V8FunctionTemplate_require_implementation.phpt
@@ -30,7 +30,7 @@ $require_func_tpl_cache = new \V8\FunctionTemplate($isolate1, function (\V8\Func
   $module = $info->Arguments()[0]->ToString($context)->Value();
 
   if (!isset($loaded_cache[$module])) {
-    $new_context = new \V8\Context($isolate, [], new \V8\ObjectTemplate($isolate));
+    $new_context = new \V8\Context($isolate, new \V8\ObjectTemplate($isolate));
 
     $script = new \V8\Script($new_context, new \V8\StringValue($isolate, $code[$module]), new \V8\ScriptOrigin($module));
 
@@ -42,7 +42,7 @@ $require_func_tpl_cache = new \V8\FunctionTemplate($isolate1, function (\V8\Func
 $global_template = new V8\ObjectTemplate($isolate1);
 $global_template->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
 $global_template->Set(new \V8\StringValue($isolate1, 'require'), $require_func_tpl_cache, \V8\PropertyAttribute::DontDelete);
-$context = new V8\Context($isolate1, [], $global_template);
+$context = new V8\Context($isolate1, $global_template);
 
 $JS = '
 var test = require("test.js");
@@ -78,7 +78,7 @@ $require_func_tpl_nocache = new \V8\FunctionTemplate($isolate1, function (\V8\Fu
   $module = $info->Arguments()[0]->ToString($context)->Value();
 
   if (!isset($loaded_no_cache[$module])) {
-    $new_context = new \V8\Context($isolate, [], new \V8\ObjectTemplate($isolate));
+    $new_context = new \V8\Context($isolate, new \V8\ObjectTemplate($isolate));
 
     $script = new \V8\Script($new_context, new \V8\StringValue($isolate, $code[$module]), new \V8\ScriptOrigin($module));
 
@@ -92,7 +92,7 @@ $require_func_tpl_nocache = new \V8\FunctionTemplate($isolate1, function (\V8\Fu
 $global_template = new V8\ObjectTemplate($isolate1);
 $global_template->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
 $global_template->Set(new \V8\StringValue($isolate1, 'require'), $require_func_tpl_nocache, \V8\PropertyAttribute::DontDelete);
-$context = new V8\Context($isolate1, [], $global_template);
+$context = new V8\Context($isolate1, $global_template);
 
 $JS = '
 var test = require("test.js");

--- a/tests/V8FunctionTemplate_weakness.phpt
+++ b/tests/V8FunctionTemplate_weakness.phpt
@@ -51,7 +51,6 @@ class MyObjectTemplate extends \V8\ObjectTemplate
 }
 
 $isolate1 = new Isolate();
-$extensions1 = [];
 
 
 class MyCallaback
@@ -73,7 +72,7 @@ $global_template1 = new MyObjectTemplate($isolate1);
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $print_func_tpl);
 $print_func_tpl = null;
 
-$context1 = new Context($isolate1, $extensions1, $global_template1);
+$context1 = new Context($isolate1, $global_template1);
 $global_template1 = null;
 
 $source1 = 'print("Hello, world\n"); delete print; "Script done"';

--- a/tests/V8Int32Value.phpt
+++ b/tests/V8Int32Value.phpt
@@ -34,9 +34,8 @@ $helper->space();
 $v8_helper->run_checks($value, 'Checkers');
 
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $string = $value->ToString($context);

--- a/tests/V8IntegerValue.phpt
+++ b/tests/V8IntegerValue.phpt
@@ -34,9 +34,8 @@ $helper->space();
 $v8_helper->run_checks($value, 'Checkers');
 
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $string = $value->ToString($context);

--- a/tests/V8Isolate_ThrowException.phpt
+++ b/tests/V8Isolate_ThrowException.phpt
@@ -34,7 +34,7 @@ $global_tpl = new \V8\ObjectTemplate($isolate);
 $global_tpl->Set(new \V8\StringValue($isolate, 'e'), $func_tpl);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 
-$context = new \V8\Context($isolate, [], $global_tpl);
+$context = new \V8\Context($isolate, $global_tpl);
 
 $v8_helper->CompileTryRun($context, 'e()');
 $v8_helper->CompileTryRun($context, 'e("test")');

--- a/tests/V8Isolate_gc_cyclic_ref_memleak.phpt
+++ b/tests/V8Isolate_gc_cyclic_ref_memleak.phpt
@@ -14,7 +14,6 @@ $v8_helper = new PhpV8Helpers($helper);
 // Tests:
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $func_tpl = new \V8\FunctionTemplate($isolate1, function () {});
@@ -39,7 +38,7 @@ $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_obj_tpl);
 
 $handlers = null;
 
-$context1 = new \V8\Context($isolate1, [], $global_template1);
+$context1 = new \V8\Context($isolate1, $global_template1);
 
 $obj = new V8\ObjectValue($context1);
 $obj->SetAccessor($context1, new \V8\StringValue($isolate1, 'test'), function () use (&$isolate1, &$foo, &$name) {});

--- a/tests/V8Isolate_limit_memory.phpt
+++ b/tests/V8Isolate_limit_memory.phpt
@@ -91,7 +91,7 @@ object(V8\Isolate)#3 (5) {
   ["memory_limit_hit":"V8\Isolate":private]=>
   bool(true)
 }
-object(V8\HeapStatistics)#14 (9) {
+object(V8\HeapStatistics)#11 (9) {
   ["total_heap_size":"V8\HeapStatistics":private]=>
   float(%d)
   ["total_heap_size_executable":"V8\HeapStatistics":private]=>

--- a/tests/V8Isolate_limit_memory.phpt
+++ b/tests/V8Isolate_limit_memory.phpt
@@ -14,11 +14,10 @@ $v8_helper = new PhpV8Helpers($helper);
 // Tests:
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate), \V8\PropertyAttribute::DontDelete);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 
 $source    = '

--- a/tests/V8Isolate_limit_memory_nested.phpt
+++ b/tests/V8Isolate_limit_memory_nested.phpt
@@ -16,11 +16,10 @@ $v8_helper = new PhpV8Helpers($helper);
 // Tests:
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate), \V8\PropertyAttribute::DontDelete);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 $func = new V8\FunctionObject($context, function (\V8\FunctionCallbackInfo $info) use (&$helper) {
     if (!$info->Arguments()) {

--- a/tests/V8Isolate_limit_memory_not_hit.phpt
+++ b/tests/V8Isolate_limit_memory_not_hit.phpt
@@ -12,11 +12,10 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate), \V8\PropertyAttribute::DontDelete);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 $source = '
 print("start\n"); 

--- a/tests/V8Isolate_limit_time_nested.phpt
+++ b/tests/V8Isolate_limit_time_nested.phpt
@@ -11,11 +11,10 @@ $helper = require '.testsuite.php';
 require '.tracking_dtors.php';
 
 $isolate1 = new V8\Isolate();
-$extensions1 = [];
 
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $func = new V8\FunctionObject($context1, function (\V8\FunctionCallbackInfo $info) use (&$helper) {
     if (!$info->Arguments()) {

--- a/tests/V8Isolate_limit_time_not_hit.phpt
+++ b/tests/V8Isolate_limit_time_not_hit.phpt
@@ -12,11 +12,10 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate), \V8\PropertyAttribute::DontDelete);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 $source = '
 print("start\n"); 

--- a/tests/V8Isolate_limit_time_set_during_execution.phpt
+++ b/tests/V8Isolate_limit_time_set_during_execution.phpt
@@ -11,11 +11,9 @@ $helper = require '.testsuite.php';
 require '.tracking_dtors.php';
 
 $isolate1 = new V8\Isolate();
-$extensions1 = [];
-
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 if ($helper->need_more_time()) {
     // On travis when valgrind active it takes more time to complete all operations so we just increase initial limits

--- a/tests/V8Isolate_nested_termination_exceptions.phpt
+++ b/tests/V8Isolate_nested_termination_exceptions.phpt
@@ -11,11 +11,9 @@ $helper = require '.testsuite.php';
 require '.tracking_dtors.php';
 
 $isolate1 = new V8\Isolate();
-$extensions1 = [];
-
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $func = new V8\FunctionObject($context1, function (\V8\FunctionCallbackInfo $info) {
     if (!$info->Arguments()) {

--- a/tests/V8MapObject.phpt
+++ b/tests/V8MapObject.phpt
@@ -12,10 +12,9 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new \V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 $value = new V8\MapObject($context);
 
@@ -116,7 +115,7 @@ object(V8\MapObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (4) {
+  object(V8\Context)#5 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -129,9 +128,6 @@ object(V8\MapObject)#6 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {
@@ -309,7 +305,7 @@ V8\MapObject(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (4) {
+      object(V8\Context)#5 (3) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -322,9 +318,6 @@ V8\MapObject(V8\Value)->ToObject():
           int(0)
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
-        }
-        ["extensions":"V8\Context":private]=>
-        array(0) {
         }
         ["global_template":"V8\Context":private]=>
         object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8MapObject.phpt
+++ b/tests/V8MapObject.phpt
@@ -347,7 +347,7 @@ V8\MapObject(V8\Value)->ToObject():
       }
     }
 V8\MapObject(V8\Value)->ToInteger():
-    object(V8\NumberValue)#119 (1) {
+    object(V8\Int32Value)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -363,7 +363,7 @@ V8\MapObject(V8\Value)->ToInteger():
       }
     }
 V8\MapObject(V8\Value)->ToUint32():
-    object(V8\NumberValue)#119 (1) {
+    object(V8\Int32Value)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -379,7 +379,7 @@ V8\MapObject(V8\Value)->ToUint32():
       }
     }
 V8\MapObject(V8\Value)->ToInt32():
-    object(V8\NumberValue)#119 (1) {
+    object(V8\Int32Value)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8Message.phpt
+++ b/tests/V8Message.phpt
@@ -113,7 +113,7 @@ object(V8\Message)#8 (12) {
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#3 (4) {
+      object(V8\Context)#3 (3) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#2 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -127,8 +127,6 @@ object(V8\Message)#8 (12) {
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["extensions":"V8\Context":private]=>
-        NULL
         ["global_template":"V8\Context":private]=>
         NULL
         ["global_object":"V8\Context":private]=>
@@ -223,7 +221,7 @@ object(V8\Message)#9 (12) {
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#3 (4) {
+      object(V8\Context)#3 (3) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#2 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -237,8 +235,6 @@ object(V8\Message)#9 (12) {
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["extensions":"V8\Context":private]=>
-        NULL
         ["global_template":"V8\Context":private]=>
         NULL
         ["global_object":"V8\Context":private]=>

--- a/tests/V8Message.phpt
+++ b/tests/V8Message.phpt
@@ -73,10 +73,14 @@ object(V8\Message)#8 (12) {
     ["resource_column_offset":"V8\ScriptOrigin":private]=>
     int(0)
     ["options":"V8\ScriptOrigin":private]=>
-    object(V8\ScriptOriginOptions)#5 (2) {
+    object(V8\ScriptOriginOptions)#5 (4) {
       ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
       bool(false)
       ["is_opaque":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_wasm":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_module":"V8\ScriptOriginOptions":private]=>
       bool(false)
     }
     ["script_id":"V8\ScriptOrigin":private]=>
@@ -179,10 +183,14 @@ object(V8\Message)#9 (12) {
     ["resource_column_offset":"V8\ScriptOrigin":private]=>
     int(0)
     ["options":"V8\ScriptOrigin":private]=>
-    object(V8\ScriptOriginOptions)#5 (2) {
+    object(V8\ScriptOriginOptions)#5 (4) {
       ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
       bool(false)
       ["is_opaque":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_wasm":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_module":"V8\ScriptOriginOptions":private]=>
       bool(false)
     }
     ["script_id":"V8\ScriptOrigin":private]=>

--- a/tests/V8NameValue.phpt
+++ b/tests/V8NameValue.phpt
@@ -36,9 +36,8 @@ $helper->space();
 
 $v8_helper->run_checks($value);
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $helper->header('Primitive converters');

--- a/tests/V8NullValue.phpt
+++ b/tests/V8NullValue.phpt
@@ -33,9 +33,8 @@ $helper->space();
 
 $v8_helper->run_checks($value, 'Checkers');
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $helper->header('Primitive converters');

--- a/tests/V8NumberObject.phpt
+++ b/tests/V8NumberObject.phpt
@@ -14,7 +14,6 @@ $v8_helper = new PhpV8Helpers($helper);
 // Tests:
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 // TODO: fix it, this cause segfault due to FunctionTemplate object destruction and all it internal structures cleanup
@@ -22,7 +21,7 @@ $global_template1 = new V8\ObjectTemplate($isolate1);
 $print_func_tpl = $v8_helper->getPrintFunctionTemplate($isolate1);
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $print_func_tpl, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $value = new V8\NumberObject($context1, 42.12);
 
@@ -84,7 +83,7 @@ object(V8\NumberObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (4) {
+  object(V8\Context)#7 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -97,9 +96,6 @@ object(V8\NumberObject)#8 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8NumberValue.phpt
+++ b/tests/V8NumberValue.phpt
@@ -32,9 +32,8 @@ $helper->space();
 
 $v8_helper->run_checks($value, 'Checkers');
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $string = $value->ToString($context);

--- a/tests/V8ObjectTemplate_MarkAsUndetectable.phpt
+++ b/tests/V8ObjectTemplate_MarkAsUndetectable.phpt
@@ -13,7 +13,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
@@ -24,7 +23,7 @@ $test_obj_tpl->MarkAsUndetectable();
 $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_obj_tpl);
 $global_template1->Set(new \V8\StringValue($isolate1, 'test2'), new \V8\ObjectTemplate($isolate1));
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 
 $source1    = '

--- a/tests/V8ObjectTemplate_Set.phpt
+++ b/tests/V8ObjectTemplate_Set.phpt
@@ -6,7 +6,6 @@ V8\ObjectTemplate::Set() - FunctionTemplate
 <?php
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $fnc = function (\V8\FunctionCallbackInfo $info) {

--- a/tests/V8ObjectTemplate_SetAccessCheckCallback.phpt
+++ b/tests/V8ObjectTemplate_SetAccessCheckCallback.phpt
@@ -74,7 +74,7 @@ $global_template->SetAccessorProperty(new \V8\StringValue($isolate, 'blocked_js_
 //  // Create an environment
 //  v8::Local<Context> context0 = Context::New(isolate, NULL, global_template);
 //  context0->Enter();
-$context0 = new \V8\Context($isolate, [], $global_template);
+$context0 = new \V8\Context($isolate, $global_template);
 
 //  v8::Handle<v8::Object> global0 = context0->Global();
 $global0 = $context0->GlobalObject();

--- a/tests/V8ObjectTemplate_SetAccessCheckCallback_func_args.phpt
+++ b/tests/V8ObjectTemplate_SetAccessCheckCallback_func_args.phpt
@@ -45,7 +45,7 @@ $test_obj_tpl->SetAccessCheckCallback($access_check_callback);
 
 $global_template->Set(new \V8\StringValue($isolate, 'test'), $test_obj_tpl);
 
-$context0 = new \V8\Context($isolate, [], $global_template);
+$context0 = new \V8\Context($isolate, $global_template);
 
 $other = $context0->GlobalObject()->Get($context0, new \V8\StringValue($isolate, 'test'));
 

--- a/tests/V8ObjectTemplate_SetCallAsFunctionHandler.phpt
+++ b/tests/V8ObjectTemplate_SetCallAsFunctionHandler.phpt
@@ -12,7 +12,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
@@ -38,7 +37,7 @@ $global_template1->Set(new \V8\StringValue($isolate1, 'func'), new \V8\FunctionT
 $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_obj_tpl);
 $global_template1->Set(new \V8\StringValue($isolate1, 'test2'), new \V8\ObjectTemplate($isolate1));
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 
 $source1    = '

--- a/tests/V8ObjectTemplate_SetHandlerForIndexedProperty.phpt
+++ b/tests/V8ObjectTemplate_SetHandlerForIndexedProperty.phpt
@@ -12,7 +12,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
@@ -77,7 +76,7 @@ $test_obj_tpl->SetHandlerForIndexedProperty(new \V8\IndexedPropertyHandlerConfig
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_obj_tpl);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 
 $source1    = '

--- a/tests/V8ObjectTemplate_SetHandlerForNamedProperty.phpt
+++ b/tests/V8ObjectTemplate_SetHandlerForNamedProperty.phpt
@@ -12,7 +12,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
@@ -64,7 +63,7 @@ $test_obj_tpl->SetHandlerForNamedProperty(new \V8\NamedPropertyHandlerConfigurat
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_obj_tpl);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 
 $source1    = '

--- a/tests/V8ObjectTemplate_SetHandler_both.phpt
+++ b/tests/V8ObjectTemplate_SetHandler_both.phpt
@@ -12,7 +12,6 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
@@ -120,7 +119,7 @@ $test_obj_tpl->SetHandlerForIndexedProperty(new \V8\IndexedPropertyHandlerConfig
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'test'), $test_obj_tpl);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 
 $source1    = '

--- a/tests/V8ObjectValue.phpt
+++ b/tests/V8ObjectValue.phpt
@@ -12,10 +12,9 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new \V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 $value = new V8\ObjectValue($context);
 
@@ -63,7 +62,7 @@ object(V8\ObjectValue)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (4) {
+  object(V8\Context)#5 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -76,9 +75,6 @@ object(V8\ObjectValue)#6 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {
@@ -256,7 +252,7 @@ V8\ObjectValue(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (4) {
+      object(V8\Context)#5 (3) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -269,9 +265,6 @@ V8\ObjectValue(V8\Value)->ToObject():
           int(0)
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
-        }
-        ["extensions":"V8\Context":private]=>
-        array(0) {
         }
         ["global_template":"V8\Context":private]=>
         object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8ObjectValue.phpt
+++ b/tests/V8ObjectValue.phpt
@@ -294,7 +294,7 @@ V8\ObjectValue(V8\Value)->ToObject():
       }
     }
 V8\ObjectValue(V8\Value)->ToInteger():
-    object(V8\NumberValue)#116 (1) {
+    object(V8\Int32Value)#116 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -310,7 +310,7 @@ V8\ObjectValue(V8\Value)->ToInteger():
       }
     }
 V8\ObjectValue(V8\Value)->ToUint32():
-    object(V8\NumberValue)#116 (1) {
+    object(V8\Int32Value)#116 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -326,7 +326,7 @@ V8\ObjectValue(V8\Value)->ToUint32():
       }
     }
 V8\ObjectValue(V8\Value)->ToInt32():
-    object(V8\NumberValue)#116 (1) {
+    object(V8\Int32Value)#116 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8ObjectValue_Get.phpt
+++ b/tests/V8ObjectValue_Get.phpt
@@ -9,10 +9,9 @@ V8\ObjectValue::Get
 $helper = require '.testsuite.php';
 
 $isolate = new \V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 $fnc = new \V8\FunctionObject($context, function () {echo 'I am fun', PHP_EOL;});
 

--- a/tests/V8ObjectValue_IsArgumentsObject.phpt
+++ b/tests/V8ObjectValue_IsArgumentsObject.phpt
@@ -14,9 +14,8 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 //THREADED_TEST(ArgumentsObject)
 

--- a/tests/V8ObjectValue_IsNativeError.phpt
+++ b/tests/V8ObjectValue_IsNativeError.phpt
@@ -14,9 +14,8 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 // THREADED_TEST(IsNativeError)
 

--- a/tests/V8ObjectValue_SetAccessor.phpt
+++ b/tests/V8ObjectValue_SetAccessor.phpt
@@ -13,7 +13,6 @@ V8\ObjectValue::SetAccessor
 $helper = require '.testsuite.php';
 
 $isolate1         = new \V8\Isolate();
-$extensions1      = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 
@@ -39,7 +38,7 @@ $print_func_tpl = new \V8\FunctionTemplate($isolate1, function (\V8\FunctionCall
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $print_func_tpl, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $prop_value = 'foo';
 

--- a/tests/V8ObjectValue_SetIntegrityLevel.phpt
+++ b/tests/V8ObjectValue_SetIntegrityLevel.phpt
@@ -12,10 +12,9 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate1         = new \V8\Isolate();
-$extensions1      = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 $v8_helper->injectConsoleLog($context1);
 
 

--- a/tests/V8PrimitiveValue.phpt
+++ b/tests/V8PrimitiveValue.phpt
@@ -31,9 +31,8 @@ $helper->space();
 
 $v8_helper->run_checks($value);
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $helper->header('Primitive converters');

--- a/tests/V8RegExpObject.phpt
+++ b/tests/V8RegExpObject.phpt
@@ -14,7 +14,6 @@ $v8_helper = new PhpV8Helpers($helper);
 // Tests:
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 // TODO: fix it, this cause segfault due to FunctionTemplate object destruction and all it internal structures cleanup
@@ -22,7 +21,7 @@ $global_template1 = new V8\ObjectTemplate($isolate1);
 $print_func_tpl = $v8_helper->getPrintFunctionTemplate($isolate1);
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $print_func_tpl, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $value = new V8\RegExpObject($context1, new \V8\StringValue($isolate1, '([a-z]{1,4})-([0-9]+)'), \V8\RegExpObject\Flags::kIgnoreCase);
 
@@ -80,7 +79,7 @@ object(V8\RegExpObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (4) {
+  object(V8\Context)#7 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -93,9 +92,6 @@ object(V8\RegExpObject)#8 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8ReturnValue.phpt
+++ b/tests/V8ReturnValue.phpt
@@ -16,13 +16,12 @@ $v8_helper = new PhpV8Helpers($helper);
 require '.tracking_dtors.php';
 
 $isolate1 = new v8Tests\TrackingDtors\Isolate();
-$extensions1 = [];
 
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 //$global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $scalar = new \V8\StringValue($isolate1, "test");
 $object = new \V8\ObjectValue($context1);

--- a/tests/V8ReturnValue_context.phpt
+++ b/tests/V8ReturnValue_context.phpt
@@ -73,7 +73,7 @@ $helper->space();
 --EXPECT--
 Object representation:
 ----------------------
-object(V8\ReturnValue)#14 (0) {
+object(V8\ReturnValue)#11 (0) {
 }
 
 
@@ -89,5 +89,5 @@ V8\Exceptions\GenericException: Attempt to use return value out of calling funct
 
 Object representation (outside of context):
 -------------------------------------------
-object(V8\ReturnValue)#14 (0) {
+object(V8\ReturnValue)#11 (0) {
 }

--- a/tests/V8Script.phpt
+++ b/tests/V8Script.phpt
@@ -47,7 +47,7 @@ $helper->space();
 $v8_helper->run_checks($res, 'Checkers');
 ?>
 --EXPECT--
-object(V8\Script)#7 (4) {
+object(V8\Script)#7 (2) {
   ["isolate":"V8\Script":private]=>
   object(V8\Isolate)#3 (5) {
     ["snapshot":"V8\Isolate":private]=>
@@ -97,46 +97,6 @@ object(V8\Script)#7 (4) {
     }
     ["global_object":"V8\Context":private]=>
     NULL
-  }
-  ["source":"V8\Script":private]=>
-  object(V8\StringValue)#8 (1) {
-    ["isolate":"V8\Value":private]=>
-    object(V8\Isolate)#3 (5) {
-      ["snapshot":"V8\Isolate":private]=>
-      NULL
-      ["time_limit":"V8\Isolate":private]=>
-      float(0)
-      ["time_limit_hit":"V8\Isolate":private]=>
-      bool(false)
-      ["memory_limit":"V8\Isolate":private]=>
-      int(0)
-      ["memory_limit_hit":"V8\Isolate":private]=>
-      bool(false)
-    }
-  }
-  ["origin":"V8\Script":private]=>
-  object(V8\ScriptOrigin)#9 (6) {
-    ["resource_name":"V8\ScriptOrigin":private]=>
-    string(7) "test.js"
-    ["resource_line_offset":"V8\ScriptOrigin":private]=>
-    int(0)
-    ["resource_column_offset":"V8\ScriptOrigin":private]=>
-    int(0)
-    ["options":"V8\ScriptOrigin":private]=>
-    object(V8\ScriptOriginOptions)#10 (4) {
-      ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
-      bool(false)
-      ["is_opaque":"V8\ScriptOriginOptions":private]=>
-      bool(false)
-      ["is_wasm":"V8\ScriptOriginOptions":private]=>
-      bool(false)
-      ["is_module":"V8\ScriptOriginOptions":private]=>
-      bool(false)
-    }
-    ["script_id":"V8\ScriptOrigin":private]=>
-    int(0)
-    ["source_map_url":"V8\ScriptOrigin":private]=>
-    string(0) ""
   }
 }
 Accessors:

--- a/tests/V8Script.phpt
+++ b/tests/V8Script.phpt
@@ -123,10 +123,14 @@ object(V8\Script)#7 (4) {
     ["resource_column_offset":"V8\ScriptOrigin":private]=>
     int(0)
     ["options":"V8\ScriptOrigin":private]=>
-    object(V8\ScriptOriginOptions)#10 (2) {
+    object(V8\ScriptOriginOptions)#10 (4) {
       ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
       bool(false)
       ["is_opaque":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_wasm":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_module":"V8\ScriptOriginOptions":private]=>
       bool(false)
     }
     ["script_id":"V8\ScriptOrigin":private]=>

--- a/tests/V8Script.phpt
+++ b/tests/V8Script.phpt
@@ -15,7 +15,6 @@ $v8_helper = new PhpV8Helpers($helper);
 
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
 $value = new V8\StringValue($isolate, 'TEST VALUE 111');
@@ -24,7 +23,7 @@ $value = new V8\StringValue($isolate, 'TEST VALUE 111');
 $global_template->Set(new \V8\StringValue($isolate, 'test'), $value);
 
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 
 $source    = 'var test = "passed"; 2+2*2-2/2 + test';
@@ -67,7 +66,7 @@ object(V8\Script)#7 (2) {
     bool(false)
   }
   ["context":"V8\Script":private]=>
-  object(V8\Context)#6 (4) {
+  object(V8\Context)#6 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -80,9 +79,6 @@ object(V8\Script)#7 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8Script.phpt
+++ b/tests/V8Script.phpt
@@ -38,6 +38,11 @@ $helper->header('Accessors');
 $helper->method_matches($script, 'GetContext', $context);
 $helper->space();
 
+$helper->header('Get unbound script');
+$helper->method_matches_instanceof($script, 'GetUnboundScript', \V8\UnboundScript::class);
+$helper->dump($script->GetUnboundScript());
+$helper->space();
+
 $res = $script->Run($context);
 
 $helper->header('Script result accessors');
@@ -102,6 +107,26 @@ object(V8\Script)#7 (2) {
 Accessors:
 ----------
 V8\Script::GetContext() matches expected value
+
+
+Get unbound script:
+-------------------
+V8\Script::GetUnboundScript() result is instance of V8\UnboundScript
+object(V8\UnboundScript)#8 (1) {
+  ["isolate":"V8\UnboundScript":private]=>
+  object(V8\Isolate)#3 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+}
 
 
 Script result accessors:

--- a/tests/V8ScriptCompiler.phpt
+++ b/tests/V8ScriptCompiler.phpt
@@ -1,0 +1,26 @@
+--TEST--
+V8\ScriptCompiler
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new V8\Isolate();
+
+$helper->header('Methods');
+$helper->inline_dump('V8\ScriptCompiler::CachedDataVersionTag()', V8\ScriptCompiler::CachedDataVersionTag());
+$helper->space();
+
+
+?>
+--EXPECTF--
+Methods:
+--------
+V8\ScriptCompiler::CachedDataVersionTag(): int(%d)

--- a/tests/V8ScriptCompiler_Compile.phpt
+++ b/tests/V8ScriptCompiler_Compile.phpt
@@ -1,0 +1,356 @@
+--TEST--
+V8\ScriptCompiler::Compile
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new V8\Isolate();
+$context = new V8\Context($isolate);
+
+$cache_data = null;
+{
+    $helper->header('Compiling');
+
+    $source_string = new V8\StringValue($isolate, '"test"');
+    $source        = new \V8\ScriptCompiler\Source($source_string);
+    $script        = V8\ScriptCompiler::Compile($context, $source);
+    $helper->assert('Compile script', $script instanceof \V8\Script);
+
+    $source_string = new V8\StringValue($isolate, 'var i = 0; while (true) {i++;}');
+    $source        = new \V8\ScriptCompiler\Source($source_string);
+    $script        = V8\ScriptCompiler::Compile($context, $source);
+    $helper->assert('Compile script', $script instanceof \V8\Script);
+
+    try {
+        $source_string = new V8\StringValue($isolate, 'garbage garbage garbage');
+        $source        = new \V8\ScriptCompiler\Source($source_string);
+        $script        = V8\ScriptCompiler::Compile($context, $source);
+    } catch (\V8\Exceptions\TryCatchException $e) {
+        $helper->exception_export($e);
+        //$helper->dump($e->GetTryCatch());
+    }
+
+    try {
+        $origin = new \V8\ScriptOrigin('test-module.js', 0, 0, false, 0, "", false, false, true);
+
+        $source_string = new V8\StringValue($isolate, '"test"');
+        $source        = new \V8\ScriptCompiler\Source($source_string, $origin);
+        $script        = V8\ScriptCompiler::Compile($context, $source);
+    } catch (\V8\Exceptions\GenericException $e) {
+        $helper->exception_export($e);
+    }
+
+    $helper->space();
+}
+
+{
+    $helper->header('Testing');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $script = V8\ScriptCompiler::Compile($context, $source);
+
+    $context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'status'), new \V8\StringValue($isolate, 'passed'));
+    $helper->dump($script->Run($context)->Value());
+
+    $helper->space();
+}
+
+{
+    $helper->header('Test cache when no cache set');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');
+    $source    = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is not set', $source->GetCachedData() === null);
+    try {
+        $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    } catch (\V8\Exceptions\GenericException $e) {
+        $helper->exception_export($e);
+    }
+}
+
+{
+    $helper->header('Test generating code cache');
+    $source_string = new V8\StringValue($isolate, '"test " + status');
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is NULL', $source->GetCachedData() === null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kProduceCodeCache);
+    $helper->assert('Source cache data is update', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $cache_data = $source->GetCachedData();
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache');
+
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache for wrong source');
+    $source_string = new V8\StringValue($isolate, '"other " + status');
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is rejected', $source->GetCachedData()->isRejected() === true);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache for source with different formatting');
+    $source_string = new V8\StringValue($isolate, '   "test "   +   status');
+    $source    = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() !== false);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test generating code cache when it already set');
+    $source_string = new V8\StringValue($isolate, '"test " + status');
+    $source    = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kProduceCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is rejected', $source->GetCachedData()->isRejected() === true);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache when requesting parser cache');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');
+    $source    = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() !== true);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test parser cache generated not for for all code');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is NULL', $source->GetCachedData() === null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kProduceParserCache);
+    $helper->assert('Source cache data is NOT updated', $source->GetCachedData() === null);
+
+    $helper->line();
+}
+
+$parser_cache_src= 'function test(arg1, args) {
+    if (arg1 > arg2) {
+        return 1+1;
+    } else {
+        return arg1 + arg2;
+    }
+}';
+
+{
+    $helper->header('Test generating parser cache');
+
+    $source_string = new V8\StringValue($isolate, $parser_cache_src);
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is NULL', $source->GetCachedData() === null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kProduceParserCache);
+    $helper->assert('Source cache data is update', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $cache_data = $source->GetCachedData();
+
+    //$helper->dump($cache_data->getData());
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming parser cache');
+
+    $source_string = new V8\StringValue($isolate, $parser_cache_src);
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming parser cache on different source (function with the same name)');
+
+    $bin = $cache_data->getData();
+    $source_string = new V8\StringValue($isolate, 'function test() { return 1+1;}');
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    try {
+        $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    } catch (\V8\Exceptions\TryCatchException $e) {
+        $helper->exception_export($e);
+    }
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming parser cache on different source');
+
+    $bin = $cache_data->getData();
+    $source_string = new V8\StringValue($isolate, 'function test2() { return 1+1;}');
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is rejected', $source->GetCachedData()->isRejected() === true);
+    $helper->assert('Source cache data is not changed', $source->GetCachedData()->getData() === $bin);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming parser cache on the same source with different formatting');
+
+    $source_string = new V8\StringValue($isolate, '           ' . $parser_cache_src);
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is rejected', $source->GetCachedData()->isRejected() === true);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache when parser cache given');
+
+    $source_string = new V8\StringValue($isolate, $parser_cache_src);
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $helper->line();
+}
+
+
+
+?>
+--EXPECT--
+Compiling:
+----------
+Compile script: ok
+Compile script: ok
+V8\Exceptions\TryCatchException: SyntaxError: Unexpected identifier
+V8\Exceptions\GenericException: Unable to compile module as script
+
+
+Testing:
+--------
+string(11) "test passed"
+
+
+Test cache when no cache set:
+-----------------------------
+Source cache data is not set: ok
+V8\Exceptions\GenericException: Unable to consume cache when it's not set
+Test generating code cache:
+---------------------------
+Source cache data is NULL: ok
+Source cache data is update: ok
+Source cache data is not rejected: ok
+
+Test consuming code cache:
+--------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test consuming code cache for wrong source:
+-------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is rejected: ok
+
+Test consuming code cache for source with different formatting:
+---------------------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test generating code cache when it already set:
+-----------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is rejected: ok
+
+Test consuming code cache when requesting parser cache:
+-------------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test parser cache generated not for for all code:
+-------------------------------------------------
+Source cache data is NULL: ok
+Source cache data is NOT updated: ok
+
+Test generating parser cache:
+-----------------------------
+Source cache data is NULL: ok
+Source cache data is update: ok
+Source cache data is not rejected: ok
+
+Test consuming parser cache:
+----------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test consuming parser cache on different source (function with the same name):
+------------------------------------------------------------------------------
+Source cache data is set: ok
+V8\Exceptions\TryCatchException: SyntaxError: Unexpected end of input
+
+Test consuming parser cache on different source:
+------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is rejected: ok
+Source cache data is not changed: ok
+
+Test consuming parser cache on the same source with different formatting:
+-------------------------------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is rejected: ok
+
+Test consuming code cache when parser cache given:
+--------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok

--- a/tests/V8ScriptCompiler_CompileFunctionInContext.phpt
+++ b/tests/V8ScriptCompiler_CompileFunctionInContext.phpt
@@ -1,0 +1,153 @@
+--TEST--
+V8\ScriptCompiler::CompileFunctionInContext
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new V8\Isolate();
+$context = new V8\Context($isolate);
+
+
+$helper->header('Compiling');
+
+$source_string = new V8\StringValue($isolate, '"test"');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source);
+$helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+
+$source_string = new V8\StringValue($isolate, 'var i = 0; while (true) {i++;}');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source);
+$helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+
+$origin = new \V8\ScriptOrigin('test-module.js', 0, 0, false, 0, "", false, false, true);
+$source_string = new V8\StringValue($isolate, '"test"');
+$source = new \V8\ScriptCompiler\Source($source_string, $origin);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source);
+$helper->assert('Compile module as function', $function instanceof \V8\FunctionObject);
+
+try {
+    $source_string = new V8\StringValue($isolate, 'garbage garbage garbage');
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $function = V8\ScriptCompiler::CompileFunctionInContext($context, $source);
+} catch (\V8\Exceptions\TryCatchException $e) {
+    $helper->exception_export($e);
+    //$helper->dump($e->GetTryCatch());
+}
+
+
+$source_string = new V8\StringValue($isolate, 'test');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [new V8\StringValue($isolate, 'test')]);
+$helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+
+$source_string = new V8\StringValue($isolate, 'test');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [new V8\StringValue($isolate, 'test')], [new \V8\ObjectValue($context)]);
+$helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+
+$source_string = new V8\StringValue($isolate, '"test"');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [], [new \V8\ObjectValue($context)]);
+$helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+
+$source_string = new V8\StringValue($isolate, '"test"');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [], [new V8\StringObject($context, new V8\StringValue($isolate, 'test'))]);
+$helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+
+
+try {
+    $source_string = new V8\StringValue($isolate, '"test"');
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [new V8\StringObject($context, new V8\StringValue($isolate, 'test'))]);
+    $helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+} catch (TypeError $e) {
+    $helper->exception_export($e);
+}
+
+try {
+    $source_string = new V8\StringValue($isolate, '"test"');
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [], [new V8\StringValue($isolate, 'test')]);
+    $helper->assert('Compile function', $function instanceof \V8\FunctionObject);
+} catch (TypeError $e) {
+    $helper->exception_export($e);
+}
+
+$helper->space();
+
+
+$helper->header('Testing');
+
+$source_string = new V8\StringValue($isolate, 'return "test";');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source);
+
+$context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'test_simple'), $function);
+
+$script = new \V8\Script($context, new \V8\StringValue($isolate, 'test_simple()'));
+
+$helper->dump($script->Run($context)->Value());
+
+
+
+$source_string = new V8\StringValue($isolate, 'return "test " + status;');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [new \V8\StringValue($isolate, 'status')]);
+
+$context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'test_with_parameter'), $function);
+
+$script = new \V8\Script($context, new \V8\StringValue($isolate, 'test_with_parameter("passed")'));
+
+$helper->dump($script->Run($context)->Value());
+
+
+$ctx_a = new \V8\ObjectValue($context);
+$ctx_a->Set($context, new \V8\StringValue($isolate, 'foo'), new \V8\StringValue($isolate, 'foo from A'));
+$ctx_a->Set($context, new \V8\StringValue($isolate, 'bar'), new \V8\StringValue($isolate, 'bar from A'));
+
+$ctx_b = new \V8\ObjectValue($context);
+$ctx_b->Set($context, new \V8\StringValue($isolate, 'foo'), new \V8\StringValue($isolate, 'foo from B'));
+$ctx_b->Set($context, new \V8\StringValue($isolate, 'baz'), new \V8\StringValue($isolate, 'baz from B'));
+
+
+$source_string = new V8\StringValue($isolate, 'return "test " + status + " " + foo + " " + bar + " " + baz;');
+$source = new \V8\ScriptCompiler\Source($source_string);
+$function = V8\ScriptCompiler::CompileFunctionInContext($context, $source, [new \V8\StringValue($isolate, 'status')], [$ctx_a, $ctx_b]);
+
+$context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'test_with_parameter_and_contexts'), $function);
+
+$script = new \V8\Script($context, new \V8\StringValue($isolate, 'test_with_parameter_and_contexts("passed")'));
+
+$helper->dump($script->Run($context)->Value());
+
+?>
+--EXPECT--
+Compiling:
+----------
+Compile function: ok
+Compile function: ok
+Compile module as function: ok
+V8\Exceptions\TryCatchException: SyntaxError: Unexpected identifier
+Compile function: ok
+Compile function: ok
+Compile function: ok
+Compile function: ok
+TypeError: Argument 3 passed to V8\ScriptCompiler::CompileFunctionInContext() should be array of \V8\StringValue, instance of V8\StringObject given at 0 offset
+TypeError: Argument 4 passed to V8\ScriptCompiler::CompileFunctionInContext() should be array of \V8\ObjectValue, instance of V8\StringValue given at 0 offset
+
+
+Testing:
+--------
+string(4) "test"
+string(11) "test passed"
+string(44) "test passed foo from B bar from A baz from B"

--- a/tests/V8ScriptCompiler_CompileUnbound.phpt
+++ b/tests/V8ScriptCompiler_CompileUnbound.phpt
@@ -1,0 +1,296 @@
+--TEST--
+V8\ScriptCompiler::CompileUnboundScript
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new V8\Isolate();
+$context = new V8\Context($isolate);
+
+$cache_data = null;
+{
+    $helper->header('Compiling');
+
+    $source_string = new V8\StringValue($isolate, '"test"');
+    $source        = new \V8\ScriptCompiler\Source($source_string);
+    $unbound        = V8\ScriptCompiler::CompileUnboundScript($context, $source);
+    $helper->assert('Compile script', $unbound instanceof \V8\UnboundScript);
+
+    $source_string = new V8\StringValue($isolate, 'var i = 0; while (true) {i++;}');
+    $source        = new \V8\ScriptCompiler\Source($source_string);
+    $unbound        = V8\ScriptCompiler::CompileUnboundScript($context, $source);
+    $helper->assert('Compile script', $unbound instanceof \V8\UnboundScript);
+
+    try {
+        $source_string = new V8\StringValue($isolate, 'garbage garbage garbage');
+        $source        = new \V8\ScriptCompiler\Source($source_string);
+        $unbound        = V8\ScriptCompiler::CompileUnboundScript($context, $source);
+    } catch (\V8\Exceptions\TryCatchException $e) {
+        $helper->exception_export($e);
+        //$helper->dump($e->GetTryCatch());
+    }
+
+    try {
+        $origin = new \V8\ScriptOrigin('test-module.js', 0, 0, false, 0, "", false, false, true);
+
+        $source_string = new V8\StringValue($isolate, '"test"');
+        $source        = new \V8\ScriptCompiler\Source($source_string, $origin);
+        $unbound        = V8\ScriptCompiler::CompileUnboundScript($context, $source);
+    } catch (\V8\Exceptions\GenericException $e) {
+        $helper->exception_export($e);
+    }
+
+    $helper->space();
+}
+
+{
+    $helper->header('Testing');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source);
+
+    $context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'status'), new \V8\StringValue($isolate, 'passed'));
+
+    $context2 = new \V8\Context($isolate);
+    $context2->GlobalObject()->Set($context2, new \V8\StringValue($isolate, 'status'), new \V8\StringValue($isolate, 'passed for second context'));
+
+    
+    $helper->dump($unbound->BindToContext($context)->Run($context)->Value());
+    $helper->dump($unbound->BindToContext($context2)->Run($context)->Value());
+    $helper->dump($unbound->BindToContext($context2)->Run($context2)->Value());
+    $helper->dump($unbound->BindToContext($context)->Run($context2)->Value());
+
+    $helper->space();
+}
+
+{
+    $helper->header('Test cache when no cache set');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');;
+    $source    = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is not set', $source->GetCachedData() === null);
+    try {
+        $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    } catch (\V8\Exceptions\GenericException $e) {
+        $helper->exception_export($e);
+    }
+}
+
+{
+    $helper->header('Test generating code cache');
+    $source_string = new V8\StringValue($isolate, '"test " + status');;
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is NULL', $source->GetCachedData() === null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kProduceCodeCache);
+    $helper->assert('Source cache data is update', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $cache_data = $source->GetCachedData();
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache');
+
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache for wrong source');
+    $source_string = new V8\StringValue($isolate, '"other " + status');;
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is rejected', $source->GetCachedData()->isRejected() === true);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache for source with different formatting');
+    $source_string = new V8\StringValue($isolate, '   "test "   +   status');;
+    $source    = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() !== false);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test generating code cache when it already set');
+    $source_string = new V8\StringValue($isolate, '"test " + status');;
+    $source    = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kProduceCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is rejected', $source->GetCachedData()->isRejected() === true);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache when requesting parser cache');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');;
+    $source    = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() !== true);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test parser cache genereted not for for all code');
+
+    $source_string = new V8\StringValue($isolate, '"test " + status');;
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is NULL', $source->GetCachedData() === null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kProduceParserCache);
+    $helper->assert('Source cache data is NOT updated', $source->GetCachedData() === null);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test generating parser cache');
+
+    $source_string = new V8\StringValue($isolate, 'function test() { return 1+1;}');;
+    $source = new \V8\ScriptCompiler\Source($source_string);
+    $helper->assert('Source cache data is NULL', $source->GetCachedData() === null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kProduceParserCache);
+    $helper->assert('Source cache data is update', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $cache_data = $source->GetCachedData();
+    $helper->line();
+}
+
+
+{
+    $helper->header('Test consuming parser cache');
+
+    $source_string = new V8\StringValue($isolate, 'function test() { return 1+1;}');;
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $helper->line();
+}
+
+{
+    $helper->header('Test consuming code cache when parser cache given');
+
+    $source_string = new V8\StringValue($isolate, 'function test() { return 1+1;}');;
+    $source = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+    $helper->assert('Source cache data is set', $source->GetCachedData() != null);
+    $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeCodeCache);
+    $helper->assert('Source cache data is still set', $source->GetCachedData() != null);
+    $helper->assert('Source cache data is not rejected', $source->GetCachedData()->isRejected() === false);
+
+    $helper->line();
+}
+
+
+
+?>
+--EXPECT--
+Compiling:
+----------
+Compile script: ok
+Compile script: ok
+V8\Exceptions\TryCatchException: SyntaxError: Unexpected identifier
+V8\Exceptions\GenericException: Unable to compile module as unbound script
+
+
+Testing:
+--------
+string(11) "test passed"
+string(30) "test passed for second context"
+string(30) "test passed for second context"
+string(11) "test passed"
+
+
+Test cache when no cache set:
+-----------------------------
+Source cache data is not set: ok
+V8\Exceptions\GenericException: Unable to consume cache when it's not set
+Test generating code cache:
+---------------------------
+Source cache data is NULL: ok
+Source cache data is update: ok
+Source cache data is not rejected: ok
+
+Test consuming code cache:
+--------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test consuming code cache for wrong source:
+-------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is rejected: ok
+
+Test consuming code cache for source with different formatting:
+---------------------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test generating code cache when it already set:
+-----------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is rejected: ok
+
+Test consuming code cache when requesting parser cache:
+-------------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test parser cache genereted not for for all code:
+-------------------------------------------------
+Source cache data is NULL: ok
+Source cache data is NOT updated: ok
+
+Test generating parser cache:
+-----------------------------
+Source cache data is NULL: ok
+Source cache data is update: ok
+Source cache data is not rejected: ok
+
+Test consuming parser cache:
+----------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok
+
+Test consuming code cache when parser cache given:
+--------------------------------------------------
+Source cache data is set: ok
+Source cache data is still set: ok
+Source cache data is not rejected: ok

--- a/tests/V8ScriptOrigin.phpt
+++ b/tests/V8ScriptOrigin.phpt
@@ -67,10 +67,14 @@ object(V8\ScriptOrigin)#2 (6) {
   ["resource_column_offset":"V8\ScriptOrigin":private]=>
   int(0)
   ["options":"V8\ScriptOrigin":private]=>
-  object(V8\ScriptOriginOptions)#3 (2) {
+  object(V8\ScriptOriginOptions)#3 (4) {
     ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
     bool(false)
     ["is_opaque":"V8\ScriptOriginOptions":private]=>
+    bool(false)
+    ["is_wasm":"V8\ScriptOriginOptions":private]=>
+    bool(false)
+    ["is_module":"V8\ScriptOriginOptions":private]=>
     bool(false)
   }
   ["script_id":"V8\ScriptOrigin":private]=>

--- a/tests/V8ScriptOriginOptions.phpt
+++ b/tests/V8ScriptOriginOptions.phpt
@@ -15,9 +15,9 @@ $helper->dump($obj);
 $helper->space();
 
 $helper->header('Test getters (default)');
-$helper->method_matches_with_output($obj, 'IsSharedCrossOrigin', false);
-$helper->method_matches_with_output($obj, 'IsOpaque', false);
+$helper->dump_object_methods($obj);
 $helper->space();
+
 
 
 $obj = new V8\ScriptOriginOptions(true);
@@ -27,19 +27,7 @@ $helper->dump($obj);
 $helper->space();
 
 $helper->header('Test getters');
-$helper->method_matches_with_output($obj, 'IsSharedCrossOrigin', true);
-$helper->method_matches_with_output($obj, 'IsOpaque', false);
-$helper->space();
-
-$obj = new V8\ScriptOriginOptions(true, true);
-
-$helper->header('Object representation');
-$helper->dump($obj);
-$helper->space();
-
-$helper->header('Test getters');
-$helper->method_matches_with_output($obj, 'IsSharedCrossOrigin', true);
-$helper->method_matches_with_output($obj, 'IsOpaque', true);
+$helper->dump_object_methods($obj);
 $helper->space();
 
 $obj = new V8\ScriptOriginOptions(false, true);
@@ -49,98 +37,136 @@ $helper->dump($obj);
 $helper->space();
 
 $helper->header('Test getters');
-$helper->method_matches_with_output($obj, 'IsSharedCrossOrigin', false);
-$helper->method_matches_with_output($obj, 'IsOpaque', true);
+$helper->dump_object_methods($obj);
 $helper->space();
 
-$obj = new V8\ScriptOriginOptions(true, false);
+$obj = new V8\ScriptOriginOptions(false, false, true);
 
 $helper->header('Object representation');
 $helper->dump($obj);
 $helper->space();
 
 $helper->header('Test getters');
-$helper->method_matches_with_output($obj, 'IsSharedCrossOrigin', true);
-$helper->method_matches_with_output($obj, 'IsOpaque', false);
+$helper->dump_object_methods($obj);
+$helper->space();
+
+$obj = new V8\ScriptOriginOptions(false, false, false, true);
+
+$helper->header('Object representation');
+$helper->dump($obj);
+$helper->space();
+
+$helper->header('Test getters');
+$helper->dump_object_methods($obj);
 $helper->space();
 
 ?>
 --EXPECT--
 Object representation (default):
 --------------------------------
-object(V8\ScriptOriginOptions)#2 (2) {
+object(V8\ScriptOriginOptions)#2 (4) {
   ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
   bool(false)
   ["is_opaque":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_wasm":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_module":"V8\ScriptOriginOptions":private]=>
   bool(false)
 }
 
 
 Test getters (default):
 -----------------------
-V8\ScriptOriginOptions::IsSharedCrossOrigin() matches expected false
-V8\ScriptOriginOptions::IsOpaque() matches expected false
+V8\ScriptOriginOptions->IsSharedCrossOrigin(): bool(false)
+V8\ScriptOriginOptions->IsOpaque(): bool(false)
+V8\ScriptOriginOptions->IsWasm(): bool(false)
+V8\ScriptOriginOptions->IsModule(): bool(false)
 
 
 Object representation:
 ----------------------
-object(V8\ScriptOriginOptions)#3 (2) {
+object(V8\ScriptOriginOptions)#11 (4) {
   ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
   bool(true)
   ["is_opaque":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_wasm":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_module":"V8\ScriptOriginOptions":private]=>
   bool(false)
 }
 
 
 Test getters:
 -------------
-V8\ScriptOriginOptions::IsSharedCrossOrigin() matches expected true
-V8\ScriptOriginOptions::IsOpaque() matches expected false
+V8\ScriptOriginOptions->IsSharedCrossOrigin(): bool(true)
+V8\ScriptOriginOptions->IsOpaque(): bool(false)
+V8\ScriptOriginOptions->IsWasm(): bool(false)
+V8\ScriptOriginOptions->IsModule(): bool(false)
 
 
 Object representation:
 ----------------------
-object(V8\ScriptOriginOptions)#2 (2) {
-  ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
-  bool(true)
-  ["is_opaque":"V8\ScriptOriginOptions":private]=>
-  bool(true)
-}
-
-
-Test getters:
--------------
-V8\ScriptOriginOptions::IsSharedCrossOrigin() matches expected true
-V8\ScriptOriginOptions::IsOpaque() matches expected true
-
-
-Object representation:
-----------------------
-object(V8\ScriptOriginOptions)#3 (2) {
+object(V8\ScriptOriginOptions)#4 (4) {
   ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
   bool(false)
   ["is_opaque":"V8\ScriptOriginOptions":private]=>
   bool(true)
-}
-
-
-Test getters:
--------------
-V8\ScriptOriginOptions::IsSharedCrossOrigin() matches expected false
-V8\ScriptOriginOptions::IsOpaque() matches expected true
-
-
-Object representation:
-----------------------
-object(V8\ScriptOriginOptions)#2 (2) {
-  ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
-  bool(true)
-  ["is_opaque":"V8\ScriptOriginOptions":private]=>
+  ["is_wasm":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_module":"V8\ScriptOriginOptions":private]=>
   bool(false)
 }
 
 
 Test getters:
 -------------
-V8\ScriptOriginOptions::IsSharedCrossOrigin() matches expected true
-V8\ScriptOriginOptions::IsOpaque() matches expected false
+V8\ScriptOriginOptions->IsSharedCrossOrigin(): bool(false)
+V8\ScriptOriginOptions->IsOpaque(): bool(true)
+V8\ScriptOriginOptions->IsWasm(): bool(false)
+V8\ScriptOriginOptions->IsModule(): bool(false)
+
+
+Object representation:
+----------------------
+object(V8\ScriptOriginOptions)#10 (4) {
+  ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_opaque":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_wasm":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_module":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+}
+
+
+Test getters:
+-------------
+V8\ScriptOriginOptions->IsSharedCrossOrigin(): bool(false)
+V8\ScriptOriginOptions->IsOpaque(): bool(false)
+V8\ScriptOriginOptions->IsWasm(): bool(false)
+V8\ScriptOriginOptions->IsModule(): bool(false)
+
+
+Object representation:
+----------------------
+object(V8\ScriptOriginOptions)#6 (4) {
+  ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_opaque":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_wasm":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+  ["is_module":"V8\ScriptOriginOptions":private]=>
+  bool(false)
+}
+
+
+Test getters:
+-------------
+V8\ScriptOriginOptions->IsSharedCrossOrigin(): bool(false)
+V8\ScriptOriginOptions->IsOpaque(): bool(false)
+V8\ScriptOriginOptions->IsWasm(): bool(false)
+V8\ScriptOriginOptions->IsModule(): bool(false)

--- a/tests/V8Script_Run.phpt
+++ b/tests/V8Script_Run.phpt
@@ -33,7 +33,7 @@ $helper->dump($res->Value());
 
 $helper->space();
 
-$scalar = new V8\NumberValue($isolate, 123);
+$scalar = new V8\Int32Value($isolate, 123);
 $obj    = new V8\ObjectValue($context);
 $context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'scalar'), $scalar);
 $context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'obj'), $obj);
@@ -114,7 +114,7 @@ string(25) "TEST VALUE 111, confirmed"
 
 Scalar:
 -------
-Expected 123.0 value is identical to actual value 123.0
+Expected 123 value is identical to actual value 123
 Expected value is not identical to actual value
 
 

--- a/tests/V8Script_Run.phpt
+++ b/tests/V8Script_Run.phpt
@@ -12,13 +12,12 @@ $v8_helper = new PhpV8Helpers($helper);
 
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
 $value = new V8\StringValue($isolate, 'TEST VALUE 111');
 
 $global_template->Set(new \V8\StringValue($isolate, 'test'), $value);
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 
 $source    = 'test; test = test + ", confirmed"';

--- a/tests/V8Script_Run_out_of_memory.phpt
+++ b/tests/V8Script_Run_out_of_memory.phpt
@@ -13,14 +13,13 @@ $v8_helper = new PhpV8Helpers($helper);
 
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
 $value = new V8\StringValue($isolate, 'TEST VALUE 111');
 
 $global_template->Set(new \V8\StringValue($isolate, 'test'), $value);
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 // This causes segfault
 $source = '

--- a/tests/V8Script_exit_during_script_execution.phpt
+++ b/tests/V8Script_exit_during_script_execution.phpt
@@ -14,7 +14,6 @@ $v8_helper = new PhpV8Helpers($helper);
 require '.tracking_dtors.php';
 
 $isolate1 = new v8Tests\TrackingDtors\Isolate();
-$extensions1 = [];
 
 register_shutdown_function(function () {
     echo 'Doing shutdown', PHP_EOL;
@@ -30,7 +29,7 @@ $exit = new v8Tests\TrackingDtors\FunctionTemplate($isolate1, function () {
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
 $global_template1->Set(new \V8\StringValue($isolate1, 'exit'), $exit, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new v8Tests\TrackingDtors\Context($isolate1, $extensions1, $global_template1);
+$context1 = new v8Tests\TrackingDtors\Context($isolate1, $global_template1);
 
 
 $source1 = '

--- a/tests/V8Script_terminate_script_execution.phpt
+++ b/tests/V8Script_terminate_script_execution.phpt
@@ -14,7 +14,6 @@ $v8_helper = new PhpV8Helpers($helper);
 require '.tracking_dtors.php';
 
 $isolate1 = new v8Tests\TrackingDtors\Isolate();
-$extensions1 = [];
 
 //$isolate1->SetCaptureStackTraceForUncaughtExceptions(true);
 
@@ -42,7 +41,7 @@ $terminate = new V8\FunctionTemplate($isolate1, function (\V8\FunctionCallbackIn
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
 $global_template1->Set(new \V8\StringValue($isolate1, 'terminate'), $terminate, \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 $global_template1 = null;
 
 $source1 = '

--- a/tests/V8SetObject.phpt
+++ b/tests/V8SetObject.phpt
@@ -12,10 +12,9 @@ require '.v8-helpers.php';
 $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new \V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 $value = new V8\SetObject($context);
 
@@ -123,7 +122,7 @@ object(V8\SetObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (4) {
+  object(V8\Context)#5 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -136,9 +135,6 @@ object(V8\SetObject)#6 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {
@@ -316,7 +312,7 @@ V8\SetObject(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (4) {
+      object(V8\Context)#5 (3) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -329,9 +325,6 @@ V8\SetObject(V8\Value)->ToObject():
           int(0)
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
-        }
-        ["extensions":"V8\Context":private]=>
-        array(0) {
         }
         ["global_template":"V8\Context":private]=>
         object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8SetObject.phpt
+++ b/tests/V8SetObject.phpt
@@ -354,7 +354,7 @@ V8\SetObject(V8\Value)->ToObject():
       }
     }
 V8\SetObject(V8\Value)->ToInteger():
-    object(V8\NumberValue)#120 (1) {
+    object(V8\Int32Value)#120 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -370,7 +370,7 @@ V8\SetObject(V8\Value)->ToInteger():
       }
     }
 V8\SetObject(V8\Value)->ToUint32():
-    object(V8\NumberValue)#120 (1) {
+    object(V8\Int32Value)#120 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -386,7 +386,7 @@ V8\SetObject(V8\Value)->ToUint32():
       }
     }
 V8\SetObject(V8\Value)->ToInt32():
-    object(V8\NumberValue)#120 (1) {
+    object(V8\Int32Value)#120 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8Source.phpt
+++ b/tests/V8Source.phpt
@@ -1,0 +1,250 @@
+--TEST--
+V8\ScriptCompiler\Source
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+// Tests:
+
+
+$isolate = new V8\Isolate();
+$source_string = new V8\StringValue($isolate, 'TEST VALUE 111');
+$origin = new \V8\ScriptOrigin('test.js');
+$cache_data = new \V8\ScriptCompiler\CachedData('some data');
+
+
+$value = new \V8\ScriptCompiler\Source($source_string);
+
+$helper->header('Object representation');
+$helper->dump($value);
+$helper->space();
+
+$helper->header('Accessors');
+$helper->method_matches($value, 'GetSourceString', $source_string);
+$helper->method_matches($value, 'GetCachedData', null);
+$helper->method_matches($value, 'GetScriptOrigin', null);
+$helper->space();
+
+
+$value = new \V8\ScriptCompiler\Source($source_string, $origin);
+
+$helper->header('Object representation');
+$helper->dump($value);
+$helper->space();
+
+$helper->header('Accessors');
+$helper->method_matches($value, 'GetSourceString', $source_string);
+$helper->method_matches($value, 'GetScriptOrigin', $origin);
+$helper->method_matches($value, 'GetCachedData', null);
+$helper->space();
+
+
+$value = new \V8\ScriptCompiler\Source($source_string, null, $cache_data);
+
+$helper->header('Object representation');
+$helper->dump($value);
+$helper->space();
+
+$helper->header('Accessors');
+$helper->method_matches($value, 'GetSourceString', $source_string);
+$helper->method_matches($value, 'GetScriptOrigin', null);
+$helper->method_matches($value, 'GetCachedData', $cache_data);
+$helper->space();
+
+$value = new \V8\ScriptCompiler\Source($source_string, $origin, $cache_data);
+
+$helper->header('Object representation');
+$helper->dump($value);
+$helper->space();
+
+$helper->header('Accessors');
+$helper->method_matches($value, 'GetSourceString', $source_string);
+$helper->method_matches($value, 'GetScriptOrigin', $origin);
+$helper->method_matches($value, 'GetCachedData', $cache_data);
+$helper->space();
+
+?>
+--EXPECT--
+Object representation:
+----------------------
+object(V8\ScriptCompiler\Source)#8 (3) {
+  ["source_string":"V8\ScriptCompiler\Source":private]=>
+  object(V8\StringValue)#4 (1) {
+    ["isolate":"V8\Value":private]=>
+    object(V8\Isolate)#3 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+  }
+  ["origin":"V8\ScriptCompiler\Source":private]=>
+  NULL
+  ["cached_data":"V8\ScriptCompiler\Source":private]=>
+  NULL
+}
+
+
+Accessors:
+----------
+V8\ScriptCompiler\Source::GetSourceString() matches expected value
+V8\ScriptCompiler\Source::GetCachedData() matches expected value
+V8\ScriptCompiler\Source::GetScriptOrigin() matches expected value
+
+
+Object representation:
+----------------------
+object(V8\ScriptCompiler\Source)#9 (3) {
+  ["source_string":"V8\ScriptCompiler\Source":private]=>
+  object(V8\StringValue)#4 (1) {
+    ["isolate":"V8\Value":private]=>
+    object(V8\Isolate)#3 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+  }
+  ["origin":"V8\ScriptCompiler\Source":private]=>
+  object(V8\ScriptOrigin)#5 (6) {
+    ["resource_name":"V8\ScriptOrigin":private]=>
+    string(7) "test.js"
+    ["resource_line_offset":"V8\ScriptOrigin":private]=>
+    int(0)
+    ["resource_column_offset":"V8\ScriptOrigin":private]=>
+    int(0)
+    ["options":"V8\ScriptOrigin":private]=>
+    object(V8\ScriptOriginOptions)#6 (4) {
+      ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_opaque":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_wasm":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_module":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+    }
+    ["script_id":"V8\ScriptOrigin":private]=>
+    int(0)
+    ["source_map_url":"V8\ScriptOrigin":private]=>
+    string(0) ""
+  }
+  ["cached_data":"V8\ScriptCompiler\Source":private]=>
+  NULL
+}
+
+
+Accessors:
+----------
+V8\ScriptCompiler\Source::GetSourceString() matches expected value
+V8\ScriptCompiler\Source::GetScriptOrigin() matches expected value
+V8\ScriptCompiler\Source::GetCachedData() matches expected value
+
+
+Object representation:
+----------------------
+object(V8\ScriptCompiler\Source)#8 (3) {
+  ["source_string":"V8\ScriptCompiler\Source":private]=>
+  object(V8\StringValue)#4 (1) {
+    ["isolate":"V8\Value":private]=>
+    object(V8\Isolate)#3 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+  }
+  ["origin":"V8\ScriptCompiler\Source":private]=>
+  NULL
+  ["cached_data":"V8\ScriptCompiler\Source":private]=>
+  object(V8\ScriptCompiler\CachedData)#7 (0) {
+  }
+}
+
+
+Accessors:
+----------
+V8\ScriptCompiler\Source::GetSourceString() matches expected value
+V8\ScriptCompiler\Source::GetScriptOrigin() matches expected value
+V8\ScriptCompiler\Source::GetCachedData() matches expected value
+
+
+Object representation:
+----------------------
+object(V8\ScriptCompiler\Source)#9 (3) {
+  ["source_string":"V8\ScriptCompiler\Source":private]=>
+  object(V8\StringValue)#4 (1) {
+    ["isolate":"V8\Value":private]=>
+    object(V8\Isolate)#3 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+  }
+  ["origin":"V8\ScriptCompiler\Source":private]=>
+  object(V8\ScriptOrigin)#5 (6) {
+    ["resource_name":"V8\ScriptOrigin":private]=>
+    string(7) "test.js"
+    ["resource_line_offset":"V8\ScriptOrigin":private]=>
+    int(0)
+    ["resource_column_offset":"V8\ScriptOrigin":private]=>
+    int(0)
+    ["options":"V8\ScriptOrigin":private]=>
+    object(V8\ScriptOriginOptions)#6 (4) {
+      ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_opaque":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_wasm":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+      ["is_module":"V8\ScriptOriginOptions":private]=>
+      bool(false)
+    }
+    ["script_id":"V8\ScriptOrigin":private]=>
+    int(0)
+    ["source_map_url":"V8\ScriptOrigin":private]=>
+    string(0) ""
+  }
+  ["cached_data":"V8\ScriptCompiler\Source":private]=>
+  object(V8\ScriptCompiler\CachedData)#7 (0) {
+  }
+}
+
+
+Accessors:
+----------
+V8\ScriptCompiler\Source::GetSourceString() matches expected value
+V8\ScriptCompiler\Source::GetScriptOrigin() matches expected value
+V8\ScriptCompiler\Source::GetCachedData() matches expected value

--- a/tests/V8StackTrace.phpt
+++ b/tests/V8StackTrace.phpt
@@ -109,7 +109,7 @@ object(V8\StackTrace)#8 (2) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(v8Tests\TrackingDtors\Context)#4 (4) {
+    object(v8Tests\TrackingDtors\Context)#4 (3) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -123,8 +123,6 @@ object(V8\StackTrace)#8 (2) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["extensions":"V8\Context":private]=>
-      NULL
       ["global_template":"V8\Context":private]=>
       NULL
       ["global_object":"V8\Context":private]=>

--- a/tests/V8StackTrace_CurrentStackTrace.phpt
+++ b/tests/V8StackTrace_CurrentStackTrace.phpt
@@ -14,7 +14,6 @@ $v8_helper = new PhpV8Helpers($helper);
 
 
 $isolate = new \v8Tests\TrackingDtors\Isolate();
-$extensions = [];
 $global_template = new v8Tests\TrackingDtors\ObjectTemplate($isolate);
 
 $stack_trace = null;
@@ -44,7 +43,7 @@ $current_stack_trace_func_tpl = new \v8Tests\TrackingDtors\FunctionTemplate($iso
 
 $global_template->Set(new \V8\StringValue($isolate, 'current_stack_trace'), $current_stack_trace_func_tpl);
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
-$context = new v8Tests\TrackingDtors\Context($isolate, $extensions, $global_template);
+$context = new v8Tests\TrackingDtors\Context($isolate, $global_template);
 
 $source    = /** @lang JavaScript */
 '

--- a/tests/V8StringObject.phpt
+++ b/tests/V8StringObject.phpt
@@ -15,12 +15,11 @@ $v8_helper = new PhpV8Helpers($helper);
 
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $value = new V8\StringObject($context1, new \V8\StringValue($isolate1, 'test string'));
 
@@ -83,7 +82,7 @@ object(V8\StringObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (4) {
+  object(V8\Context)#5 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -96,9 +95,6 @@ object(V8\StringObject)#6 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8StringValue.phpt
+++ b/tests/V8StringValue.phpt
@@ -46,9 +46,8 @@ $helper->method_export($value, 'IsOneByte');
 $helper->method_export($value, 'ContainsOnlyOneByte');
 $helper->space();
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $helper->header('Primitive converters');

--- a/tests/V8String_range_error_length.phpt
+++ b/tests/V8String_range_error_length.phpt
@@ -14,11 +14,10 @@ $v8_helper = new PhpV8Helpers($helper);
 // Tests:
 
 $isolate = new V8\Isolate();
-$extensions = [];
 $global_template = new V8\ObjectTemplate($isolate);
 $global_template->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate), \V8\PropertyAttribute::DontDelete);
 
-$context = new V8\Context($isolate, $extensions, $global_template);
+$context = new V8\Context($isolate, $global_template);
 
 
 $source    = '

--- a/tests/V8SymbolObject.phpt
+++ b/tests/V8SymbolObject.phpt
@@ -15,12 +15,11 @@ $v8_helper = new PhpV8Helpers($helper);
 
 
 $isolate1 = new \V8\Isolate();
-$extensions1 = [];
 $global_template1 = new V8\ObjectTemplate($isolate1);
 
 $global_template1->Set(new \V8\StringValue($isolate1, 'print'), $v8_helper->getPrintFunctionTemplate($isolate1), \V8\PropertyAttribute::DontDelete);
 
-$context1 = new V8\Context($isolate1, $extensions1, $global_template1);
+$context1 = new V8\Context($isolate1, $global_template1);
 
 $value = new V8\SymbolObject($context1, new \V8\SymbolValue($isolate1, new \V8\StringValue($isolate1, 'test')));
 
@@ -86,7 +85,7 @@ object(V8\SymbolObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (4) {
+  object(V8\Context)#5 (3) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -99,9 +98,6 @@ object(V8\SymbolObject)#6 (2) {
       int(0)
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
-    }
-    ["extensions":"V8\Context":private]=>
-    array(0) {
     }
     ["global_template":"V8\Context":private]=>
     object(V8\ObjectTemplate)#4 (1) {

--- a/tests/V8SymbolValue.phpt
+++ b/tests/V8SymbolValue.phpt
@@ -158,6 +158,12 @@ $helper->pretty_dump('Symbol GetUnscopables() name', $value->Name()->Value());
 $helper->line();
 
 $helper->assert('Isolate not in context', !$isolate->InContext());
+$value = V8\SymbolValue::GetToPrimitive($isolate);
+$helper->assert('Symbol GetToPrimitive() returned', $value instanceof \V8\SymbolValue);
+$helper->pretty_dump('Symbol GetToPrimitive() name', $value->Name()->Value());
+$helper->line();
+
+$helper->assert('Isolate not in context', !$isolate->InContext());
 $value = V8\SymbolValue::GetToStringTag($isolate);
 $helper->assert('Symbol GetToStringTag() returned', $value instanceof \V8\SymbolValue);
 $helper->pretty_dump('Symbol GetToStringTag() name', $value->Name()->Value());
@@ -199,7 +205,7 @@ Accessors:
 ----------
 V8\SymbolValue::GetIsolate() matches expected value
 V8\SymbolValue->Name():
-    object(V8\Value)#85 (1) {
+    object(V8\Value)#86 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -276,7 +282,7 @@ Null constructor:
 
 Object representation:
 ----------------------
-object(V8\SymbolValue)#85 (1) {
+object(V8\SymbolValue)#86 (1) {
   ["isolate":"V8\Value":private]=>
   object(V8\Isolate)#3 (5) {
     ["snapshot":"V8\Isolate":private]=>
@@ -503,7 +509,7 @@ Accessors:
 ----------
 V8\SymbolValue::GetIsolate() matches expected value
 V8\SymbolValue->Name():
-    object(V8\StringValue)#86 (1) {
+    object(V8\StringValue)#87 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -705,6 +711,10 @@ Symbol GetIterator() name: string(15) "Symbol.iterator"
 Isolate not in context: ok
 Symbol GetUnscopables() returned: ok
 Symbol GetUnscopables() name: string(18) "Symbol.unscopables"
+
+Isolate not in context: ok
+Symbol GetToPrimitive() returned: ok
+Symbol GetToPrimitive() name: string(18) "Symbol.toPrimitive"
 
 Isolate not in context: ok
 Symbol GetToStringTag() returned: ok

--- a/tests/V8TryCatch.phpt
+++ b/tests/V8TryCatch.phpt
@@ -234,10 +234,14 @@ object(V8\TryCatch)#12 (7) {
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#8 (2) {
+      object(V8\ScriptOriginOptions)#8 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_wasm":"V8\ScriptOriginOptions":private]=>
+        bool(false)
+        ["is_module":"V8\ScriptOriginOptions":private]=>
         bool(false)
       }
       ["script_id":"V8\ScriptOrigin":private]=>

--- a/tests/V8TryCatch.phpt
+++ b/tests/V8TryCatch.phpt
@@ -84,7 +84,7 @@ object(V8\TryCatch)#4 (7) {
     bool(false)
   }
   ["context":"V8\TryCatch":private]=>
-  object(v8Tests\TrackingDtors\Context)#3 (4) {
+  object(v8Tests\TrackingDtors\Context)#3 (3) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -98,8 +98,6 @@ object(V8\TryCatch)#4 (7) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["extensions":"V8\Context":private]=>
-    NULL
     ["global_template":"V8\Context":private]=>
     NULL
     ["global_object":"V8\Context":private]=>
@@ -146,7 +144,7 @@ object(V8\TryCatch)#12 (7) {
     bool(false)
   }
   ["context":"V8\TryCatch":private]=>
-  object(v8Tests\TrackingDtors\Context)#3 (4) {
+  object(v8Tests\TrackingDtors\Context)#3 (3) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -160,8 +158,6 @@ object(V8\TryCatch)#12 (7) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["extensions":"V8\Context":private]=>
-    NULL
     ["global_template":"V8\Context":private]=>
     NULL
     ["global_object":"V8\Context":private]=>
@@ -183,7 +179,7 @@ object(V8\TryCatch)#12 (7) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(v8Tests\TrackingDtors\Context)#3 (4) {
+    object(v8Tests\TrackingDtors\Context)#3 (3) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -197,8 +193,6 @@ object(V8\TryCatch)#12 (7) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["extensions":"V8\Context":private]=>
-      NULL
       ["global_template":"V8\Context":private]=>
       NULL
       ["global_object":"V8\Context":private]=>
@@ -274,7 +268,7 @@ object(V8\TryCatch)#12 (7) {
           bool(false)
         }
         ["context":"V8\ObjectValue":private]=>
-        object(v8Tests\TrackingDtors\Context)#3 (4) {
+        object(v8Tests\TrackingDtors\Context)#3 (3) {
           ["isolate":"V8\Context":private]=>
           object(v8Tests\TrackingDtors\Isolate)#2 (5) {
             ["snapshot":"V8\Isolate":private]=>
@@ -288,8 +282,6 @@ object(V8\TryCatch)#12 (7) {
             ["memory_limit_hit":"V8\Isolate":private]=>
             bool(false)
           }
-          ["extensions":"V8\Context":private]=>
-          NULL
           ["global_template":"V8\Context":private]=>
           NULL
           ["global_object":"V8\Context":private]=>

--- a/tests/V8TryCatch_from_script.phpt
+++ b/tests/V8TryCatch_from_script.phpt
@@ -49,7 +49,7 @@ $nested_try_catch_func_tpl = new \v8Tests\TrackingDtors\FunctionTemplate($isolat
 
 $global_object_tpl = new \v8Tests\TrackingDtors\ObjectTemplate($isolate);
 $global_object_tpl->Set(new \V8\StringValue($isolate, 'nested_throw'), $nested_try_catch_func_tpl);
-$context = new v8Tests\TrackingDtors\Context($isolate, [], $global_object_tpl);
+$context = new v8Tests\TrackingDtors\Context($isolate, $global_object_tpl);
 
 $source = /** @lang JavaScript */
     'throw new Error("Top-level error");';

--- a/tests/V8Uint32Value.phpt
+++ b/tests/V8Uint32Value.phpt
@@ -32,9 +32,8 @@ $helper->space();
 
 $v8_helper->run_checks($value, 'Checkers for negative');
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $string = $value->ToString($context);

--- a/tests/V8UnboundScript.phpt
+++ b/tests/V8UnboundScript.phpt
@@ -1,0 +1,114 @@
+--TEST--
+V8\UnboundScript
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new V8\Isolate();
+$context = new V8\Context($isolate);
+
+$source    = 'var test = "test";
+let status = "passed";
+test + " " + status
+';
+
+$file_name = 'test.js';
+
+$script = new V8\Script($context, new \V8\StringValue($isolate, $source), new \V8\ScriptOrigin($file_name));
+
+$unbound = $script->GetUnboundScript();
+
+$helper->header('UnboundScript representation');
+$helper->dump($unbound);
+$helper->space();
+
+$helper->header('Class constants');
+$helper->dump_object_constants($unbound);
+$helper->space();
+
+$helper->header('Accessors');
+$helper->method_matches($unbound, 'GetIsolate', $isolate);
+$helper->method_matches_instanceof($unbound, 'BindToContext', V8\Script::class, [$context]);
+
+$filter = new ArrayListFilter(['GetId', 'GetScriptName', 'GetSourceURL', 'GetSourceMappingURL'], false);
+$finalizer = new CallChainFinalizer([\V8\StringValue::class => 'Value', \V8\Value::class => 'IsUndefined'], [], false);
+$helper->dump_object_methods($unbound, [], $filter, $finalizer);
+
+$helper->space();
+
+$helper->header('Getting line number');
+$helper->method_dump($unbound, 'GetLineNumber', [-1]);
+$helper->method_dump($unbound, 'GetLineNumber', [0]);
+$helper->method_dump($unbound, 'GetLineNumber', [1]);
+$helper->method_dump($unbound, 'GetLineNumber', [18]);
+$helper->method_dump($unbound, 'GetLineNumber', [19]);
+$helper->method_dump($unbound, 'GetLineNumber', [9999]);
+
+$helper->space();
+
+
+$helper->header('Get script back');
+$helper->method_matches_instanceof($unbound, 'BindToContext', V8\Script::class, [$context]);
+
+$new_script = $unbound->BindToContext($context);
+$helper->dump($new_script->Run($context)->Value());
+$helper->space();
+
+?>
+--EXPECTF--
+UnboundScript representation:
+-----------------------------
+object(V8\UnboundScript)#6 (1) {
+  ["isolate":"V8\UnboundScript":private]=>
+  object(V8\Isolate)#3 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+}
+
+
+Class constants:
+----------------
+V8\UnboundScript::kNoScriptId = 0
+
+
+Accessors:
+----------
+V8\UnboundScript::GetIsolate() matches expected value
+V8\UnboundScript::BindToContext() result is instance of V8\Script
+V8\UnboundScript->GetId(): int(%d)
+V8\UnboundScript->GetScriptName(): V8\StringValue->Value(): string(7) "test.js"
+V8\UnboundScript->GetSourceURL(): V8\Value->IsUndefined(): bool(true)
+V8\UnboundScript->GetSourceMappingURL(): V8\StringValue->Value(): string(0) ""
+
+
+Getting line number:
+--------------------
+V8\UnboundScript::GetLineNumber() 0
+V8\UnboundScript::GetLineNumber() 0
+V8\UnboundScript::GetLineNumber() 0
+V8\UnboundScript::GetLineNumber() 0
+V8\UnboundScript::GetLineNumber() 1
+V8\UnboundScript::GetLineNumber() -1
+
+
+Get script back:
+----------------
+V8\UnboundScript::BindToContext() result is instance of V8\Script
+string(11) "test passed"

--- a/tests/V8Value.phpt
+++ b/tests/V8Value.phpt
@@ -32,9 +32,8 @@ $helper->space();
 
 $v8_helper->run_checks($value);
 
-$extensions = [];
 $global_template = new \V8\ObjectTemplate($isolate);
-$context = new \V8\Context($isolate, $extensions, $global_template);
+$context = new \V8\Context($isolate, $global_template);
 
 
 $helper->header('Primitive converters');

--- a/v8.cc
+++ b/v8.cc
@@ -32,6 +32,7 @@
 #include "php_v8_function_template.h"
 #include "php_v8_script.h"
 #include "php_v8_unbound_script.h"
+#include "php_v8_cached_data.h"
 #include "php_v8_null.h"
 #include "php_v8_boolean.h"
 #include "php_v8_symbol.h"
@@ -108,6 +109,7 @@ PHP_MINIT_FUNCTION(v8)
     PHP_MINIT(php_v8_context)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_script)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_unbound_script)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_cached_data)(INIT_FUNC_ARGS_PASSTHRU);
 
     PHP_MINIT(php_v8_exception)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_try_catch)(INIT_FUNC_ARGS_PASSTHRU);

--- a/v8.cc
+++ b/v8.cc
@@ -31,6 +31,7 @@
 #include "php_v8_object_template.h"
 #include "php_v8_function_template.h"
 #include "php_v8_script.h"
+#include "php_v8_unbound_script.h"
 #include "php_v8_null.h"
 #include "php_v8_boolean.h"
 #include "php_v8_symbol.h"
@@ -106,6 +107,7 @@ PHP_MINIT_FUNCTION(v8)
     PHP_MINIT(php_v8_isolate)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_context)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_script)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_unbound_script)(INIT_FUNC_ARGS_PASSTHRU);
 
     PHP_MINIT(php_v8_exception)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_try_catch)(INIT_FUNC_ARGS_PASSTHRU);

--- a/v8.cc
+++ b/v8.cc
@@ -35,6 +35,7 @@
 #include "php_v8_cached_data.h"
 #include "php_v8_compile_options.h"
 #include "php_v8_source.h"
+#include "php_v8_script_compiler.h"
 #include "php_v8_null.h"
 #include "php_v8_boolean.h"
 #include "php_v8_symbol.h"
@@ -109,11 +110,13 @@ PHP_MINIT_FUNCTION(v8)
     PHP_MINIT(php_v8_startup_data)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_isolate)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_context)(INIT_FUNC_ARGS_PASSTHRU);
+
     PHP_MINIT(php_v8_script)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_unbound_script)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_cached_data)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_compile_options)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_source)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_script_compiler)(INIT_FUNC_ARGS_PASSTHRU);
 
     PHP_MINIT(php_v8_exception)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_try_catch)(INIT_FUNC_ARGS_PASSTHRU);

--- a/v8.cc
+++ b/v8.cc
@@ -34,6 +34,7 @@
 #include "php_v8_unbound_script.h"
 #include "php_v8_cached_data.h"
 #include "php_v8_compile_options.h"
+#include "php_v8_source.h"
 #include "php_v8_null.h"
 #include "php_v8_boolean.h"
 #include "php_v8_symbol.h"
@@ -112,6 +113,7 @@ PHP_MINIT_FUNCTION(v8)
     PHP_MINIT(php_v8_unbound_script)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_cached_data)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_compile_options)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_source)(INIT_FUNC_ARGS_PASSTHRU);
 
     PHP_MINIT(php_v8_exception)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_try_catch)(INIT_FUNC_ARGS_PASSTHRU);

--- a/v8.cc
+++ b/v8.cc
@@ -33,6 +33,7 @@
 #include "php_v8_script.h"
 #include "php_v8_unbound_script.h"
 #include "php_v8_cached_data.h"
+#include "php_v8_compile_options.h"
 #include "php_v8_null.h"
 #include "php_v8_boolean.h"
 #include "php_v8_symbol.h"
@@ -110,6 +111,7 @@ PHP_MINIT_FUNCTION(v8)
     PHP_MINIT(php_v8_script)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_unbound_script)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_cached_data)(INIT_FUNC_ARGS_PASSTHRU);
+    PHP_MINIT(php_v8_compile_options)(INIT_FUNC_ARGS_PASSTHRU);
 
     PHP_MINIT(php_v8_exception)(INIT_FUNC_ARGS_PASSTHRU);
     PHP_MINIT(php_v8_try_catch)(INIT_FUNC_ARGS_PASSTHRU);


### PR DESCRIPTION
This PR adds more missed API to bring ES Modules closer. At this time their API is highly experimental, so it doesn't make much sense to add support for them at this time (unless you want to practice in gdb and catching segfaults), let's wait before getting more stable.

Public API changes In this PR and changes that may affect BC:
 - Raise required V8 version to 5.8.168;
 - Add `$is_wasm` and `$is_module` options to `V8\ScriptOriginOptions` and `V8\ScriptOrigin`;
 - Handle `V8\IntegerValue` sub-types when returning values from V8, fixes #19;
 - Remove non-standard `V8\Scrip::{getSource,getOrigin}`;
 - Add `V8\UnboundScript` class;
 - Simplify build system;
 - Drop non-working `V8\Context` extensions support;
 - Add `V8\ScriptCompiler\CachedData` class;
 - Add test for `V8\AccessControl` class;
 - Add `V8\ScriptCompiler\CompileOptions` class;
 - Add `V8\ScriptCompiler\Source` class;
 - Add typed array args unpacking for `V8\StringValue` and `V8\ObjectValue`;
 - Add `V8\ScriptCompiler`;
 - Add `V8\SymbolValue::GetToPrimitive()` method;
