### PR TITLE
Cleanups and optimizations

### DIFF
--- a/php_v8.h
+++ b/php_v8.h
@@ -17,9 +17,11 @@
 #include "config.h"
 #endif
 
+#include <v8-version.h>
+#include <v8.h>
+
 extern "C" {
 #include "php.h"
-#include <v8-version.h>
 
 #ifdef ZTS
 #include "TSRM.h"
@@ -51,6 +53,7 @@ extern zend_module_entry php_v8_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(v8)
     bool v8_initialized;
+    v8::Platform *platform;
 ZEND_END_MODULE_GLOBALS(v8)
 
 // Add zend_type support (new since PHP 7.2)

--- a/src/php_v8_a.cc
+++ b/src/php_v8_a.cc
@@ -29,7 +29,7 @@ void php_v8_init()
 
     v8::V8::InitializeICUDefaultLocation(PHP_V8_ICU_DATA_DIR);
 
-    // NOTE: if we use snapshot and extenal startup data then we have to initialize it (see https://codereview.chromium.org/315033002/)
+    // If we use snapshot and extenal startup data then we have to initialize it (see https://codereview.chromium.org/315033002/)
     // v8::V8::InitializeExternalStartupData(NULL);
     v8::Platform *platform = v8::platform::CreateDefaultPlatform();
     v8::V8::InitializePlatform(platform);
@@ -37,20 +37,21 @@ void php_v8_init()
 //    const char *flags = "--no-hard_abort";
 //    v8::V8::SetFlagsFromString(flags, strlen(flags));
 
-
-    // TODO: remove flags?
-    /* Set V8 command line flags (must be done before V8::Initialize()!) */
-//    if (PHP_V8_G(v8_flags)) {
-//        v8::V8::SetFlagsFromString(PHP_V8_G(v8_flags), strlen(PHP_V8_G(v8_flags)));
-//    }
-
     /* Initialize V8 */
     v8::V8::Initialize();
 
     /* Run only once */
     PHP_V8_G(v8_initialized) = true;
+    PHP_V8_G(platform) = platform;
+}
 
-//    TODO: probably, not necessary to call it on shutdown
-//    v8::V8::Dispose();
-//    v8::V8::ShutdownPlatform();
+void php_v8_shutdown() {
+    if (!PHP_V8_G(v8_initialized)) {
+        return;
+    }
+
+    v8::V8::Dispose();
+    v8::V8::ShutdownPlatform();
+
+    delete PHP_V8_G(platform);
 }

--- a/src/php_v8_a.h
+++ b/src/php_v8_a.h
@@ -13,6 +13,15 @@
 #ifndef PHP_V8_A_H
 #define PHP_V8_A_H
 
+extern "C" {
+#include "php.h"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+};
+
 void php_v8_init();
+void php_v8_shutdown();
 
 #endif //PHP_V8_A_H

--- a/src/php_v8_array.cc
+++ b/src/php_v8_array.cc
@@ -24,9 +24,6 @@
 zend_class_entry *php_v8_array_class_entry;
 #define this_ce php_v8_array_class_entry
 
-v8::Local<v8::Array> php_v8_value_get_array_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Array>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8Array, __construct) {
     zval rv;
@@ -60,7 +57,7 @@ static PHP_METHOD(V8Array, Length) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
 
-    RETURN_LONG((zend_long) php_v8_value_get_array_local(isolate, php_v8_value)->Length());
+    RETURN_LONG(static_cast<zend_long >(php_v8_value_get_local_as<v8::Array>(php_v8_value)->Length()));
 }
 
 

--- a/src/php_v8_array.cc
+++ b/src/php_v8_array.cc
@@ -43,7 +43,6 @@ static PHP_METHOD(V8Array, __construct) {
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_array, "Failed to create Array value");
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_array);
 
     php_v8_value->persistent->Reset(isolate, local_array);

--- a/src/php_v8_array.cc
+++ b/src/php_v8_array.cc
@@ -47,7 +47,7 @@ static PHP_METHOD(V8Array, __construct) {
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_array, "Failed to create Array value");
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_array, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_array);
 
     php_v8_value->persistent->Reset(isolate, local_array);
 }

--- a/src/php_v8_array.h
+++ b/src/php_v8_array.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_array_class_entry;
 
-extern v8::Local<v8::Array> php_v8_value_get_array_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_array);
 

--- a/src/php_v8_boolean.cc
+++ b/src/php_v8_boolean.cc
@@ -23,10 +23,6 @@ zend_class_entry *php_v8_boolean_class_entry;
 #define this_ce php_v8_boolean_class_entry
 
 
-v8::Local<v8::Boolean> php_v8_value_get_boolean_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Boolean>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
-
 static PHP_METHOD(V8BooleanValue, __construct) {
     zval *php_v8_isolate_zv;
 
@@ -53,8 +49,7 @@ static PHP_METHOD(V8BooleanValue, Value) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
-    v8::Local<v8::Boolean> local_boolean = v8::Local<v8::Boolean>::Cast(local_value);
+    v8::Local<v8::Boolean> local_boolean = php_v8_value_get_local_as<v8::Boolean>(php_v8_value);
 
     RETVAL_BOOL(static_cast<zend_bool>(local_boolean->Value()));
 }

--- a/src/php_v8_boolean.h
+++ b/src/php_v8_boolean.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_boolean_class_entry;
 
-extern v8::Local<v8::Boolean> php_v8_value_get_boolean_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_boolean);
 

--- a/src/php_v8_boolean_object.cc
+++ b/src/php_v8_boolean_object.cc
@@ -42,7 +42,7 @@ static PHP_METHOD(V8BooleanObject, __construct) {
     v8::Local<v8::BooleanObject> local_bool_obj = v8::BooleanObject::New(isolate, value).As<v8::BooleanObject>();
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_bool_obj, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_bool_obj);
 
     php_v8_value->persistent->Reset(isolate, local_bool_obj);
 }

--- a/src/php_v8_boolean_object.cc
+++ b/src/php_v8_boolean_object.cc
@@ -38,7 +38,6 @@ static PHP_METHOD(V8BooleanObject, __construct) {
 
     v8::Local<v8::BooleanObject> local_bool_obj = v8::BooleanObject::New(isolate, value).As<v8::BooleanObject>();
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_bool_obj);
 
     php_v8_value->persistent->Reset(isolate, local_bool_obj);

--- a/src/php_v8_boolean_object.cc
+++ b/src/php_v8_boolean_object.cc
@@ -23,9 +23,6 @@
 zend_class_entry *php_v8_boolean_object_class_entry;
 #define this_ce php_v8_boolean_object_class_entry
 
-v8::Local<v8::BooleanObject> php_v8_value_get_boolean_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::BooleanObject>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8BooleanObject, __construct) {
     zval rv;
@@ -56,7 +53,7 @@ static PHP_METHOD(V8BooleanObject, ValueOf) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
 
-    v8::Local<v8::BooleanObject> local_boolean = php_v8_value_get_boolean_object_local(isolate, php_v8_value);
+    v8::Local<v8::BooleanObject> local_boolean = php_v8_value_get_local_as<v8::BooleanObject>(php_v8_value);
 
     RETURN_BOOL(static_cast<zend_bool>(local_boolean->ValueOf()));
 }

--- a/src/php_v8_boolean_object.h
+++ b/src/php_v8_boolean_object.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_boolean_object_class_entry;
 
-extern v8::Local<v8::BooleanObject> php_v8_value_get_boolean_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_boolean_object);
 

--- a/src/php_v8_cached_data.cc
+++ b/src/php_v8_cached_data.cc
@@ -136,8 +136,9 @@ PHP_MINIT_FUNCTION(php_v8_cached_data)
 
     memcpy(&php_v8_cached_data_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_cached_data_object_handlers.offset = XtOffsetOf(php_v8_cached_data_t, std);
-    php_v8_cached_data_object_handlers.free_obj = php_v8_cached_data_free;
+    php_v8_cached_data_object_handlers.offset    = XtOffsetOf(php_v8_cached_data_t, std);
+    php_v8_cached_data_object_handlers.free_obj  = php_v8_cached_data_free;
+    php_v8_cached_data_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_cached_data.cc
+++ b/src/php_v8_cached_data.cc
@@ -24,9 +24,6 @@ zend_class_entry * php_v8_cached_data_class_entry;
 
 static zend_object_handlers php_v8_cached_data_object_handlers;
 
-php_v8_cached_data_t * php_v8_cached_data_fetch_object(zend_object *obj) {
-    return (php_v8_cached_data_t *)((char *)obj - XtOffsetOf(php_v8_cached_data_t, std));
-}
 
 php_v8_cached_data_t * php_v8_create_cached_data(zval *return_value, const v8::ScriptCompiler::CachedData *cached_data) {
 

--- a/src/php_v8_cached_data.h
+++ b/src/php_v8_cached_data.h
@@ -28,7 +28,7 @@ extern "C" {
 
 extern zend_class_entry *php_v8_cached_data_class_entry;
 
-extern php_v8_cached_data_t * php_v8_cached_data_fetch_object(zend_object *obj);
+inline php_v8_cached_data_t * php_v8_cached_data_fetch_object(zend_object *obj);
 extern php_v8_cached_data_t * php_v8_create_cached_data(zval *return_value, const v8::ScriptCompiler::CachedData *cached_data);
 
 
@@ -56,6 +56,10 @@ struct _php_v8_cached_data_t {
 
   zend_object std;
 };
+
+inline php_v8_cached_data_t * php_v8_cached_data_fetch_object(zend_object *obj) {
+    return (php_v8_cached_data_t *)((char *)obj - XtOffsetOf(php_v8_cached_data_t, std));
+}
 
 PHP_MINIT_FUNCTION(php_v8_cached_data);
 

--- a/src/php_v8_callback_info.cc
+++ b/src/php_v8_callback_info.cc
@@ -25,9 +25,6 @@ zend_class_entry *php_v8_callback_info_class_entry;
 
 static zend_object_handlers php_v8_callback_info_object_handlers;
 
-php_v8_callback_info_t * php_v8_callback_info_fetch_object(zend_object *obj) {
-    return (php_v8_callback_info_t *)((char *)obj - XtOffsetOf(php_v8_callback_info_t, std));
-}
 
 void php_v8_callback_info_invalidate(php_v8_callback_info_t *php_v8_callback_info) {
     if (php_v8_callback_info->php_v8_return_value) {

--- a/src/php_v8_callback_info.cc
+++ b/src/php_v8_callback_info.cc
@@ -26,177 +26,65 @@ zend_class_entry *php_v8_callback_info_class_entry;
 static zend_object_handlers php_v8_callback_info_object_handlers;
 
 
-void php_v8_callback_info_invalidate(php_v8_callback_info_t *php_v8_callback_info) {
-    if (php_v8_callback_info->php_v8_return_value) {
-        php_v8_return_value_mark_expired(php_v8_callback_info->php_v8_return_value);
-    }
-}
-
-
-static HashTable * php_v8_callback_info_gc(zval *object, zval **table, int *n) {
-    PHP_V8_CALLBACK_INFO_FETCH_INTO(object, php_v8_callback_info);
-
-    int size = 2; // args + php_v8_return_value->this_ptr
-
-    if (php_v8_callback_info->gc_data_count < size) {
-        php_v8_callback_info->gc_data = (zval *)safe_erealloc(php_v8_callback_info->gc_data, size, sizeof(zval), 0);
-    }
-
-    php_v8_callback_info->gc_data_count = size;
-
-    ZVAL_COPY_VALUE(&php_v8_callback_info->gc_data[0], &php_v8_callback_info->args);
-    ZVAL_COPY_VALUE(&php_v8_callback_info->gc_data[1], &php_v8_callback_info->php_v8_return_value->this_ptr);
-
-    *table = php_v8_callback_info->gc_data;
-    *n     = php_v8_callback_info->gc_data_count;
-
-    return zend_std_get_properties(object);
-}
-
-void php_v8_callback_info_free(zend_object *object) {
-    php_v8_callback_info_t *php_v8_callback_info = php_v8_callback_info_fetch_object(object);
-
-    if (php_v8_callback_info->length) {
-
-        for (int i=0; i< php_v8_callback_info->length; i++) {
-            if (PHP_V8_ISOLATE_HAS_VALID_HANDLE(php_v8_callback_info)) {
-                php_v8_callback_info->arguments[i]->Reset();
-            }
-
-            delete php_v8_callback_info->arguments[i];
-        }
-
-        efree(php_v8_callback_info->arguments);
-    }
-
-    if (php_v8_callback_info->this_obj) {
-        if (PHP_V8_ISOLATE_HAS_VALID_HANDLE(php_v8_callback_info)) {
-            php_v8_callback_info->this_obj->Reset();
-        }
-
-        delete php_v8_callback_info->this_obj;
-    }
-
-    if (php_v8_callback_info->holder_obj) {
-        if (PHP_V8_ISOLATE_HAS_VALID_HANDLE(php_v8_callback_info)) {
-            php_v8_callback_info->holder_obj->Reset();
-        }
-
-        delete php_v8_callback_info->holder_obj;
-    }
-
-    if (php_v8_callback_info->php_v8_return_value) {
-        if (!Z_ISUNDEF(php_v8_callback_info->php_v8_return_value->this_ptr)) {
-            zval_ptr_dtor(&php_v8_callback_info->php_v8_return_value->this_ptr);
-        }
-
-        php_v8_callback_info->php_v8_return_value = NULL;
-    }
-
-    if (!Z_ISUNDEF(php_v8_callback_info->args)) {
-        zval_ptr_dtor(&php_v8_callback_info->args);
-    }
-
-    if (php_v8_callback_info->gc_data) {
-        efree(php_v8_callback_info->gc_data);
-    }
-
-    zend_object_std_dtor(&php_v8_callback_info->std);
-}
-
-static zend_object * php_v8_callback_info_ctor(zend_class_entry *ce) {
-
-    php_v8_callback_info_t *php_v8_callback_info;
-
-    php_v8_callback_info = (php_v8_callback_info_t *) ecalloc(1, sizeof(php_v8_callback_info_t) + zend_object_properties_size(ce));
-
-    zend_object_std_init(&php_v8_callback_info->std, ce);
-    object_properties_init(&php_v8_callback_info->std, ce);
-
-    php_v8_callback_info->this_obj = new v8::Persistent<v8::Object>();
-    php_v8_callback_info->holder_obj = new v8::Persistent<v8::Object>();
-
-    php_v8_callback_info->std.handlers = &php_v8_callback_info_object_handlers;
-
-    return &php_v8_callback_info->std;
-}
-
-
 static PHP_METHOD(V8CallbackInfo, GetIsolate) {
+    zval rv;
+    zval *tmp;
+
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
-
-    ZVAL_OBJ(return_value, &php_v8_callback_info->php_v8_isolate->std);
-    Z_ADDREF_P(return_value);
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("isolate"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
 }
 
 static PHP_METHOD(V8CallbackInfo, GetContext) {
+    zval rv;
+    zval *tmp;
+
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
-
-    ZVAL_OBJ(return_value, &php_v8_callback_info->php_v8_context->std);
-    Z_ADDREF_P(return_value);
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("context"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
 }
 
 static PHP_METHOD(V8CallbackInfo, This) {
+    zval rv;
+    zval *tmp;
+
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
-
-    v8::Isolate *isolate = php_v8_callback_info->php_v8_isolate->isolate;
-
-    v8::Local<v8::Object> local_object = v8::Local<v8::Object>::New(isolate, *php_v8_callback_info->this_obj);
-
-    php_v8_get_or_create_value(return_value, local_object, php_v8_callback_info->php_v8_isolate);
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("this"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
 }
 
 static PHP_METHOD(V8CallbackInfo, Holder) {
+    zval rv;
+    zval *tmp;
+
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
-
-    v8::Isolate *isolate = php_v8_callback_info->php_v8_isolate->isolate;
-
-    v8::Local<v8::Object> local_object = v8::Local<v8::Object>::New(isolate, *php_v8_callback_info->holder_obj);
-
-    php_v8_get_or_create_value(return_value, local_object, php_v8_callback_info->php_v8_isolate);
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("holder"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
 }
 
 static PHP_METHOD(V8CallbackInfo, GetReturnValue) {
+    zval rv;
+    zval *tmp;
+
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
-
-    RETVAL_ZVAL(&php_v8_callback_info->php_v8_return_value->this_ptr, 1, 0);
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("return_value"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
 }
-
-static PHP_METHOD(V8CallbackInfo, InContext) {
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
-
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-
-    RETURN_BOOL(PHP_V8_V8_CALLBACK_INFO_IN_CONTEXT(php_v8_callback_info));
-}
-
 
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_callback_info_GetIsolate, ZEND_RETURN_VALUE, 0, V8\\Isolate, 0)
 ZEND_END_ARG_INFO()
@@ -213,17 +101,12 @@ ZEND_END_ARG_INFO()
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_callback_info_GetReturnValue, ZEND_RETURN_VALUE, 0, V8\\ReturnValue, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_callback_info_InContext, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
-ZEND_END_ARG_INFO()
-
-
 static const zend_function_entry php_v8_callback_info_methods[] = {
         PHP_ME(V8CallbackInfo, This, arginfo_v8_callback_info_This, ZEND_ACC_PUBLIC)
         PHP_ME(V8CallbackInfo, Holder, arginfo_v8_callback_info_Holder, ZEND_ACC_PUBLIC)
         PHP_ME(V8CallbackInfo, GetIsolate, arginfo_v8_callback_info_GetIsolate, ZEND_ACC_PUBLIC)
         PHP_ME(V8CallbackInfo, GetContext, arginfo_v8_callback_info_GetContext, ZEND_ACC_PUBLIC)
         PHP_ME(V8CallbackInfo, GetReturnValue, arginfo_v8_callback_info_GetReturnValue, ZEND_ACC_PUBLIC)
-        PHP_ME(V8CallbackInfo, InContext, arginfo_v8_callback_info_InContext, ZEND_ACC_PUBLIC)
         PHP_FE_END
 };
 
@@ -232,13 +115,14 @@ PHP_MINIT_FUNCTION (php_v8_callback_info) {
 
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "CallbackInfo", php_v8_callback_info_methods);
     this_ce = zend_register_internal_class(&ce);
-    this_ce->create_object = php_v8_callback_info_ctor;
 
     memcpy(&php_v8_callback_info_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_callback_info_object_handlers.offset   = XtOffsetOf(php_v8_callback_info_t, std);
-    php_v8_callback_info_object_handlers.free_obj = php_v8_callback_info_free;
-    php_v8_callback_info_object_handlers.get_gc   = php_v8_callback_info_gc;
+    zend_declare_property_null(this_ce, ZEND_STRL("isolate"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("context"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("this"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("holder"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("return_value"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/php_v8_callback_info.cc
+++ b/src/php_v8_callback_info.cc
@@ -159,7 +159,7 @@ static PHP_METHOD(V8CallbackInfo, This) {
 
     v8::Local<v8::Object> local_object = v8::Local<v8::Object>::New(isolate, *php_v8_callback_info->this_obj);
 
-    php_v8_get_or_create_value(return_value, local_object, isolate);
+    php_v8_get_or_create_value(return_value, local_object, php_v8_callback_info->php_v8_isolate);
 }
 
 static PHP_METHOD(V8CallbackInfo, Holder) {
@@ -174,7 +174,7 @@ static PHP_METHOD(V8CallbackInfo, Holder) {
 
     v8::Local<v8::Object> local_object = v8::Local<v8::Object>::New(isolate, *php_v8_callback_info->holder_obj);
 
-    php_v8_get_or_create_value(return_value, local_object, isolate);
+    php_v8_get_or_create_value(return_value, local_object, php_v8_callback_info->php_v8_isolate);
 }
 
 static PHP_METHOD(V8CallbackInfo, GetReturnValue) {

--- a/src/php_v8_callback_info.cc
+++ b/src/php_v8_callback_info.cc
@@ -130,7 +130,8 @@ static PHP_METHOD(V8CallbackInfo, GetIsolate) {
     PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
     PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
 
-    RETVAL_ZVAL(&php_v8_callback_info->php_v8_isolate->this_ptr, 1, 0);
+    ZVAL_OBJ(return_value, &php_v8_callback_info->php_v8_isolate->std);
+    Z_ADDREF_P(return_value);
 }
 
 static PHP_METHOD(V8CallbackInfo, GetContext) {
@@ -141,7 +142,8 @@ static PHP_METHOD(V8CallbackInfo, GetContext) {
     PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
     PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
 
-    RETVAL_ZVAL(&php_v8_callback_info->php_v8_context->this_ptr, 1, 0);
+    ZVAL_OBJ(return_value, &php_v8_callback_info->php_v8_context->std);
+    Z_ADDREF_P(return_value);
 }
 
 static PHP_METHOD(V8CallbackInfo, This) {

--- a/src/php_v8_callback_info.h
+++ b/src/php_v8_callback_info.h
@@ -32,7 +32,7 @@ extern "C" {
 extern zend_class_entry* php_v8_callback_info_class_entry;
 
 
-extern php_v8_callback_info_t * php_v8_callback_info_fetch_object(zend_object *obj);
+inline php_v8_callback_info_t * php_v8_callback_info_fetch_object(zend_object *obj);
 extern void php_v8_callback_info_invalidate(php_v8_callback_info_t *php_v8_callback_info);
 
 #define PHP_V8_CALLBACK_INFO_FETCH(zv) php_v8_callback_info_fetch_object(Z_OBJ_P(zv))
@@ -76,6 +76,10 @@ struct _php_v8_callback_info_t {
 
     zend_object std;
 };
+
+inline php_v8_callback_info_t * php_v8_callback_info_fetch_object(zend_object *obj) {
+    return (php_v8_callback_info_t *)((char *)obj - XtOffsetOf(php_v8_callback_info_t, std));
+}
 
 PHP_MINIT_FUNCTION(php_v8_callback_info);
 

--- a/src/php_v8_callback_info.h
+++ b/src/php_v8_callback_info.h
@@ -13,14 +13,6 @@
 #ifndef PHP_V8_CALLBACK_INFO_H
 #define PHP_V8_CALLBACK_INFO_H
 
-typedef struct _php_v8_callback_info_t php_v8_callback_info_t;
-
-#include "php_v8_return_value.h"
-#include "php_v8_exceptions.h"
-#include "php_v8_context.h"
-#include "php_v8_isolate.h"
-#include <v8.h>
-
 extern "C" {
 #include "php.h"
 
@@ -31,55 +23,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_callback_info_class_entry;
 
-
-inline php_v8_callback_info_t * php_v8_callback_info_fetch_object(zend_object *obj);
-extern void php_v8_callback_info_invalidate(php_v8_callback_info_t *php_v8_callback_info);
-
-#define PHP_V8_CALLBACK_INFO_FETCH(zv) php_v8_callback_info_fetch_object(Z_OBJ_P(zv))
-#define PHP_V8_CALLBACK_INFO_FETCH_INTO(pzval, into) php_v8_callback_info_t *(into) = PHP_V8_CALLBACK_INFO_FETCH((pzval));
-
-
-#define PHP_V8_EMPTY_CALLBACK_INFO_MSG "CallbackInfo" PHP_V8_EMPTY_HANDLER_MSG_PART
-#define PHP_V8_CHECK_EMPTY_CALLBACK_INFO_HANDLER_MSG(val, message) if (NULL == (val)->php_v8_isolate) { PHP_V8_THROW_EXCEPTION(message); return; }
-#define PHP_V8_CHECK_EMPTY_CALLBACK_INFO_HANDLER(val) PHP_V8_CHECK_EMPTY_CALLBACK_INFO_HANDLER_MSG((val), PHP_V8_EMPTY_CALLBACK_INFO_MSG)
-
-#define PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(pzval, into) \
-    PHP_V8_CALLBACK_INFO_FETCH_INTO(pzval, into); \
-    PHP_V8_CHECK_EMPTY_CALLBACK_INFO_HANDLER(into);
-
-#define PHP_V8_V8_CALLBACK_INFO_IN_CONTEXT(value) ((value)->php_v8_return_value != NULL && PHP_V8_RETURN_VALUE_IN_CONTEXT((value)->php_v8_return_value))
-
-#define PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(value) \
-    if (!PHP_V8_V8_CALLBACK_INFO_IN_CONTEXT(value)) { \
-        PHP_V8_THROW_EXCEPTION("Attempt to use callback info object out of callback context"); \
-        return; \
-    }
-
-
-struct _php_v8_callback_info_t {
-    php_v8_isolate_t *php_v8_isolate;
-    php_v8_context_t *php_v8_context;
-    uint32_t isolate_handle;
-
-    int length;
-    // TODO: find something for V8_INLINE Local<Value> operator[](int i) const;
-    v8::Persistent<v8::Value> **arguments;
-    v8::Persistent<v8::Object> *this_obj;
-    v8::Persistent<v8::Object> *holder_obj;
-    bool is_construct_call;
-
-    php_v8_return_value_t *php_v8_return_value;
-    zval args;
-
-    zval *gc_data;
-    int gc_data_count;
-
-    zend_object std;
-};
-
-inline php_v8_callback_info_t * php_v8_callback_info_fetch_object(zend_object *obj) {
-    return (php_v8_callback_info_t *)((char *)obj - XtOffsetOf(php_v8_callback_info_t, std));
-}
 
 PHP_MINIT_FUNCTION(php_v8_callback_info);
 

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -310,6 +310,7 @@ void php_v8_callback_function(const v8::FunctionCallbackInfo<v8::Value> &info) {
 
 void php_v8_callback_accessor_name_getter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value> &info) {
     PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(info.GetIsolate());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     zval args;
     zval property_name;
@@ -317,7 +318,7 @@ void php_v8_callback_accessor_name_getter(v8::Local<v8::Name> property, const v8
     /* Build the parameter array */
     array_init_size(&args, 2);
 
-    php_v8_get_or_create_value(&property_name, property, isolate);
+    php_v8_get_or_create_value(&property_name, property, php_v8_isolate);
     add_index_zval(&args, 0, &property_name);
 
     php_v8_callback_call_from_bucket_with_zargs(0, info, info.GetReturnValue(), &args);
@@ -327,6 +328,7 @@ void php_v8_callback_accessor_name_getter(v8::Local<v8::Name> property, const v8
 
 void php_v8_callback_accessor_name_setter(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void> &info) {
     PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(info.GetIsolate());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     zval args;
     zval property_name;
@@ -335,8 +337,8 @@ void php_v8_callback_accessor_name_setter(v8::Local<v8::Name> property, v8::Loca
     /* Build the parameter array */
     array_init_size(&args, 3);
 
-    php_v8_get_or_create_value(&property_name, property, isolate);
-    php_v8_get_or_create_value(&property_value, value, isolate);
+    php_v8_get_or_create_value(&property_name, property, php_v8_isolate);
+    php_v8_get_or_create_value(&property_value, value, php_v8_isolate);
 
     add_index_zval(&args, 0, &property_name);
     add_index_zval(&args, 1, &property_value);
@@ -349,6 +351,7 @@ void php_v8_callback_accessor_name_setter(v8::Local<v8::Name> property, v8::Loca
 
 void php_v8_callback_generic_named_property_getter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value> &info) {
     PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(info.GetIsolate());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     zval args;
     zval property_name;
@@ -356,7 +359,7 @@ void php_v8_callback_generic_named_property_getter(v8::Local<v8::Name> property,
     /* Build the parameter array */
     array_init_size(&args, 2);
 
-    php_v8_get_or_create_value(&property_name, property, isolate);
+    php_v8_get_or_create_value(&property_name, property, php_v8_isolate);
     add_index_zval(&args, 0, &property_name);
 
     php_v8_callback_call_from_bucket_with_zargs(0, info, info.GetReturnValue(), &args);
@@ -366,6 +369,7 @@ void php_v8_callback_generic_named_property_getter(v8::Local<v8::Name> property,
 
 void php_v8_callback_generic_named_property_setter(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value> &info) {
     PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(info.GetIsolate());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     zval args;
     zval property_name;
@@ -374,8 +378,8 @@ void php_v8_callback_generic_named_property_setter(v8::Local<v8::Name> property,
     /* Build the parameter array */
     array_init_size(&args, 3);
 
-    php_v8_get_or_create_value(&property_name, property, isolate);
-    php_v8_get_or_create_value(&property_value, value, isolate);
+    php_v8_get_or_create_value(&property_name, property, php_v8_isolate);
+    php_v8_get_or_create_value(&property_value, value, php_v8_isolate);
 
     add_index_zval(&args, 0, &property_name);
     add_index_zval(&args, 1, &property_value);
@@ -387,6 +391,7 @@ void php_v8_callback_generic_named_property_setter(v8::Local<v8::Name> property,
 
 void php_v8_callback_generic_named_property_query(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Integer> &info) {
     PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(info.GetIsolate());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     zval args;
     zval property_name;
@@ -394,7 +399,7 @@ void php_v8_callback_generic_named_property_query(v8::Local<v8::Name> property, 
     /* Build the parameter array */
     array_init_size(&args, 2);
 
-    php_v8_get_or_create_value(&property_name, property, isolate);
+    php_v8_get_or_create_value(&property_name, property, php_v8_isolate);
     add_index_zval(&args, 0, &property_name);
 
     php_v8_callback_call_from_bucket_with_zargs(2, info, info.GetReturnValue(), &args);
@@ -404,6 +409,7 @@ void php_v8_callback_generic_named_property_query(v8::Local<v8::Name> property, 
 
 void php_v8_callback_generic_named_property_deleter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Boolean> &info) {
     PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(info.GetIsolate());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     zval args;
     zval property_name;
@@ -411,7 +417,7 @@ void php_v8_callback_generic_named_property_deleter(v8::Local<v8::Name> property
     /* Build the parameter array */
     array_init_size(&args, 2);
 
-    php_v8_get_or_create_value(&property_name, property, isolate);
+    php_v8_get_or_create_value(&property_name, property, php_v8_isolate);
     add_index_zval(&args, 0, &property_name);
 
     php_v8_callback_call_from_bucket_with_zargs(3, info, info.GetReturnValue(), &args);
@@ -453,6 +459,7 @@ void php_v8_callback_indexed_property_getter(uint32_t index, const v8::PropertyC
 
 void php_v8_callback_indexed_property_setter(uint32_t index, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value> &info) {
     PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(info.GetIsolate());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     zval args;
     zval property_name;
@@ -462,7 +469,7 @@ void php_v8_callback_indexed_property_setter(uint32_t index, v8::Local<v8::Value
     array_init_size(&args, 3);
 
     ZVAL_LONG(&property_name, index);
-    php_v8_get_or_create_value(&property_value, value, isolate);
+    php_v8_get_or_create_value(&property_value, value, php_v8_isolate);
 
     add_index_zval(&args, 0, &property_name);
     add_index_zval(&args, 1, &property_value);
@@ -520,10 +527,12 @@ void php_v8_callback_indexed_property_enumerator(const v8::PropertyCallbackInfo<
 }
 
 bool php_v8_callback_access_check(v8::Local<v8::Context> accessing_context, v8::Local<v8::Object> accessed_object, v8::Local<v8::Value> data) {
-    PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(v8::Isolate::GetCurrent());
-
     PHP_V8_THROW_EXCEPTION("Broken due to problem (see https://groups.google.com/forum/?fromgroups#!topic/v8-dev/c7LhW2bNabY)");
     return false;
+
+    PHP_V8_DECLARE_ISOLATE_LOCAL_ALIAS(v8::Isolate::GetCurrent());
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
+
 
     zval args;
     zval accessed_object_zv;
@@ -539,7 +548,7 @@ bool php_v8_callback_access_check(v8::Local<v8::Context> accessing_context, v8::
 
     assert(NULL != php_v8_context);
 
-    php_v8_get_or_create_value(&accessed_object_zv, accessed_object, isolate);
+    php_v8_get_or_create_value(&accessed_object_zv, accessed_object, php_v8_isolate);
 
     add_index_zval(&args, 0, &php_v8_context->this_ptr);
     add_index_zval(&args, 1, &accessed_object_zv);

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -268,7 +268,7 @@ void php_v8_callback_call_from_bucket_with_zargs(size_t index, v8::Local<v8::Val
         ZVAL_ZVAL(retval, fci.retval, 1, 1);
     }
 
-    // TODO: what about exceptions? - we let user handle any case of exceptions for themselves
+    // We let user handle any case of exceptions for themselves
 
     /* Clean up our mess */
     zend_fcall_info_args_clear(&fci, 1);

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -277,21 +277,22 @@ void php_v8_callback_call_from_bucket_with_zargs(size_t index, v8::Local<v8::Val
 template<class T, class M>
 void php_v8_callback_call_from_bucket_with_zargs(size_t index, const T &info, M rv, zval *args) {
     zval callback_info;
-    php_v8_callback_info_t *php_v8_callback_info;
+    php_v8_return_value_t *php_v8_return_value;
     // Wrap callback info
-    php_v8_callback_info = php_v8_callback_info_create_from_info(&callback_info, info);
 
-    if (!php_v8_callback_info) {
+    php_v8_return_value = php_v8_callback_info_create_from_info(&callback_info, info);
+
+    if (!php_v8_return_value) {
         return;
     }
 
     add_next_index_zval(args, &callback_info);
 
-    php_v8_callback_set_retval_from_callback_info(&rv, php_v8_callback_info->php_v8_return_value);
+    php_v8_callback_set_retval_from_callback_info(&rv, php_v8_return_value);
 
     php_v8_callback_call_from_bucket_with_zargs(index, info.Data(), args, NULL);
 
-    php_v8_callback_info_invalidate(php_v8_callback_info);
+    php_v8_return_value_mark_expired(php_v8_return_value);
 }
 
 

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -537,6 +537,7 @@ bool php_v8_callback_access_check(v8::Local<v8::Context> accessing_context, v8::
     zval args;
     zval accessed_object_zv;
     zval retval;
+    zval context_zv;
 
     bool security_retval = false;
 
@@ -550,7 +551,8 @@ bool php_v8_callback_access_check(v8::Local<v8::Context> accessing_context, v8::
 
     php_v8_get_or_create_value(&accessed_object_zv, accessed_object, php_v8_isolate);
 
-    add_index_zval(&args, 0, &php_v8_context->this_ptr);
+    ZVAL_OBJ(&context_zv, &php_v8_context->std);
+    add_index_zval(&args, 0, &context_zv);
     add_index_zval(&args, 1, &accessed_object_zv);
 
     php_v8_callback_call_from_bucket_with_zargs(0, data, &args, &retval);

--- a/src/php_v8_context.cc
+++ b/src/php_v8_context.cc
@@ -40,10 +40,6 @@ static void php_v8_context_free(zend_object *object)
         delete php_v8_context->context;
     }
 
-    if (!Z_ISUNDEF(php_v8_context->this_ptr)) {
-        zval_ptr_dtor(&php_v8_context->this_ptr);
-    }
-
     zend_object_std_dtor(&php_v8_context->std);
 }
 
@@ -122,7 +118,6 @@ static PHP_METHOD(V8Context, __construct)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(context, "Failed to create Context");
 
-    ZVAL_COPY_VALUE(&php_v8_context->this_ptr, getThis());
     php_v8_context_store_reference(isolate, context, php_v8_context);
 
     php_v8_context->context->Reset(isolate, context);

--- a/src/php_v8_context.cc
+++ b/src/php_v8_context.cc
@@ -355,8 +355,9 @@ PHP_MINIT_FUNCTION(php_v8_context)
 
     memcpy(&php_v8_context_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_context_object_handlers.offset = XtOffsetOf(php_v8_context_t, std);
-    php_v8_context_object_handlers.free_obj = php_v8_context_free;
+    php_v8_context_object_handlers.offset    = XtOffsetOf(php_v8_context_t, std);
+    php_v8_context_object_handlers.free_obj  = php_v8_context_free;
+    php_v8_context_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_context.cc
+++ b/src/php_v8_context.cc
@@ -160,7 +160,7 @@ static PHP_METHOD(V8Context, GlobalObject)
 
     v8::Local<v8::Object> local_object = context->Global();
 
-    php_v8_get_or_create_value(return_value, local_object, isolate);
+    php_v8_get_or_create_value(return_value, local_object, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Context, DetachGlobal)
@@ -224,7 +224,7 @@ static PHP_METHOD(V8Context, GetSecurityToken)
     v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
     v8::Local<v8::Value> local_value = local_context->GetSecurityToken();
 
-    php_v8_get_or_create_value(return_value, local_value, isolate);
+    php_v8_get_or_create_value(return_value, local_value, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Context, AllowCodeGenerationFromStrings)

--- a/src/php_v8_context.cc
+++ b/src/php_v8_context.cc
@@ -96,10 +96,6 @@ static PHP_METHOD(V8Context, __construct)
     PHP_V8_STORE_POINTER_TO_ISOLATE(php_v8_context, php_v8_isolate);
     PHP_V8_ENTER_ISOLATE(php_v8_isolate);
 
-    if (php_v8_global_template_zv) {
-        zend_update_property(this_ce, getThis(), ZEND_STRL("global_template"), php_v8_global_template_zv);
-    }
-
     if (php_v8_global_template_zv && Z_TYPE_P(php_v8_global_template_zv) != IS_NULL) {
         PHP_V8_FETCH_OBJECT_TEMPLATE_WITH_CHECK(php_v8_global_template_zv, php_v8_global_template);
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_context, php_v8_global_template);
@@ -352,8 +348,6 @@ PHP_MINIT_FUNCTION(php_v8_context)
     this_ce->create_object = php_v8_context_ctor;
 
     zend_declare_property_null(this_ce, ZEND_STRL("isolate"), ZEND_ACC_PRIVATE);
-    zend_declare_property_null(this_ce, ZEND_STRL("global_template"), ZEND_ACC_PRIVATE);
-    zend_declare_property_null(this_ce, ZEND_STRL("global_object"), ZEND_ACC_PRIVATE);
 
     memcpy(&php_v8_context_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 

--- a/src/php_v8_context.cc
+++ b/src/php_v8_context.cc
@@ -26,10 +26,6 @@ zend_class_entry* php_v8_context_class_entry;
 static zend_object_handlers php_v8_context_object_handlers;
 
 
-php_v8_context_t * php_v8_context_fetch_object(zend_object *obj) {
-    return (php_v8_context_t *)((char *)obj - XtOffsetOf(php_v8_context_t, std));
-}
-
 static void php_v8_context_free(zend_object *object)
 {
     php_v8_context_t *php_v8_context = php_v8_context_fetch_object(object);

--- a/src/php_v8_context.cc
+++ b/src/php_v8_context.cc
@@ -30,10 +30,14 @@ static void php_v8_context_free(zend_object *object)
 {
     php_v8_context_t *php_v8_context = php_v8_context_fetch_object(object);
 
-    // TODO: if we become weak, don't forget to remove stored `zval* this_ptr` to Context object
-
     if (php_v8_context->context) {
         if (PHP_V8_ISOLATE_HAS_VALID_HANDLE(php_v8_context)) {
+            {
+                PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+                PHP_V8_DECLARE_CONTEXT(php_v8_context);
+                php_v8_context_store_reference(isolate, context, nullptr);
+            }
+
             php_v8_context->context->Reset();
         }
 

--- a/src/php_v8_context.h
+++ b/src/php_v8_context.h
@@ -72,7 +72,7 @@ struct _php_v8_context_t {
     v8::Persistent<v8::Context> *context;
 
     uint32_t isolate_handle;
-    zval this_ptr;
+
     zend_object std;
 };
 

--- a/src/php_v8_context.h
+++ b/src/php_v8_context.h
@@ -28,10 +28,9 @@ extern "C" {
 
 extern zend_class_entry *php_v8_context_class_entry;
 
-extern php_v8_context_t *php_v8_context_fetch_object(zend_object *obj);
+inline php_v8_context_t *php_v8_context_fetch_object(zend_object *obj);
 
 extern void php_v8_context_store_reference(v8::Isolate *isolate, v8::Local<v8::Context> context, php_v8_context_t *php_v8_context);
-
 extern php_v8_context_t *php_v8_context_get_reference(v8::Local<v8::Context> context);
 
 
@@ -77,6 +76,9 @@ struct _php_v8_context_t {
     zend_object std;
 };
 
+inline php_v8_context_t * php_v8_context_fetch_object(zend_object *obj) {
+    return (php_v8_context_t *)((char *)obj - XtOffsetOf(php_v8_context_t, std));
+}
 
 PHP_MINIT_FUNCTION(php_v8_context);
 

--- a/src/php_v8_context.h
+++ b/src/php_v8_context.h
@@ -28,12 +28,9 @@ extern "C" {
 
 extern zend_class_entry *php_v8_context_class_entry;
 
-extern v8::Local<v8::Context> php_v8_context_get_local(v8::Isolate *isolate, php_v8_context_t *php_v8_context);
-
 extern php_v8_context_t *php_v8_context_fetch_object(zend_object *obj);
 
-extern void php_v8_context_store_reference(v8::Isolate *isolate, v8::Local<v8::Context> context,
-                                           php_v8_context_t *php_v8_context);
+extern void php_v8_context_store_reference(v8::Isolate *isolate, v8::Local<v8::Context> context, php_v8_context_t *php_v8_context);
 
 extern php_v8_context_t *php_v8_context_get_reference(v8::Local<v8::Context> context);
 
@@ -65,7 +62,7 @@ extern php_v8_context_t *php_v8_context_get_reference(v8::Local<v8::Context> con
     v8::Context::Scope context_scope(context);
 
 #define PHP_V8_ENTER_CONTEXT(php_v8_context) \
-    v8::Local<v8::Context> context = php_v8_context_get_local(isolate, (php_v8_context)); \
+    PHP_V8_DECLARE_CONTEXT(php_v8_context);  \
     PHP_V8_CONTEXT_ENTER(context);
 
 #define PHP_V8_ENTER_STORED_CONTEXT(stored) PHP_V8_ENTER_CONTEXT((stored)->php_v8_context);

--- a/src/php_v8_date.cc
+++ b/src/php_v8_date.cc
@@ -42,7 +42,6 @@ static PHP_METHOD(V8Date, __construct) {
 
     v8::Local<v8::Date> local_date = maybe_local_date.ToLocalChecked().As<v8::Date>();
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_date);
 
     php_v8_value->persistent->Reset(isolate, local_date);

--- a/src/php_v8_date.cc
+++ b/src/php_v8_date.cc
@@ -46,7 +46,7 @@ static PHP_METHOD(V8Date, __construct) {
     v8::Local<v8::Date> local_date = maybe_local_date.ToLocalChecked().As<v8::Date>();
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_date, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_date);
 
     php_v8_value->persistent->Reset(isolate, local_date);
 }

--- a/src/php_v8_date.cc
+++ b/src/php_v8_date.cc
@@ -23,9 +23,6 @@
 zend_class_entry *php_v8_date_class_entry;
 #define this_ce php_v8_date_class_entry
 
-v8::Local<v8::Date> php_v8_value_get_date_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Date>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8Date, __construct) {
     zval rv;
@@ -60,23 +57,9 @@ static PHP_METHOD(V8Date, ValueOf) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
 
-    RETURN_DOUBLE(php_v8_value_get_date_local(isolate, php_v8_value)->ValueOf());
+    RETURN_DOUBLE(php_v8_value_get_local_as<v8::Date>(php_v8_value)->ValueOf());
 }
 
-
-///**
-// * Notification that the embedder has changed the time zone,
-// * daylight savings time, or other date / time configuration
-// * parameters.  V8 keeps a cache of various values used for
-// * date / time computation.  This notification will reset
-// * those cached values for the current context so that date /
-// * time configuration changes would be reflected in the Date
-// * object.
-// *
-// * This API should not be called more than needed as it will
-// * negatively impact the performance of date operations.
-// */
-//static void DateTimeConfigurationChangeNotification(Isolate* isolate);
 static PHP_METHOD(V8Date, DateTimeConfigurationChangeNotification) {
     zval *isolate_zv;
 

--- a/src/php_v8_date.h
+++ b/src/php_v8_date.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_date_class_entry;
 
-extern v8::Local<v8::Date> php_v8_value_get_date_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_date);
 

--- a/src/php_v8_exception.cc
+++ b/src/php_v8_exception.cc
@@ -46,7 +46,7 @@ static PHP_METHOD(V8Exception, RangeError) {
 
     v8::Local<v8::Value> local_value = v8::Exception::RangeError(message);
 
-    php_v8_create_value(return_value, local_value, isolate);
+    php_v8_create_value(return_value, local_value, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Exception, ReferenceError) {
@@ -69,7 +69,7 @@ static PHP_METHOD(V8Exception, ReferenceError) {
 
     v8::Local<v8::Value> local_value = v8::Exception::ReferenceError(message);
 
-    php_v8_create_value(return_value, local_value, isolate);
+    php_v8_create_value(return_value, local_value, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Exception, SyntaxError) {
@@ -92,7 +92,7 @@ static PHP_METHOD(V8Exception, SyntaxError) {
 
     v8::Local<v8::Value> local_value = v8::Exception::SyntaxError(message);
 
-    php_v8_create_value(return_value, local_value, isolate);
+    php_v8_create_value(return_value, local_value, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Exception, TypeError) {
@@ -114,7 +114,7 @@ static PHP_METHOD(V8Exception, TypeError) {
 
     v8::Local<v8::Value> local_value = v8::Exception::TypeError(message);
 
-    php_v8_create_value(return_value, local_value, isolate);
+    php_v8_create_value(return_value, local_value, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Exception, Error) {
@@ -137,7 +137,7 @@ static PHP_METHOD(V8Exception, Error) {
 
     v8::Local<v8::Value> local_value = v8::Exception::Error(message);
 
-    php_v8_create_value(return_value, local_value, isolate);
+    php_v8_create_value(return_value, local_value, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Exception, CreateMessage) {

--- a/src/php_v8_exception.cc
+++ b/src/php_v8_exception.cc
@@ -42,7 +42,7 @@ static PHP_METHOD(V8Exception, RangeError) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::String> message = php_v8_value_get_string_local(isolate, php_v8_message);
+    v8::Local<v8::String> message = php_v8_value_get_local_as<v8::String>(php_v8_message);
 
     v8::Local<v8::Value> local_value = v8::Exception::RangeError(message);
 
@@ -65,7 +65,7 @@ static PHP_METHOD(V8Exception, ReferenceError) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::String> message = php_v8_value_get_string_local(isolate, php_v8_message);
+    v8::Local<v8::String> message = php_v8_value_get_local_as<v8::String>(php_v8_message);
 
     v8::Local<v8::Value> local_value = v8::Exception::ReferenceError(message);
 
@@ -88,7 +88,7 @@ static PHP_METHOD(V8Exception, SyntaxError) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::String> message = php_v8_value_get_string_local(isolate, php_v8_message);
+    v8::Local<v8::String> message = php_v8_value_get_local_as<v8::String>(php_v8_message);
 
     v8::Local<v8::Value> local_value = v8::Exception::SyntaxError(message);
 
@@ -110,7 +110,7 @@ static PHP_METHOD(V8Exception, TypeError) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
-    v8::Local<v8::String> message = php_v8_value_get_string_local(isolate, php_v8_message);
+    v8::Local<v8::String> message = php_v8_value_get_local_as<v8::String>(php_v8_message);
 
     v8::Local<v8::Value> local_value = v8::Exception::TypeError(message);
 
@@ -133,7 +133,7 @@ static PHP_METHOD(V8Exception, Error) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::String> message = php_v8_value_get_string_local(isolate, php_v8_message);
+    v8::Local<v8::String> message = php_v8_value_get_local_as<v8::String>(php_v8_message);
 
     v8::Local<v8::Value> local_value = v8::Exception::Error(message);
 
@@ -156,7 +156,7 @@ static PHP_METHOD(V8Exception, CreateMessage) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Value> exception = php_v8_value_get_value_local(isolate, php_v8_exception);
+    v8::Local<v8::Value> exception = php_v8_value_get_local(php_v8_exception);
 
     v8::Local<v8::Message> local_message = v8::Exception::CreateMessage(isolate, exception);
 
@@ -179,7 +179,7 @@ static PHP_METHOD(V8Exception, GetStackTrace) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Value> exception = php_v8_value_get_value_local(isolate, php_v8_exception);
+    v8::Local<v8::Value> exception = php_v8_value_get_local(php_v8_exception);
 
     v8::Local<v8::StackTrace> local_stack_trace = v8::Exception::GetStackTrace(exception);
 

--- a/src/php_v8_exceptions.cc
+++ b/src/php_v8_exceptions.cc
@@ -58,6 +58,9 @@ void php_v8_throw_try_catch_exception(php_v8_context_t *php_v8_context, v8::TryC
 
 void php_v8_create_try_catch_exception(zval *return_value, php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, v8::TryCatch *try_catch)
 {
+    zval isolate_zv;
+    zval context_zv;
+
     zval try_catch_zv;
     zend_class_entry* ce = NULL;
     const char *message = NULL;
@@ -88,8 +91,11 @@ void php_v8_create_try_catch_exception(zval *return_value, php_v8_isolate_t *php
         zend_update_property_string(php_v8_try_catch_exception_class_entry, return_value, ZEND_STRL("message"), message);
     }
 
-    PHP_V8_TRY_CATCH_EXCEPTION_STORE_ISOLATE(return_value, &php_v8_isolate->this_ptr);
-    PHP_V8_TRY_CATCH_EXCEPTION_STORE_CONTEXT(return_value, &php_v8_context->this_ptr);
+    ZVAL_OBJ(&isolate_zv, &php_v8_isolate->std);
+    ZVAL_OBJ(&context_zv, &php_v8_context->std);
+
+    PHP_V8_TRY_CATCH_EXCEPTION_STORE_ISOLATE(return_value, &isolate_zv);
+    PHP_V8_TRY_CATCH_EXCEPTION_STORE_CONTEXT(return_value, &context_zv);
 
     php_v8_try_catch_create_from_try_catch(&try_catch_zv, php_v8_isolate, php_v8_context, try_catch);
     PHP_V8_TRY_CATCH_EXCEPTION_STORE_TRY_CATCH(return_value, &try_catch_zv);

--- a/src/php_v8_exceptions.cc
+++ b/src/php_v8_exceptions.cc
@@ -27,22 +27,8 @@ zend_class_entry* php_v8_time_limit_exception_class_entry;
 zend_class_entry* php_v8_memory_limit_exception_class_entry;
 
 zend_class_entry* php_v8_value_exception_class_entry;
-zend_class_entry* php_v8_script_exception_class_entry;
 
 void php_v8_create_try_catch_exception(zval *return_value, php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, v8::TryCatch *try_catch);
-
-void php_v8_try_catch_throw_exception(v8::TryCatch *try_catch, const char* message, zend_class_entry *ce) {
-    if (try_catch->Exception()->IsNull() && try_catch->Message().IsEmpty() && !try_catch->CanContinue() && try_catch->HasTerminated()) {
-        // TODO: output termination exception somehow
-        return;
-    }
-
-    v8::String::Utf8Value exception(try_catch->Exception());
-
-    PHP_V8_CONVERT_UTF8VALUE_TO_STRING_WITH_CHECK(exception, exception_message);
-
-    PHP_V8_THROW_EXCEPTION_CE(exception_message, ce);
-}
 
 void php_v8_throw_try_catch_exception(php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, v8::TryCatch *try_catch) {
     zval exception_zv;
@@ -255,10 +241,6 @@ PHP_MINIT_FUNCTION(php_v8_exceptions) {
 
     INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "ValueException", php_v8_value_exception_methods);
     php_v8_value_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_generic_exception_class_entry);
-
-    // TODO: completely replace ScriptException with TryCatchException
-    INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "ScriptException", php_v8_script_exception_methods);
-    php_v8_script_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_generic_exception_class_entry);
 
     return SUCCESS;
 }

--- a/src/php_v8_exceptions.h
+++ b/src/php_v8_exceptions.h
@@ -35,9 +35,7 @@ extern zend_class_entry* php_v8_time_limit_exception_class_entry;
 extern zend_class_entry* php_v8_memory_limit_exception_class_entry;
 
 extern zend_class_entry* php_v8_value_exception_class_entry;
-extern zend_class_entry* php_v8_script_exception_class_entry;
 
-extern void php_v8_try_catch_throw_exception(v8::TryCatch *try_catch, const char* message, zend_class_entry *ce);
 extern void php_v8_throw_try_catch_exception(php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, v8::TryCatch *try_catch);
 extern void php_v8_throw_try_catch_exception(php_v8_context_t *php_v8_context, v8::TryCatch *try_catch);
 

--- a/src/php_v8_function.cc
+++ b/src/php_v8_function.cc
@@ -75,9 +75,9 @@ bool php_v8_function_unpack_args(zval *arguments_zv, int arg_position, v8::Isola
 
         php_v8_tmp_data = PHP_V8_VALUE_FETCH(pzval);
 
-        // NOTE: check for emptiness may be considered redundant while we may catch the fact that value was not properly
-        //       constructed by checking isolates mismatch, but this check serves for user-friendly purposes to throw
-        //       less confusing exception message
+        // Check for emptiness may be considered redundant while we may catch the fact that value was not properly
+        // constructed by checking isolates mismatch, but this check serves for user-friendly purposes to throw
+        // less confusing exception message
         if (NULL == php_v8_tmp_data->persistent || php_v8_tmp_data->persistent->IsEmpty()) {
             spprintf(&exception_message, 0, PHP_V8_EMPTY_VALUE_MSG ": argument %d passed to %s::%s() at %d offset",
                      arg_position, ZSTR_VAL(ce_name), get_active_function_name(), i);
@@ -164,9 +164,9 @@ bool php_v8_function_unpack_string_args(zval* arguments_zv, int arg_position, v8
 
                 php_v8_tmp_data = PHP_V8_VALUE_FETCH(pzval);
 
-                // NOTE: check for emptiness may be considered redundant while we may catch the fact that value was not properly
-                //       constructed by checking isolates mismatch, but this check serves for user-friendly purposes to throw
-                //       less confusing exception message
+                // Check for emptiness may be considered redundant while we may catch the fact that value was not properly
+                // constructed by checking isolates mismatch, but this check serves for user-friendly purposes to throw
+                // less confusing exception message
                 if (NULL == php_v8_tmp_data->persistent || php_v8_tmp_data->persistent->IsEmpty()) {
                     spprintf(&exception_message, 0, PHP_V8_EMPTY_VALUE_MSG ": argument %d passed to %s::%s() at %d offset",
                              arg_position, ZSTR_VAL(ce_name), get_active_function_name(), i);
@@ -253,9 +253,9 @@ bool php_v8_function_unpack_object_args(zval* arguments_zv, int arg_position, v8
 
                 php_v8_tmp_data = PHP_V8_VALUE_FETCH(pzval);
 
-                // NOTE: check for emptiness may be considered redundant while we may catch the fact that value was not properly
-                //       constructed by checking isolates mismatch, but this check serves for user-friendly purposes to throw
-                //       less confusing exception message
+                // Check for emptiness may be considered redundant while we may catch the fact that value was not properly
+                // constructed by checking isolates mismatch, but this check serves for user-friendly purposes to throw
+                // less confusing exception message
                 if (NULL == php_v8_tmp_data->persistent || php_v8_tmp_data->persistent->IsEmpty()) {
                     spprintf(&exception_message, 0, PHP_V8_EMPTY_VALUE_MSG ": argument %d passed to %s::%s() at %d offset",
                              arg_position, ZSTR_VAL(ce_name), get_active_function_name(), i);
@@ -333,14 +333,7 @@ static PHP_METHOD(V8Function, __construct) {
         callback = php_v8_callback_function;
     }
 
-    // TODO: check length range (PHP uses long, while V8 uses int
-
-    v8::MaybeLocal<v8::Function> maybe_local_function = v8::Function::New(
-            context,
-            callback,
-            data,
-            (int) length
-    );
+    v8::MaybeLocal<v8::Function> maybe_local_function = v8::Function::New(context, callback, data, static_cast<int>(length));
 
     if (maybe_local_function.IsEmpty()) {
         PHP_V8_THROW_EXCEPTION("Failed to create Function value");

--- a/src/php_v8_function.cc
+++ b/src/php_v8_function.cc
@@ -25,9 +25,6 @@
 zend_class_entry *php_v8_function_class_entry;
 #define this_ce php_v8_function_class_entry
 
-v8::Local<v8::Function> php_v8_value_get_function_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Function>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 bool php_v8_function_unpack_args(zval *arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::Value> **argv) {
     if (NULL == arguments_zv || zend_hash_num_elements(Z_ARRVAL_P(arguments_zv)) < 1) {
@@ -104,7 +101,7 @@ bool php_v8_function_unpack_args(zval *arguments_zv, int arg_position, v8::Isola
             break;
         }
 
-        (*argv)[i++] = php_v8_value_get_value_local(isolate, php_v8_tmp_data);
+        (*argv)[i++] = php_v8_value_get_local(php_v8_tmp_data);
     } ZEND_HASH_FOREACH_END();
 
     if (has_error) {
@@ -193,7 +190,7 @@ bool php_v8_function_unpack_string_args(zval* arguments_zv, int arg_position, v8
                     break;
                 }
 
-                (*argv)[i++] = php_v8_value_get_string_local(isolate, php_v8_tmp_data);
+                (*argv)[i++] = php_v8_value_get_local_as<v8::String>(php_v8_tmp_data);
             } ZEND_HASH_FOREACH_END();
 
     if (has_error) {
@@ -282,7 +279,7 @@ bool php_v8_function_unpack_object_args(zval* arguments_zv, int arg_position, v8
                     break;
                 }
 
-                (*argv)[i++] = php_v8_value_get_object_local(isolate, php_v8_tmp_data);
+                (*argv)[i++] = php_v8_value_get_local_as<v8::Object>(php_v8_tmp_data);
             } ZEND_HASH_FOREACH_END();
 
     if (has_error) {
@@ -324,8 +321,8 @@ static PHP_METHOD(V8Function, __construct) {
     PHP_V8_STORE_POINTER_TO_CONTEXT(php_v8_value, php_v8_context);
     PHP_V8_COPY_POINTER_TO_ISOLATE(php_v8_value, php_v8_context);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
     if (fci.size) {
         phpv8::CallbacksBucket *bucket = php_v8_value->persistent_data->bucket("callback");
@@ -382,7 +379,7 @@ static PHP_METHOD(V8Function, NewInstance) {
         return;
     }
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);
@@ -427,8 +424,8 @@ static PHP_METHOD(V8Function, Call) {
         return;
     }
 
-    v8::Local<v8::Value> local_recv = php_v8_value_get_value_local(isolate, php_v8_value_recv);
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_recv = php_v8_value_get_local(php_v8_value_recv);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);
@@ -462,8 +459,8 @@ static PHP_METHOD(V8Function, SetName) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
-    v8::Local<v8::String> local_name = php_v8_value_get_string_local(isolate, php_v8_string);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
+    v8::Local<v8::String> local_name = php_v8_value_get_local_as<v8::String>(php_v8_string);
 
     local_function->SetName(local_name);
 }
@@ -477,7 +474,7 @@ static PHP_METHOD(V8Function, GetName) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
     v8::Local<v8::Value> local_name = local_function->GetName();
 
     php_v8_get_or_create_value(return_value, local_name, php_v8_value->php_v8_isolate);
@@ -492,7 +489,7 @@ static PHP_METHOD(V8Function, GetInferredName) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
     v8::Local<v8::Value> local_inferred_name = local_function->GetInferredName();
 
     php_v8_get_or_create_value(return_value, local_inferred_name, php_v8_value->php_v8_isolate);
@@ -508,7 +505,7 @@ static PHP_METHOD(V8Function, GetDisplayName) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
     v8::Local<v8::Value> local_display_name = local_function->GetDisplayName();
 
     php_v8_get_or_create_value(return_value, local_display_name, php_v8_value->php_v8_isolate);
@@ -524,7 +521,7 @@ static PHP_METHOD(V8Function, GetScriptLineNumber) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
 
     int line_number = local_function->GetScriptLineNumber();
 
@@ -545,7 +542,7 @@ static PHP_METHOD(V8Function, GetScriptColumnNumber) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
 
     int column_number = local_function->GetScriptColumnNumber();
 
@@ -565,7 +562,7 @@ static PHP_METHOD(V8Function, GetBoundFunction) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
 
     v8::Local<v8::Value> local_value = local_function->GetBoundFunction();
 
@@ -581,7 +578,7 @@ static PHP_METHOD(V8Function, GetScriptOrigin) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
+    v8::Local<v8::Function> local_function = php_v8_value_get_local_as<v8::Function>(php_v8_value);
 
     v8::ScriptOrigin script_origin = local_function->GetScriptOrigin();
 

--- a/src/php_v8_function.cc
+++ b/src/php_v8_function.cc
@@ -353,7 +353,7 @@ static PHP_METHOD(V8Function, __construct) {
     v8::Local<v8::Function> local_function = maybe_local_function.ToLocalChecked();
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_function, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_function);
 
     php_v8_value->persistent->Reset(isolate, local_function);
 }
@@ -398,7 +398,7 @@ static PHP_METHOD(V8Function, NewInstance) {
 
     v8::Local<v8::Object> local_obj = maybe_local_obj.ToLocalChecked();
 
-    php_v8_get_or_create_value(return_value, local_obj, isolate);
+    php_v8_get_or_create_value(return_value, local_obj, php_v8_value->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Function, Call) {
@@ -444,7 +444,7 @@ static PHP_METHOD(V8Function, Call) {
 
     v8::Local<v8::Value> local_res = maybe_local_res.ToLocalChecked();
 
-    php_v8_get_or_create_value(return_value, local_res, isolate);
+    php_v8_get_or_create_value(return_value, local_res, php_v8_value->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Function, SetName) {
@@ -480,7 +480,7 @@ static PHP_METHOD(V8Function, GetName) {
     v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
     v8::Local<v8::Value> local_name = local_function->GetName();
 
-    php_v8_get_or_create_value(return_value, local_name, isolate);
+    php_v8_get_or_create_value(return_value, local_name, php_v8_value->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Function, GetInferredName) {
@@ -495,7 +495,7 @@ static PHP_METHOD(V8Function, GetInferredName) {
     v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
     v8::Local<v8::Value> local_inferred_name = local_function->GetInferredName();
 
-    php_v8_get_or_create_value(return_value, local_inferred_name, isolate);
+    php_v8_get_or_create_value(return_value, local_inferred_name, php_v8_value->php_v8_isolate);
 
 }
 
@@ -511,7 +511,7 @@ static PHP_METHOD(V8Function, GetDisplayName) {
     v8::Local<v8::Function> local_function = php_v8_value_get_function_local(isolate, php_v8_value);
     v8::Local<v8::Value> local_display_name = local_function->GetDisplayName();
 
-    php_v8_get_or_create_value(return_value, local_display_name, isolate);
+    php_v8_get_or_create_value(return_value, local_display_name, php_v8_value->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Function, GetScriptLineNumber) {
@@ -569,7 +569,7 @@ static PHP_METHOD(V8Function, GetBoundFunction) {
 
     v8::Local<v8::Value> local_value = local_function->GetBoundFunction();
 
-    php_v8_get_or_create_value(return_value, local_value, isolate);
+    php_v8_get_or_create_value(return_value, local_value, php_v8_value->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Function, GetScriptOrigin) {

--- a/src/php_v8_function.cc
+++ b/src/php_v8_function.cc
@@ -349,7 +349,6 @@ static PHP_METHOD(V8Function, __construct) {
 
     v8::Local<v8::Function> local_function = maybe_local_function.ToLocalChecked();
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_function);
 
     php_v8_value->persistent->Reset(isolate, local_function);

--- a/src/php_v8_function.h
+++ b/src/php_v8_function.h
@@ -26,9 +26,7 @@ extern "C" {
 
 extern zend_class_entry* php_v8_function_class_entry;
 
-extern v8::Local<v8::Function> php_v8_value_get_function_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-extern bool
-php_v8_function_unpack_args(zval *arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::Value> **argv);
+extern bool php_v8_function_unpack_args(zval *arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::Value> **argv);
 extern bool php_v8_function_unpack_string_args(zval* arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::String> **argv);
 extern bool php_v8_function_unpack_object_args(zval* arguments_zv, int arg_position, v8::Isolate *isolate, int *argc, v8::Local<v8::Object> **argv);
 

--- a/src/php_v8_function_callback_info.cc
+++ b/src/php_v8_function_callback_info.cc
@@ -102,7 +102,7 @@ static PHP_METHOD(V8FunctionCallbackInfo, Arguments) {
 
         local_value = v8::Local<v8::Value>::New(isolate, *php_v8_callback_info->arguments[i]);
 
-        php_v8_get_or_create_value(&arg_zv, local_value, isolate);
+        php_v8_get_or_create_value(&arg_zv, local_value, php_v8_callback_info->php_v8_isolate);
 
         add_index_zval(&php_v8_callback_info->args, static_cast<zend_ulong>(i), &arg_zv);
     }

--- a/src/php_v8_function_callback_info.cc
+++ b/src/php_v8_function_callback_info.cc
@@ -29,7 +29,6 @@ php_v8_return_value_t * php_v8_callback_info_create_from_info(zval *return_value
     zval tmp;
     zval arg_zv;
     php_v8_return_value_t *php_v8_return_value;
-    v8::Local<v8::Value> local_value;
 
     v8::Isolate *isolate = args.GetIsolate();
     v8::Local<v8::Context> context = isolate->GetEnteredContext();
@@ -87,6 +86,19 @@ php_v8_return_value_t * php_v8_callback_info_create_from_info(zval *return_value
     return php_v8_return_value;
 }
 
+static PHP_METHOD(V8FunctionCallbackInfo, Length) {
+    zval rv;
+    zval *tmp;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("arguments"), 0, &rv);
+
+    RETURN_LONG(zend_array_count(Z_ARRVAL_P(tmp)));
+}
+
 static PHP_METHOD(V8FunctionCallbackInfo, Arguments) {
     zval rv;
     zval *tmp;
@@ -124,6 +136,9 @@ static PHP_METHOD(V8FunctionCallbackInfo, IsConstructCall) {
 }
 
 
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_callback_info_Length, ZEND_RETURN_VALUE, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_callback_info_Arguments, ZEND_RETURN_VALUE, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
@@ -135,6 +150,7 @@ ZEND_END_ARG_INFO()
 
 
 static const zend_function_entry php_v8_function_callback_info_methods[] = {
+        PHP_ME(V8FunctionCallbackInfo, Length, arginfo_v8_function_callback_info_Length, ZEND_ACC_PUBLIC)
         PHP_ME(V8FunctionCallbackInfo, Arguments, arginfo_v8_function_callback_info_Arguments, ZEND_ACC_PUBLIC)
         PHP_ME(V8FunctionCallbackInfo, NewTarget, arginfo_v8_function_callback_info_NewTarget, ZEND_ACC_PUBLIC)
         PHP_ME(V8FunctionCallbackInfo, IsConstructCall, arginfo_v8_function_callback_info_IsConstructCall, ZEND_ACC_PUBLIC)

--- a/src/php_v8_function_callback_info.cc
+++ b/src/php_v8_function_callback_info.cc
@@ -32,7 +32,7 @@ php_v8_return_value_t * php_v8_callback_info_create_from_info(zval *return_value
     v8::Local<v8::Value> local_value;
 
     v8::Isolate *isolate = args.GetIsolate();
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Context> context = isolate->GetEnteredContext();
 
     if (context.IsEmpty()) {
         PHP_V8_THROW_EXCEPTION("Internal exception: no calling context found");

--- a/src/php_v8_function_callback_info.cc
+++ b/src/php_v8_function_callback_info.cc
@@ -25,8 +25,12 @@ zend_class_entry* php_v8_function_callback_info_class_entry;
 #define this_ce php_v8_function_callback_info_class_entry
 
 
-php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::FunctionCallbackInfo<v8::Value> &args) {
-    zval retval;
+php_v8_return_value_t * php_v8_callback_info_create_from_info(zval *return_value, const v8::FunctionCallbackInfo<v8::Value> &args) {
+    zval tmp;
+    zval arg_zv;
+    php_v8_return_value_t *php_v8_return_value;
+    v8::Local<v8::Value> local_value;
+
     v8::Isolate *isolate = args.GetIsolate();
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
@@ -35,97 +39,95 @@ php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, co
         return NULL;
     }
 
-    object_init_ex(this_ptr, this_ce);
-    PHP_V8_CALLBACK_INFO_FETCH_INTO(this_ptr, php_v8_callback_info);
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
+    php_v8_context_t *php_v8_context = php_v8_context_get_reference(context);
 
-    php_v8_callback_info->php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
-    php_v8_callback_info->php_v8_context = php_v8_context_get_reference(context);
+    object_init_ex(return_value, this_ce);
 
-    php_v8_callback_info->this_obj->Reset(isolate, args.This());
-    php_v8_callback_info->holder_obj->Reset(isolate, args.Holder());
+    // common to both callback structures:
+    // isolate
+    ZVAL_OBJ(&tmp, &php_v8_isolate->std);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("isolate"), &tmp);
+    // context
+    ZVAL_OBJ(&tmp, &php_v8_context->std);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("context"), &tmp);
+    // this
+    php_v8_get_or_create_value(&tmp, args.This(), php_v8_isolate);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("this"), &tmp);
+    Z_DELREF(tmp);
+    // holder
+    php_v8_get_or_create_value(&tmp, args.Holder(), php_v8_isolate);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("holder"), &tmp);
+    Z_DELREF(tmp);
+    // return value
+    php_v8_return_value = php_v8_return_value_create_from_return_value(&tmp, php_v8_context, PHP_V8_RETVAL_ACCEPTS_ANY);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("return_value"), &tmp);
+    Z_DELREF(tmp);
 
-    php_v8_callback_info->php_v8_return_value = php_v8_return_value_create_from_return_value(
-            &retval,
-            php_v8_callback_info->php_v8_isolate,
-            php_v8_callback_info->php_v8_context,
-            PHP_V8_RETVAL_ACCEPTS_ANY
-    );
+    // specific to function callback structure:
+    // length & arguments, all in one
+    array_init_size(&tmp, static_cast<uint>(args.Length()));
 
-    /* function callback specific part */
-    php_v8_callback_info->length = args.Length();
+    for (int i=0; i < args.Length(); i++) {
+        php_v8_get_or_create_value(&arg_zv,  args[i], php_v8_isolate);
 
-    php_v8_callback_info->arguments = (v8::Persistent<v8::Value> **) ecalloc(static_cast<size_t>(php_v8_callback_info->length), sizeof(*php_v8_callback_info->arguments));
-
-    for (int i=0; i < php_v8_callback_info->length; i++) {
-        php_v8_callback_info->arguments[i] = new v8::Persistent<v8::Value>(isolate, args[i]);
+        add_index_zval(&tmp, static_cast<zend_ulong>(i), &arg_zv);
     }
+    zend_update_property(this_ce, return_value, ZEND_STRL("arguments"), &tmp);
+    Z_DELREF(tmp);
 
-    php_v8_callback_info->is_construct_call = args.IsConstructCall();
+    // new_target
+    php_v8_get_or_create_value(&tmp, args.NewTarget(), php_v8_isolate);
+    zend_update_property(this_ce, return_value, ZEND_STRL("new_target"), &tmp);
+    Z_DELREF(tmp);
 
-    return php_v8_callback_info;
-}
+    // is_constructor_call
+    zend_update_property_bool(this_ce, return_value, ZEND_STRL("is_constructor_call"), static_cast<zend_bool>(args.IsConstructCall()));
 
-
-static PHP_METHOD(V8FunctionCallbackInfo, Length) {
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
-
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
-
-    RETURN_LONG(static_cast<zend_long>(php_v8_callback_info->length));
+    return php_v8_return_value;
 }
 
 static PHP_METHOD(V8FunctionCallbackInfo, Arguments) {
-    v8::Local<v8::Value> local_value;
-
-    zval arg_zv;
+    zval rv;
+    zval *tmp;
 
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("arguments"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
+}
 
-    if (!Z_ISUNDEF(php_v8_callback_info->args)) {
-        RETURN_ZVAL(&php_v8_callback_info->args, 1, 0);
+static PHP_METHOD(V8FunctionCallbackInfo, NewTarget) {
+    zval rv;
+    zval *tmp;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
     }
 
-    // TODO: looks like PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT make sure we have current context, but check this one more time
-    v8::Isolate *isolate = php_v8_callback_info->php_v8_isolate->isolate;
-
-    array_init_size(&php_v8_callback_info->args, static_cast<uint>(php_v8_callback_info->length));
-
-    for (int i=0; i < php_v8_callback_info->length; i++) {
-
-        local_value = v8::Local<v8::Value>::New(isolate, *php_v8_callback_info->arguments[i]);
-
-        php_v8_get_or_create_value(&arg_zv, local_value, php_v8_callback_info->php_v8_isolate);
-
-        add_index_zval(&php_v8_callback_info->args, static_cast<zend_ulong>(i), &arg_zv);
-    }
-
-    RETURN_ZVAL(&php_v8_callback_info->args, 1, 0);
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("new_target"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
 }
 
 static PHP_METHOD(V8FunctionCallbackInfo, IsConstructCall) {
+    zval rv;
+    zval *tmp;
+
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    PHP_V8_CALLBACK_INFO_FETCH_WITH_CHECK(getThis(), php_v8_callback_info);
-    PHP_V8_V8_CALLBACK_INFO_CHECK_IN_CONTEXT(php_v8_callback_info);
-
-    RETURN_BOOL(php_v8_callback_info->is_construct_call)
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("is_constructor_call"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
 }
 
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_callback_info_Length, ZEND_RETURN_VALUE, 0, IS_LONG, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_callback_info_Arguments, ZEND_RETURN_VALUE, 0, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_callback_info_Arguments, ZEND_RETURN_VALUE, 0, IS_ARRAY, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_function_callback_info_NewTarget, ZEND_RETURN_VALUE, 0, V8\\Value, 0)
 ZEND_END_ARG_INFO()
 
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_function_callback_info_IsConstructCall, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
@@ -133,8 +135,8 @@ ZEND_END_ARG_INFO()
 
 
 static const zend_function_entry php_v8_function_callback_info_methods[] = {
-        PHP_ME(V8FunctionCallbackInfo, Length, arginfo_v8_function_callback_info_Length, ZEND_ACC_PUBLIC)
         PHP_ME(V8FunctionCallbackInfo, Arguments, arginfo_v8_function_callback_info_Arguments, ZEND_ACC_PUBLIC)
+        PHP_ME(V8FunctionCallbackInfo, NewTarget, arginfo_v8_function_callback_info_NewTarget, ZEND_ACC_PUBLIC)
         PHP_ME(V8FunctionCallbackInfo, IsConstructCall, arginfo_v8_function_callback_info_IsConstructCall, ZEND_ACC_PUBLIC)
         PHP_FE_END
 };
@@ -144,6 +146,10 @@ PHP_MINIT_FUNCTION(php_v8_function_callback_info) {
 
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "FunctionCallbackInfo", php_v8_function_callback_info_methods);
     this_ce = zend_register_internal_class_ex(&ce, php_v8_callback_info_class_entry);
+
+    zend_declare_property_null(this_ce, ZEND_STRL("arguments"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("new_target"), ZEND_ACC_PRIVATE);
+    zend_declare_property_null(this_ce, ZEND_STRL("is_constructor_call"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/php_v8_function_callback_info.h
+++ b/src/php_v8_function_callback_info.h
@@ -13,6 +13,7 @@
 #ifndef PHP_V8_FUNCTION_CALLBACK_INFO_H
 #define PHP_V8_FUNCTION_CALLBACK_INFO_H
 
+#include "php_v8_return_value.h"
 #include "php_v8_callback_info.h"
 #include <v8.h>
 
@@ -26,7 +27,7 @@ extern "C" {
 
 extern zend_class_entry* php_v8_function_callback_info_class_entry;
 
-extern php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::FunctionCallbackInfo<v8::Value>&args);
+extern php_v8_return_value_t * php_v8_callback_info_create_from_info(zval *return_value, const v8::FunctionCallbackInfo<v8::Value> &args);
 
 
 PHP_MINIT_FUNCTION (php_v8_function_callback_info);

--- a/src/php_v8_function_template.cc
+++ b/src/php_v8_function_template.cc
@@ -30,10 +30,6 @@ zend_class_entry *php_v8_function_template_class_entry;
 static zend_object_handlers php_v8_function_template_object_handlers;
 
 
-php_v8_function_template_t * php_v8_function_template_fetch_object(zend_object *obj) {
-    return (php_v8_function_template_t *)((char *)obj - XtOffsetOf(php_v8_function_template_t, std));
-}
-
 static void php_v8_function_template_weak_callback(const v8::WeakCallbackInfo<v8::Persistent<v8::FunctionTemplate>> &data) {
     v8::Isolate *isolate = data.GetIsolate();
     php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);

--- a/src/php_v8_function_template.cc
+++ b/src/php_v8_function_template.cc
@@ -232,7 +232,7 @@ static PHP_METHOD(V8FunctionTemplate, GetFunction) {
 
     v8::Local<v8::Function> local_function = maybe_local_function.ToLocalChecked();
 
-    php_v8_get_or_create_value(return_value, local_function, isolate);
+    php_v8_get_or_create_value(return_value, local_function, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8FunctionTemplate, SetCallHandler) {

--- a/src/php_v8_function_template.cc
+++ b/src/php_v8_function_template.cc
@@ -574,9 +574,10 @@ PHP_MINIT_FUNCTION (php_v8_function_template) {
 
     memcpy(&php_v8_function_template_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_function_template_object_handlers.offset   = XtOffsetOf(php_v8_function_template_t, std);
-    php_v8_function_template_object_handlers.free_obj = php_v8_function_template_free;
-    php_v8_function_template_object_handlers.get_gc   = php_v8_function_template_gc;
+    php_v8_function_template_object_handlers.offset    = XtOffsetOf(php_v8_function_template_t, std);
+    php_v8_function_template_object_handlers.free_obj  = php_v8_function_template_free;
+    php_v8_function_template_object_handlers.get_gc    = php_v8_function_template_gc;
+    php_v8_function_template_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_function_template.cc
+++ b/src/php_v8_function_template.cc
@@ -29,9 +29,6 @@ zend_class_entry *php_v8_function_template_class_entry;
 
 static zend_object_handlers php_v8_function_template_object_handlers;
 
-v8::Local<v8::FunctionTemplate> php_v8_function_template_get_local(v8::Isolate *isolate, php_v8_function_template_t *php_v8_function_template) {
-    return v8::Local<v8::FunctionTemplate>::New(isolate, *php_v8_function_template->persistent);
-}
 
 php_v8_function_template_t * php_v8_function_template_fetch_object(zend_object *obj) {
     return (php_v8_function_template_t *)((char *)obj - XtOffsetOf(php_v8_function_template_t, std));
@@ -225,7 +222,7 @@ static PHP_METHOD(V8FunctionTemplate, GetFunction) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(php_v8_function_template);
     v8::MaybeLocal<v8::Function> maybe_local_function = local_function_tpl->GetFunction(context);
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(maybe_local_function, "Failed to get function instance");
@@ -253,7 +250,7 @@ static PHP_METHOD(V8FunctionTemplate, SetCallHandler) {
     phpv8::CallbacksBucket *bucket= php_v8_function_template->persistent_data->bucket("callback");
     bucket->add(0, fci, fci_cache);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_function_template);
 
     local_template->SetCallHandler(php_v8_callback_function, v8::External::New(isolate, bucket));
 }
@@ -270,7 +267,7 @@ static PHP_METHOD(V8FunctionTemplate, SetLength) {
     PHP_V8_FETCH_FUNCTION_TEMPLATE_WITH_CHECK(getThis(), php_v8_function_template);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_function_template);
 
     local_template->SetLength(static_cast<int>(length));
 }
@@ -286,7 +283,7 @@ static PHP_METHOD(V8FunctionTemplate, InstanceTemplate) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(php_v8_function_template);
 
     v8::Local<v8::ObjectTemplate> local_obj_tpl = local_function_tpl->InstanceTemplate();
 
@@ -310,8 +307,8 @@ static PHP_METHOD(V8FunctionTemplate, Inherit) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_function_template);
-    v8::Local<v8::FunctionTemplate> local_template_parent = php_v8_function_template_get_local(isolate, php_v8_function_template_parent);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_template_parent = php_v8_function_template_get_local(php_v8_function_template_parent);
 
     local_template->Inherit(local_template_parent);
 }
@@ -327,7 +324,7 @@ static PHP_METHOD(V8FunctionTemplate, PrototypeTemplate) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(php_v8_function_template);
 
     v8::Local<v8::ObjectTemplate> local_obj_tpl = local_function_tpl->PrototypeTemplate();
 
@@ -353,8 +350,8 @@ static PHP_METHOD(V8FunctionTemplate, SetClassName) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(isolate, php_v8_function_template);
-    v8::Local<v8::String> local_name = php_v8_value_get_string_local(isolate, php_v8_string);
+    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(php_v8_function_template);
+    v8::Local<v8::String> local_name = php_v8_value_get_local_as<v8::String>(php_v8_string);
 
     local_function_tpl->SetClassName(local_name);
 }
@@ -370,7 +367,7 @@ static PHP_METHOD(V8FunctionTemplate, SetAcceptAnyReceiver) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_function_template);
 
     local_template->SetAcceptAnyReceiver(static_cast<bool>(value));
 }
@@ -385,7 +382,7 @@ static PHP_METHOD(V8FunctionTemplate, SetHiddenPrototype) {
     PHP_V8_FETCH_FUNCTION_TEMPLATE_WITH_CHECK(getThis(), php_v8_function_template);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_function_template);
 
     local_template->SetHiddenPrototype(static_cast<bool>(value));
 }
@@ -399,7 +396,7 @@ static PHP_METHOD(V8FunctionTemplate, ReadOnlyPrototype) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(php_v8_function_template);
 
     local_function_tpl->ReadOnlyPrototype();
 }
@@ -413,7 +410,7 @@ static PHP_METHOD(V8FunctionTemplate, RemovePrototype) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(isolate, php_v8_function_template);
+    v8::Local<v8::FunctionTemplate> local_function_tpl = php_v8_function_template_get_local(php_v8_function_template);
 
     local_function_tpl->RemovePrototype();
 }
@@ -430,8 +427,8 @@ static PHP_METHOD(V8FunctionTemplate, HasInstance) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_function_template);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_function_template);
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_object);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_function_template);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_object);
 
     RETURN_BOOL(local_template->HasInstance(local_obj));
 }

--- a/src/php_v8_function_template.cc
+++ b/src/php_v8_function_template.cc
@@ -77,8 +77,7 @@ static void php_v8_function_template_free(zend_object *object) {
      * persistent handler and cleanup callbacks. Alternatively, we can detect in weak callback that object is live and
      * unmark it as weak and do all that cleanings in free handler. What about if object will be reused after being
      * unmarked as week? Note, that the only action on weak handler callback is Reset()ing persistent handler.
-     *
-     * */
+     */
     if (zend_is_executing() && !CG(unclean_shutdown) && php_v8_function_template->persistent_data && !php_v8_function_template->persistent_data->empty()) {
         php_v8_function_template_make_weak(php_v8_function_template);
     }
@@ -161,13 +160,7 @@ static PHP_METHOD(V8FunctionTemplate, __construct) {
         callback = php_v8_callback_function;
     }
 
-    v8::Local<v8::FunctionTemplate> local_template = v8::FunctionTemplate::New(
-            isolate,
-            callback,
-            data,
-            signature,
-            static_cast<int>(length)
-    );
+    v8::Local<v8::FunctionTemplate> local_template = v8::FunctionTemplate::New(isolate, callback, data, signature, static_cast<int>(length));
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_template, "Failed to create FunctionTemplate value");
 

--- a/src/php_v8_function_template.h
+++ b/src/php_v8_function_template.h
@@ -32,7 +32,6 @@ extern zend_class_entry* php_v8_function_template_class_entry;
 typedef struct _php_v8_function_template_t php_v8_function_template_t;
 
 
-extern v8::Local<v8::FunctionTemplate> php_v8_function_template_get_local(v8::Isolate *isolate, php_v8_function_template_t *php_v8_function_template);
 extern php_v8_function_template_t * php_v8_function_template_fetch_object(zend_object *obj);
 
 
@@ -64,6 +63,10 @@ struct _php_v8_function_template_t {
 
     zend_object std;
 };
+
+inline v8::Local<v8::FunctionTemplate> php_v8_function_template_get_local(php_v8_function_template_t *php_v8_function_template) {
+    return v8::Local<v8::FunctionTemplate>::New(php_v8_function_template->php_v8_isolate->isolate, *php_v8_function_template->persistent);
+}
 
 
 PHP_MINIT_FUNCTION(php_v8_function_template);

--- a/src/php_v8_function_template.h
+++ b/src/php_v8_function_template.h
@@ -32,8 +32,7 @@ extern zend_class_entry* php_v8_function_template_class_entry;
 typedef struct _php_v8_function_template_t php_v8_function_template_t;
 
 
-extern php_v8_function_template_t * php_v8_function_template_fetch_object(zend_object *obj);
-
+inline php_v8_function_template_t * php_v8_function_template_fetch_object(zend_object *obj);
 
 #define PHP_V8_FUNCTION_TEMPLATE_FETCH(zv) php_v8_function_template_fetch_object(Z_OBJ_P(zv))
 #define PHP_V8_FUNCTION_TEMPLATE_FETCH_INTO(pzval, into) php_v8_function_template_t *(into) = PHP_V8_FUNCTION_TEMPLATE_FETCH((pzval));
@@ -63,6 +62,10 @@ struct _php_v8_function_template_t {
 
     zend_object std;
 };
+
+inline php_v8_function_template_t * php_v8_function_template_fetch_object(zend_object *obj) {
+    return (php_v8_function_template_t *)((char *)obj - XtOffsetOf(php_v8_function_template_t, std));
+}
 
 inline v8::Local<v8::FunctionTemplate> php_v8_function_template_get_local(php_v8_function_template_t *php_v8_function_template) {
     return v8::Local<v8::FunctionTemplate>::New(php_v8_function_template->php_v8_isolate->isolate, *php_v8_function_template->persistent);

--- a/src/php_v8_indexed_property_handler_configuration.cc
+++ b/src/php_v8_indexed_property_handler_configuration.cc
@@ -24,9 +24,6 @@ zend_class_entry* php_v8_indexed_property_handler_configuration_class_entry;
 
 static zend_object_handlers php_v8_indexed_property_handler_configuration_object_handlers;
 
-php_v8_indexed_property_handler_configuration_t * php_v8_indexed_property_handler_configuration_fetch_object(zend_object *obj) {
-    return (php_v8_indexed_property_handler_configuration_t *)((char *)obj - XtOffsetOf(php_v8_indexed_property_handler_configuration_t, std));
-}
 
 static HashTable * php_v8_indexed_property_handler_configuration_gc(zval *object, zval **table, int *n) {
     PHP_V8_INDEXED_PROPERTY_HANDLER_FETCH_INTO(object, php_v8_handlers);

--- a/src/php_v8_indexed_property_handler_configuration.cc
+++ b/src/php_v8_indexed_property_handler_configuration.cc
@@ -119,8 +119,7 @@ static PHP_METHOD (V8IndexedPropertyHandlerConfiguration, __construct) {
         php_v8_handlers->enumerator = php_v8_callback_indexed_property_enumerator;
     }
 
-    // TODO: php_v8_handlers->flags is long, while flag is zend_long, unify types or cast ???
-    php_v8_handlers->flags = flags ? flags & PHP_V8_PROPERTY_HANDLER_FLAGS : flags;
+    php_v8_handlers->flags = static_cast<long>(flags ? flags & PHP_V8_PROPERTY_HANDLER_FLAGS : flags);
 }
 
 

--- a/src/php_v8_indexed_property_handler_configuration.cc
+++ b/src/php_v8_indexed_property_handler_configuration.cc
@@ -149,9 +149,10 @@ PHP_MINIT_FUNCTION(php_v8_indexed_property_handler_configuration) {
 
     memcpy(&php_v8_indexed_property_handler_configuration_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_indexed_property_handler_configuration_object_handlers.offset   = XtOffsetOf(php_v8_indexed_property_handler_configuration_t, std);
-    php_v8_indexed_property_handler_configuration_object_handlers.free_obj = php_v8_indexed_property_handler_configuration_free;
-    php_v8_indexed_property_handler_configuration_object_handlers.get_gc   = php_v8_indexed_property_handler_configuration_gc;
+    php_v8_indexed_property_handler_configuration_object_handlers.offset    = XtOffsetOf(php_v8_indexed_property_handler_configuration_t, std);
+    php_v8_indexed_property_handler_configuration_object_handlers.free_obj  = php_v8_indexed_property_handler_configuration_free;
+    php_v8_indexed_property_handler_configuration_object_handlers.get_gc    = php_v8_indexed_property_handler_configuration_gc;
+    php_v8_indexed_property_handler_configuration_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_indexed_property_handler_configuration.h
+++ b/src/php_v8_indexed_property_handler_configuration.h
@@ -27,7 +27,7 @@ extern "C" {
 extern zend_class_entry* php_v8_indexed_property_handler_configuration_class_entry;
 typedef struct _php_v8_indexed_property_handler_configuration_t php_v8_indexed_property_handler_configuration_t;
 
-extern php_v8_indexed_property_handler_configuration_t * php_v8_indexed_property_handler_configuration_fetch_object(zend_object *obj);
+inline php_v8_indexed_property_handler_configuration_t * php_v8_indexed_property_handler_configuration_fetch_object(zend_object *obj);
 
 #define PHP_V8_INDEXED_PROPERTY_HANDLER_FETCH(zv) php_v8_indexed_property_handler_configuration_fetch_object(Z_OBJ_P(zv))
 #define PHP_V8_INDEXED_PROPERTY_HANDLER_FETCH_INTO(pzval, into) php_v8_indexed_property_handler_configuration_t *(into) = PHP_V8_INDEXED_PROPERTY_HANDLER_FETCH((pzval));
@@ -61,6 +61,10 @@ typedef struct _php_v8_indexed_property_handler_configuration_t {
 
     zend_object std;
 } php_v8_indexed_property_handler_configuration_t;
+
+inline php_v8_indexed_property_handler_configuration_t * php_v8_indexed_property_handler_configuration_fetch_object(zend_object *obj) {
+    return (php_v8_indexed_property_handler_configuration_t *)((char *)obj - XtOffsetOf(php_v8_indexed_property_handler_configuration_t, std));
+}
 
 
 PHP_MINIT_FUNCTION(php_v8_indexed_property_handler_configuration);

--- a/src/php_v8_indexed_property_handler_configuration.h
+++ b/src/php_v8_indexed_property_handler_configuration.h
@@ -38,7 +38,7 @@ inline php_v8_indexed_property_handler_configuration_t * php_v8_indexed_property
 
 #define PHP_V8_INDEXED_PROPERTY_HANDLER_FETCH_WITH_CHECK(pzval, into) \
     PHP_V8_INDEXED_PROPERTY_HANDLER_FETCH_INTO(pzval, into); \
-    PHP_V8_CHECK_EMPTY_INDEXED_PROPERTY_HANDLER(into);// TODO: fetch with check
+    PHP_V8_CHECK_EMPTY_INDEXED_PROPERTY_HANDLER(into);
 
 #define PHP_V8_INDEXED_PROPERTY_HANDLER_STORE_ISOLATE(to_zval, from_isolate_zv) zend_update_property(php_v8_indexed_property_handler_configuration_class_entry, (to_zval), ZEND_STRL("isolate"), (from_isolate_zv));
 #define PHP_V8_INDEXED_PROPERTY_HANDLER_READ_ISOLATE(from_zval) zend_read_property(php_v8_indexed_property_handler_configuration_class_entry, (from_zval), ZEND_STRL("isolate"), 0, &rv)

--- a/src/php_v8_int32.cc
+++ b/src/php_v8_int32.cc
@@ -53,8 +53,7 @@ static PHP_METHOD(V8Int32, Value) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
-    v8::Local<v8::Int32> local_number = v8::Local<v8::Int32>::Cast(local_value);
+    v8::Local<v8::Int32> local_number = php_v8_value_get_local_as<v8::Int32>(php_v8_value);
 
     RETVAL_LONG(local_number->Value());
 }

--- a/src/php_v8_integer.cc
+++ b/src/php_v8_integer.cc
@@ -23,10 +23,6 @@
 zend_class_entry *php_v8_integer_class_entry;
 #define this_ce php_v8_integer_class_entry
 
-v8::Local<v8::Integer> php_v8_value_get_integer_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Integer>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-}
-
 
 static PHP_METHOD(V8Integer, __construct) {
     zval *php_v8_isolate_zv;
@@ -62,8 +58,7 @@ static PHP_METHOD(V8Integer, Value) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
-    v8::Local<v8::Integer> local_number = v8::Local<v8::Integer>::Cast(local_value);
+    v8::Local<v8::Integer> local_number = php_v8_value_get_local_as<v8::Integer>(php_v8_value);
 
     RETVAL_LONG(local_number->Value());
 }

--- a/src/php_v8_integer.h
+++ b/src/php_v8_integer.h
@@ -26,7 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_integer_class_entry;
 
-extern v8::Local<v8::Integer> php_v8_value_get_integer_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 
 #define PHP_V8_CHECK_INTEGER_RANGE(val, message) \
     if ((val) > UINT32_MAX || (val) < INT32_MIN) { \

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -360,7 +360,7 @@ static PHP_METHOD(V8Isolate, InContext) {
     RETURN_BOOL(php_v8_isolate->isolate->InContext())
 }
 
-static PHP_METHOD(V8Isolate, GetCurrentContext) {
+static PHP_METHOD(V8Isolate, GetEnteredContext) {
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
@@ -370,8 +370,8 @@ static PHP_METHOD(V8Isolate, GetCurrentContext) {
 
     PHP_V8_ISOLATE_REQUIRE_IN_CONTEXT(isolate);
 
-    v8::Local<v8::Context> local_context = php_v8_isolate->isolate->GetCurrentContext();
-
+    v8::Local<v8::Context> local_context = php_v8_isolate->isolate->GetEnteredContext();
+    
     php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_context);
 
     ZVAL_OBJ(return_value, &php_v8_context->std);
@@ -551,7 +551,7 @@ ZEND_END_ARG_INFO()
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_isolate_InContext, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_isolate_GetCurrentContext, ZEND_RETURN_VALUE, 0, V8\\Context, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_isolate_GetEnteredContext, ZEND_RETURN_VALUE, 0, V8\\Context, 0)
 ZEND_END_ARG_INFO()
 
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_isolate_ThrowException, ZEND_RETURN_VALUE, 1, V8\\Value, 0)
@@ -610,7 +610,7 @@ static const zend_function_entry php_v8_isolate_methods[] = {
         PHP_ME(V8Isolate, GetHeapStatistics, arginfo_v8_isolate_GetHeapStatistics, ZEND_ACC_PUBLIC)
 
         PHP_ME(V8Isolate, InContext, arginfo_v8_isolate_InContext, ZEND_ACC_PUBLIC)
-        PHP_ME(V8Isolate, GetCurrentContext, arginfo_v8_isolate_GetCurrentContext, ZEND_ACC_PUBLIC)
+        PHP_ME(V8Isolate, GetEnteredContext, arginfo_v8_isolate_GetEnteredContext, ZEND_ACC_PUBLIC)
 
         PHP_ME(V8Isolate, ThrowException, arginfo_v8_isolate_ThrowException, ZEND_ACC_PUBLIC)
         PHP_ME(V8Isolate, IdleNotificationDeadline, arginfo_v8_isolate_IdleNotificationDeadline, ZEND_ACC_PUBLIC)

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -401,8 +401,7 @@ static PHP_METHOD(V8Isolate, ThrowException) {
 
     PHP_V8_ISOLATE_REQUIRE_IN_CONTEXT(isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
-
+    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
     v8::Local<v8::Value> local_return_value = isolate->ThrowException(local_value);
 
     /* From v8 source code, Isolate::ThrowException() returns v8::Undefined() */

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -109,10 +109,6 @@ static void php_v8_isolate_free(zend_object *object) {
         delete php_v8_isolate->weak_values;
     }
 
-    if (!Z_ISUNDEF(php_v8_isolate->this_ptr)) {
-        zval_ptr_dtor(&php_v8_isolate->this_ptr);
-    }
-
     if (php_v8_isolate->gc_data) {
         efree(php_v8_isolate->gc_data);
     }
@@ -208,7 +204,6 @@ static PHP_METHOD(V8Isolate, __construct) {
     php_v8_isolate->isolate = v8::Isolate::New(*php_v8_isolate->create_params);
     PHP_V8_ISOLATE_STORE_REFERENCE(php_v8_isolate);
 
-    ZVAL_COPY_VALUE(&php_v8_isolate->this_ptr, getThis());
     php_v8_isolate->isolate_handle = Z_OBJ_HANDLE_P(getThis());
 
     php_v8_isolate->isolate->SetFatalErrorHandler(php_v8_fatal_error_handler);
@@ -379,7 +374,8 @@ static PHP_METHOD(V8Isolate, GetCurrentContext) {
 
     php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_context);
 
-    RETURN_ZVAL(&php_v8_context->this_ptr, 1, 0);
+    ZVAL_OBJ(return_value, &php_v8_context->std);
+    Z_ADDREF_P(return_value);
 }
 
 static PHP_METHOD(V8Isolate, ThrowException) {

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -646,9 +646,10 @@ PHP_MINIT_FUNCTION (php_v8_isolate) {
 
     memcpy(&php_v8_isolate_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_isolate_object_handlers.offset   = XtOffsetOf(php_v8_isolate_t, std);
-    php_v8_isolate_object_handlers.free_obj = php_v8_isolate_free;
-    php_v8_isolate_object_handlers.get_gc   = php_v8_isolate_gc;
+    php_v8_isolate_object_handlers.offset    = XtOffsetOf(php_v8_isolate_t, std);
+    php_v8_isolate_object_handlers.free_obj  = php_v8_isolate_free;
+    php_v8_isolate_object_handlers.get_gc    = php_v8_isolate_gc;
+    php_v8_isolate_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -371,7 +371,7 @@ static PHP_METHOD(V8Isolate, GetEnteredContext) {
     PHP_V8_ISOLATE_REQUIRE_IN_CONTEXT(isolate);
 
     v8::Local<v8::Context> local_context = php_v8_isolate->isolate->GetEnteredContext();
-    
+
     php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_context);
 
     ZVAL_OBJ(return_value, &php_v8_context->std);

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -164,8 +164,6 @@ static void php_v8_fatal_error_handler(const char *location, const char *message
     v8::Isolate *isolate = v8::Isolate::GetCurrent();
     assert(isolate != NULL); // as we set fatal error handler per-isolate, we should always have at least any of them as current one
 
-    // TODO: if there are no entered isolates = fatal error
-
     php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
 
     assert(NULL != php_v8_isolate);

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -46,16 +46,13 @@ static void php_v8_maybe_terminate_execution(php_v8_isolate_t *php_v8_isolate) {
 static inline void php_v8_isolate_destroy(php_v8_isolate_t *php_v8_isolate) {
     if (php_v8_isolate->isolate) {
 
-        // TODO: terminate all executions!
         php_v8_maybe_terminate_execution(php_v8_isolate);
 
         while (php_v8_isolate->isolate->InContext()) {
             v8::Local<v8::Context> context = php_v8_isolate->isolate->GetEnteredContext();
-//            context->GetIsolate()->Exit();
             context->Exit();
         }
 
-        // TODO: exit if entered, TODO: maybe, move it to love above?
         if (php_v8_isolate->isolate == v8::Isolate::GetCurrent()) {
             php_v8_isolate->isolate->Exit();
         }
@@ -144,7 +141,6 @@ static zend_object *php_v8_isolate_ctor(zend_class_entry *ce) {
     zend_object_std_init(&php_v8_isolate->std, ce);
     object_properties_init(&php_v8_isolate->std, ce);
 
-    // TODO: inline? module init?
     php_v8_init();
 
     php_v8_isolate->create_params = new v8::Isolate::CreateParams();
@@ -422,7 +418,7 @@ static PHP_METHOD(V8Isolate, LowMemoryNotification) {
     PHP_V8_ISOLATE_FETCH_WITH_CHECK(getThis(), php_v8_isolate);
     PHP_V8_ENTER_ISOLATE(php_v8_isolate);
 
-    isolate->LowMemoryNotification(); // TODO: for some reason it reports memleak
+    isolate->LowMemoryNotification();
 }
 
 
@@ -460,7 +456,7 @@ static PHP_METHOD(V8Isolate, IsExecutionTerminating) {
     }
 
     PHP_V8_ISOLATE_FETCH_WITH_CHECK(getThis(), php_v8_isolate);
-    PHP_V8_ENTER_ISOLATE(php_v8_isolate); // TODO: can we just fetch isolate object here and do not eneter it?
+    PHP_V8_ENTER_ISOLATE(php_v8_isolate);
 
     RETURN_BOOL(isolate->IsExecutionTerminating());
 }
@@ -471,7 +467,7 @@ static PHP_METHOD(V8Isolate, CancelTerminateExecution) {
     }
 
     PHP_V8_ISOLATE_FETCH_WITH_CHECK(getThis(), php_v8_isolate);
-    PHP_V8_ENTER_ISOLATE(php_v8_isolate); // TODO: can we just fetch isolate object here and do not eneter it?
+    PHP_V8_ENTER_ISOLATE(php_v8_isolate);
 
     isolate->CancelTerminateExecution();
 }
@@ -488,7 +484,7 @@ static PHP_METHOD(V8Isolate, SetCaptureStackTraceForUncaughtExceptions) {
     PHP_V8_CHECK_STACK_TRACE_RANGE(frame_limit, "Frame limit is out of range");
 
     PHP_V8_ISOLATE_FETCH_WITH_CHECK(getThis(), php_v8_isolate);
-    PHP_V8_ENTER_ISOLATE(php_v8_isolate); // TODO: can we just fetch isolate object here and do not eneter it?
+    PHP_V8_ENTER_ISOLATE(php_v8_isolate);
 
     isolate->SetCaptureStackTraceForUncaughtExceptions(static_cast<bool>(capture),
                                                        static_cast<int>(frame_limit),

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -34,9 +34,6 @@ zend_class_entry *php_v8_isolate_class_entry;
 
 static zend_object_handlers php_v8_isolate_object_handlers;
 
-php_v8_isolate_t *php_v8_isolate_fetch_object(zend_object *obj) {
-    return (php_v8_isolate_t *) ((char *) obj - XtOffsetOf(php_v8_isolate_t, std));
-}
 
 static void php_v8_maybe_terminate_execution(php_v8_isolate_t *php_v8_isolate) {
     if (php_v8_isolate->isolate->IsExecutionTerminating()) {

--- a/src/php_v8_isolate.h
+++ b/src/php_v8_isolate.h
@@ -133,7 +133,6 @@ struct _php_v8_isolate_t {
     zval *gc_data;
     int   gc_data_count;
 
-    zval this_ptr;
     zend_object std;
 };
 

--- a/src/php_v8_isolate.h
+++ b/src/php_v8_isolate.h
@@ -31,7 +31,8 @@ extern "C" {
 
 extern zend_class_entry *php_v8_isolate_class_entry;
 
-extern php_v8_isolate_t * php_v8_isolate_fetch_object(zend_object *obj);
+inline php_v8_isolate_t * php_v8_isolate_fetch_object(zend_object *obj);
+inline v8::Local<v8::Private> php_v8_isolate_get_key_local(php_v8_isolate_t *php_v8_isolate);
 
 // TODO: remove or cleanup to use for debug reasons
 #define SX(x) #x
@@ -135,6 +136,10 @@ struct _php_v8_isolate_t {
     zval this_ptr;
     zend_object std;
 };
+
+inline php_v8_isolate_t *php_v8_isolate_fetch_object(zend_object *obj) {
+    return (php_v8_isolate_t *) ((char *) obj - XtOffsetOf(php_v8_isolate_t, std));
+}
 
 inline v8::Local<v8::Private> php_v8_isolate_get_key_local(php_v8_isolate_t *php_v8_isolate) {
     return v8::Local<v8::Private>::New(php_v8_isolate->isolate, php_v8_isolate->key);

--- a/src/php_v8_isolate.h
+++ b/src/php_v8_isolate.h
@@ -57,7 +57,6 @@ inline v8::Local<v8::Private> php_v8_isolate_get_key_local(php_v8_isolate_t *php
     PHP_V8_CHECK_EMPTY_ISOLATE_HANDLER(into);
 
 
-// TODO: cover cases when first and/or second are NULLs
 #define PHP_V8_ISOLATES_CHECK(first, second) if ((first)->isolate != (second)->isolate) { PHP_V8_THROW_EXCEPTION(PHP_V8_ISOLATES_MISMATCH_MSG); return; }
 #define PHP_V8_ISOLATES_CHECK_USING_ISOLATE(first, using_isolate) if ((first)->isolate != (using_isolate)) { PHP_V8_THROW_EXCEPTION(PHP_V8_ISOLATES_MISMATCH_MSG); return; }
 

--- a/src/php_v8_isolate.h
+++ b/src/php_v8_isolate.h
@@ -115,6 +115,7 @@ extern php_v8_isolate_t * php_v8_isolate_fetch_object(zend_object *obj);
     }                                               \
 
 
+
 struct _php_v8_isolate_t {
     v8::Isolate *isolate;
     v8::Isolate::CreateParams *create_params;
@@ -122,6 +123,8 @@ struct _php_v8_isolate_t {
     phpv8::PersistentCollection<v8::FunctionTemplate> *weak_function_templates;
     phpv8::PersistentCollection<v8::ObjectTemplate> *weak_object_templates;
     phpv8::PersistentCollection<v8::Value> *weak_values;
+
+    v8::Persistent<v8::Private> key;
 
     uint32_t isolate_handle;
     php_v8_isolate_limits_t limits;
@@ -133,6 +136,9 @@ struct _php_v8_isolate_t {
     zend_object std;
 };
 
+inline v8::Local<v8::Private> php_v8_isolate_get_key_local(php_v8_isolate_t *php_v8_isolate) {
+    return v8::Local<v8::Private>::New(php_v8_isolate->isolate, php_v8_isolate->key);
+}
 
 PHP_MINIT_FUNCTION(php_v8_isolate);
 

--- a/src/php_v8_isolate_limits.cc
+++ b/src/php_v8_isolate_limits.cc
@@ -183,12 +183,16 @@ void php_v8_isolate_limits_ctor(php_v8_isolate_t *php_v8_isolate) {
 }
 
 void php_v8_isolate_maybe_update_limits_hit(php_v8_isolate_t *php_v8_isolate) {
+    zval isolate_zv;
+
+    ZVAL_OBJ(&isolate_zv, &php_v8_isolate->std);
     PHP_V8_DECLARE_LIMITS(php_v8_isolate);
+
     if (limits->time_limit) {
-        zend_update_property_bool(php_v8_isolate_class_entry, &php_v8_isolate->this_ptr, ZEND_STRL("time_limit_hit"), limits->time_limit_hit);
+        zend_update_property_bool(php_v8_isolate_class_entry, &isolate_zv, ZEND_STRL("time_limit_hit"), limits->time_limit_hit);
     }
     if (limits->memory_limit) {
-        zend_update_property_bool(php_v8_isolate_class_entry, &php_v8_isolate->this_ptr, ZEND_STRL("memory_limit_hit"), limits->memory_limit_hit);
+        zend_update_property_bool(php_v8_isolate_class_entry, &isolate_zv, ZEND_STRL("memory_limit_hit"), limits->memory_limit_hit);
     }
 }
 

--- a/src/php_v8_map.cc
+++ b/src/php_v8_map.cc
@@ -23,9 +23,6 @@
 zend_class_entry *php_v8_map_class_entry;
 #define this_ce php_v8_map_class_entry
 
-v8::Local<v8::Map> php_v8_value_get_map_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Map>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8Map, __construct) {
     zval rv;
@@ -56,7 +53,7 @@ static PHP_METHOD(V8Map, Size) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    RETURN_DOUBLE(php_v8_value_get_map_local(isolate, php_v8_value)->Size());
+    RETURN_DOUBLE(php_v8_value_get_local_as<v8::Map>(php_v8_value)->Size());
 }
 
 static PHP_METHOD(V8Map, Clear) {
@@ -68,7 +65,7 @@ static PHP_METHOD(V8Map, Clear) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    php_v8_value_get_map_local(isolate, php_v8_value)->Clear();
+    php_v8_value_get_local_as<v8::Map>(php_v8_value)->Clear();
 }
 
 static PHP_METHOD(V8Map, Get) {
@@ -87,11 +84,11 @@ static PHP_METHOD(V8Map, Get) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Map> local_map = php_v8_value_get_map_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key = php_v8_value_get_value_local(isolate, php_v8_key);
+    v8::Local<v8::Map> local_map = php_v8_value_get_local_as<v8::Map>(php_v8_value);
+    v8::Local<v8::Value> local_key = php_v8_value_get_local(php_v8_key);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -125,12 +122,12 @@ static PHP_METHOD(V8Map, Set) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_value_value_to_set);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Map> local_map = php_v8_value_get_map_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key = php_v8_value_get_value_local(isolate, php_v8_key);
-    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_value_local(isolate, php_v8_value_value_to_set);
+    v8::Local<v8::Map> local_map = php_v8_value_get_local_as<v8::Map>(php_v8_value);
+    v8::Local<v8::Value> local_key = php_v8_value_get_local(php_v8_key);
+    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_local(php_v8_value_value_to_set);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -159,11 +156,11 @@ static PHP_METHOD(V8Map, Has) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Map> local_map = php_v8_value_get_map_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key = php_v8_value_get_value_local(isolate, php_v8_key);
+    v8::Local<v8::Map> local_map = php_v8_value_get_local_as<v8::Map>(php_v8_value);
+    v8::Local<v8::Value> local_key = php_v8_value_get_local(php_v8_key);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -191,11 +188,11 @@ static PHP_METHOD(V8Map, Delete) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Map> local_map = php_v8_value_get_map_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key = php_v8_value_get_value_local(isolate, php_v8_key);
+    v8::Local<v8::Map> local_map = php_v8_value_get_local_as<v8::Map>(php_v8_value);
+    v8::Local<v8::Value> local_key = php_v8_value_get_local(php_v8_key);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -220,7 +217,7 @@ static PHP_METHOD(V8Map, AsArray) {
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Local<v8::Array> local_array = php_v8_value_get_map_local(isolate, php_v8_value)->AsArray();
+    v8::Local<v8::Array> local_array = php_v8_value_get_local_as<v8::Map>(php_v8_value)->AsArray();
 
     PHP_V8_MAYBE_CATCH(php_v8_value->php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(local_array, "Failed to get property names")

--- a/src/php_v8_map.cc
+++ b/src/php_v8_map.cc
@@ -38,7 +38,6 @@ static PHP_METHOD(V8Map, __construct) {
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_map, "Failed to create Map value");
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_map);
 
     php_v8_value->persistent->Reset(isolate, local_map);
@@ -137,7 +136,7 @@ static PHP_METHOD(V8Map, Set) {
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_local_res, "Failed to set");
 
-    RETVAL_ZVAL(&php_v8_value->this_ptr, 1, 0);
+    ZVAL_COPY(return_value, getThis());
 }
 
 

--- a/src/php_v8_map.cc
+++ b/src/php_v8_map.cc
@@ -42,7 +42,7 @@ static PHP_METHOD(V8Map, __construct) {
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_map, "Failed to create Map value");
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_map, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_map);
 
     php_v8_value->persistent->Reset(isolate, local_map);
 }
@@ -103,7 +103,7 @@ static PHP_METHOD(V8Map, Get) {
 
     v8::Local<v8::Value> local_value =  maybe_local.ToLocalChecked();
 
-    php_v8_get_or_create_value(return_value, local_value, isolate);
+    php_v8_get_or_create_value(return_value, local_value, php_v8_value->php_v8_isolate);
 }
 
 
@@ -225,7 +225,7 @@ static PHP_METHOD(V8Map, AsArray) {
     PHP_V8_MAYBE_CATCH(php_v8_value->php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(local_array, "Failed to get property names")
 
-    php_v8_get_or_create_value(return_value, local_array, isolate);
+    php_v8_get_or_create_value(return_value, local_array, php_v8_value->php_v8_isolate);
 }
 
 

--- a/src/php_v8_map.h
+++ b/src/php_v8_map.h
@@ -26,7 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_map_class_entry;
 
-extern v8::Local<v8::Map> php_v8_value_get_map_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 
 PHP_MINIT_FUNCTION(php_v8_map);
 

--- a/src/php_v8_message.cc
+++ b/src/php_v8_message.cc
@@ -30,7 +30,7 @@ void php_v8_message_create_from_message(zval *return_value, php_v8_isolate_t *ph
     object_init_ex(return_value, this_ce);
 
     v8::Isolate *isolate = php_v8_isolate->isolate;
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Context> context = isolate->GetEnteredContext();
 
     /* v8::Message::Get */
     if (!message->Get().IsEmpty()) {

--- a/src/php_v8_name.cc
+++ b/src/php_v8_name.cc
@@ -22,10 +22,6 @@
 zend_class_entry* php_v8_name_class_entry;
 #define this_ce php_v8_name_class_entry
 
-v8::Local<v8::Name> php_v8_value_get_name_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Name>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
-
 
 static PHP_METHOD(V8Name, GetIdentityHash)
 {
@@ -36,7 +32,7 @@ static PHP_METHOD(V8Name, GetIdentityHash)
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_value);
 
     if (!local_name->IsString() && !local_name->IsSymbol()) {
         RETURN_LONG(0);

--- a/src/php_v8_name.h
+++ b/src/php_v8_name.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_name_class_entry;
 
-extern v8::Local<v8::Name> php_v8_value_get_name_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_name);
 

--- a/src/php_v8_named_property_handler_configuration.cc
+++ b/src/php_v8_named_property_handler_configuration.cc
@@ -23,9 +23,6 @@ zend_class_entry* php_v8_named_property_handler_configuration_class_entry;
 
 static zend_object_handlers php_v8_named_property_handler_configuration_object_handlers;
 
-php_v8_named_property_handler_configuration_t * php_v8_named_property_handler_configuration_fetch_object(zend_object *obj) {
-    return (php_v8_named_property_handler_configuration_t *)((char *)obj - XtOffsetOf(php_v8_named_property_handler_configuration_t, std));
-}
 
 static HashTable * php_v8_named_property_handler_configuration_gc(zval *object, zval **table, int *n) {
     PHP_V8_NAMED_PROPERTY_HANDLER_FETCH_INTO(object, php_v8_handlers);

--- a/src/php_v8_named_property_handler_configuration.cc
+++ b/src/php_v8_named_property_handler_configuration.cc
@@ -148,9 +148,10 @@ PHP_MINIT_FUNCTION(php_v8_named_property_handler_configuration) {
 
     memcpy(&php_v8_named_property_handler_configuration_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_named_property_handler_configuration_object_handlers.offset   = XtOffsetOf(php_v8_named_property_handler_configuration_t, std);
-    php_v8_named_property_handler_configuration_object_handlers.free_obj = php_v8_named_property_handler_configuration_free;
-    php_v8_named_property_handler_configuration_object_handlers.get_gc   = php_v8_named_property_handler_configuration_gc;
+    php_v8_named_property_handler_configuration_object_handlers.offset    = XtOffsetOf(php_v8_named_property_handler_configuration_t, std);
+    php_v8_named_property_handler_configuration_object_handlers.free_obj  = php_v8_named_property_handler_configuration_free;
+    php_v8_named_property_handler_configuration_object_handlers.get_gc    = php_v8_named_property_handler_configuration_gc;
+    php_v8_named_property_handler_configuration_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_named_property_handler_configuration.h
+++ b/src/php_v8_named_property_handler_configuration.h
@@ -28,7 +28,7 @@ extern "C" {
 
 extern zend_class_entry* php_v8_named_property_handler_configuration_class_entry;
 
-extern php_v8_named_property_handler_configuration_t * php_v8_named_property_handler_configuration_fetch_object(zend_object *obj);
+inline php_v8_named_property_handler_configuration_t * php_v8_named_property_handler_configuration_fetch_object(zend_object *obj);
 
 #define PHP_V8_NAMED_PROPERTY_HANDLER_FETCH(zv) php_v8_named_property_handler_configuration_fetch_object(Z_OBJ_P(zv))
 #define PHP_V8_NAMED_PROPERTY_HANDLER_FETCH_INTO(pzval, into) php_v8_named_property_handler_configuration_t *(into) = PHP_V8_NAMED_PROPERTY_HANDLER_FETCH((pzval));
@@ -63,6 +63,10 @@ typedef struct _php_v8_named_property_handler_configuration_t {
 
   zend_object std;
 } php_v8_named_property_handler_configuration_t;
+
+inline php_v8_named_property_handler_configuration_t * php_v8_named_property_handler_configuration_fetch_object(zend_object *obj) {
+    return (php_v8_named_property_handler_configuration_t *)((char *)obj - XtOffsetOf(php_v8_named_property_handler_configuration_t, std));
+}
 
 
 PHP_MINIT_FUNCTION(php_v8_named_property_handler_configuration);

--- a/src/php_v8_number.cc
+++ b/src/php_v8_number.cc
@@ -50,8 +50,7 @@ static PHP_METHOD(V8Number, Value) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
-    v8::Local<v8::Number> local_number = v8::Local<v8::Number>::Cast(local_value);
+    v8::Local<v8::Number> local_number = php_v8_value_get_local_as<v8::Number>(php_v8_value);
 
     RETVAL_DOUBLE(local_number->Value());
 }

--- a/src/php_v8_number_object.cc
+++ b/src/php_v8_number_object.cc
@@ -40,7 +40,6 @@ static PHP_METHOD(V8NumberObject, __construct) {
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_number_obj, "Failed to create NumberObject value");
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_number_obj);
 
     php_v8_value->persistent->Reset(isolate, local_number_obj);

--- a/src/php_v8_number_object.cc
+++ b/src/php_v8_number_object.cc
@@ -44,7 +44,7 @@ static PHP_METHOD(V8NumberObject, __construct) {
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_number_obj, "Failed to create NumberObject value");
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_number_obj, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_number_obj);
 
     php_v8_value->persistent->Reset(isolate, local_number_obj);
 }

--- a/src/php_v8_number_object.cc
+++ b/src/php_v8_number_object.cc
@@ -23,9 +23,6 @@
 zend_class_entry *php_v8_number_object_class_entry;
 #define this_ce php_v8_number_object_class_entry
 
-v8::Local<v8::NumberObject> php_v8_value_get_number_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::NumberObject>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8NumberObject, __construct) {
     zval rv;
@@ -58,7 +55,7 @@ static PHP_METHOD(V8NumberObject, ValueOf) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     //PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    RETURN_DOUBLE(php_v8_value_get_number_object_local(isolate, php_v8_value)->ValueOf());
+    RETURN_DOUBLE(php_v8_value_get_local_as<v8::NumberObject>(php_v8_value)->ValueOf());
 }
 
 

--- a/src/php_v8_number_object.h
+++ b/src/php_v8_number_object.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_number_object_class_entry;
 
-extern v8::Local<v8::NumberObject> php_v8_value_get_number_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_number_object);
 

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -58,7 +58,6 @@ bool php_v8_object_store_self_ptr(php_v8_value_t *php_v8_value, v8::Local<v8::Ob
 {
     assert(NULL != v8::Isolate::GetCurrent());
     assert(v8::Isolate::GetCurrent()->InContext());
-    assert(v8::Isolate::GetCurrent()->GetCurrentContext() == local_object->CreationContext());
 
     v8::Local<v8::Private> key = php_v8_isolate_get_key_local(php_v8_value->php_v8_isolate);
     assert(!key.IsEmpty());
@@ -79,13 +78,8 @@ bool php_v8_object_store_self_ptr(php_v8_value_t *php_v8_value, v8::Local<v8::Ob
 
 php_v8_value_t * php_v8_object_get_self_ptr(php_v8_isolate_t *php_v8_isolate, v8::Local<v8::Object> local_object)
 {
-    //assert(isolate->InContext())
     assert(NULL != v8::Isolate::GetCurrent());
     assert(v8::Isolate::GetCurrent()->InContext());
-    assert(v8::Isolate::GetCurrent()->GetCurrentContext() == local_object->CreationContext());
-
-//    PHP_V8_ISOLATE_ENTER(isolate);
-//    PHP_V8_CONTEXT_ENTER(local_object->CreationContext());
 
     v8::Local<v8::Private> key = php_v8_isolate_get_key_local(php_v8_isolate);
     assert(!key.IsEmpty());
@@ -98,7 +92,8 @@ php_v8_value_t * php_v8_object_get_self_ptr(php_v8_isolate_t *php_v8_isolate, v8
 
     v8::Local<v8::Value> local_value = maybe_local_value.ToLocalChecked();
 
-    //assert(local_value->IsExternal()); // TODO: for some reason this check fails, but value IS external
+    // for some reason this check fails, but value IS external
+    //assert(local_value->IsExternal());
 
     return static_cast<php_v8_value_t *>(local_value.As<v8::External>()->Value());
 }

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -34,9 +34,6 @@ zend_class_entry *php_v8_object_class_entry;
 #define this_ce php_v8_object_class_entry
 
 
-v8::Local<v8::Object> php_v8_value_get_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Object>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 bool php_v8_object_delete_self_ptr(php_v8_value_t *php_v8_value, v8::Local<v8::Object> local_object) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
@@ -157,12 +154,12 @@ static PHP_METHOD(V8Object, Set) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key_or_index);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_value_value_to_set);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_value_local(isolate, php_v8_key_or_index);
-    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_value_local(isolate, php_v8_value_value_to_set);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_local(php_v8_key_or_index);
+    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_local(php_v8_value_value_to_set);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -193,12 +190,12 @@ static PHP_METHOD(V8Object, CreateDataProperty) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key_or_index);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_value_value_to_set);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_key_or_index = php_v8_value_get_name_local(isolate, php_v8_key_or_index);
-    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_value_local(isolate, php_v8_value_value_to_set);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_key_or_index = php_v8_value_get_local_as<v8::Name>(php_v8_key_or_index);
+    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_local(php_v8_value_value_to_set);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -232,13 +229,13 @@ static PHP_METHOD(V8Object, DefineOwnProperty) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_value_value_to_set);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_value_local(isolate, php_v8_value_value_to_set);
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_value_to_set = php_v8_value_get_local(php_v8_value_value_to_set);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_key);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_key);
 
     attributes = attributes ? attributes & PHP_V8_PROPERTY_ATTRIBUTE_FLAGS : attributes;
 
@@ -272,11 +269,11 @@ static PHP_METHOD(V8Object, Get) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key_or_index);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_value_local(isolate, php_v8_key_or_index);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_local(php_v8_key_or_index);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -306,11 +303,11 @@ static PHP_METHOD(V8Object, GetPropertyAttributes) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_string)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::String> local_string = php_v8_value_get_string_local(isolate, php_v8_string);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::String> local_string = php_v8_value_get_local_as<v8::String>(php_v8_string);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -338,11 +335,11 @@ static PHP_METHOD(V8Object, GetOwnPropertyDescriptor) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_string)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::String> local_string = php_v8_value_get_string_local(isolate, php_v8_string);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::String> local_string = php_v8_value_get_local_as<v8::String>(php_v8_string);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -372,11 +369,11 @@ static PHP_METHOD(V8Object, Has) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key_or_index);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_value_local(isolate, php_v8_key_or_index);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_local(php_v8_key_or_index);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -404,11 +401,11 @@ static PHP_METHOD(V8Object, Delete) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key_or_index);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_value_local(isolate, php_v8_key_or_index);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Value> local_key_or_index = php_v8_value_get_local(php_v8_key_or_index);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -452,12 +449,11 @@ static PHP_METHOD(V8Object, SetAccessor) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_CONVERT_FROM_V8_STRING_TO_STRING(name, local_name);
 
@@ -481,7 +477,7 @@ static PHP_METHOD(V8Object, SetAccessor) {
         setter = php_v8_callback_accessor_name_setter;
     }
 
-    v8::Maybe<bool> maybe_res = local_object->SetAccessor(local_context,
+    v8::Maybe<bool> maybe_res = local_object->SetAccessor(context,
                                                           local_name,
                                                           getter,
                                                           setter,
@@ -515,7 +511,7 @@ static PHP_METHOD(V8Object, SetAccessorProperty) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     attributes = attributes ? attributes & PHP_V8_PROPERTY_ATTRIBUTE_FLAGS : attributes;
     settings = settings ? settings & PHP_V8_ACCESS_CONTROL_FLAGS : settings;
@@ -526,16 +522,16 @@ static PHP_METHOD(V8Object, SetAccessorProperty) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getter_zv, php_v8_getter);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_getter, php_v8_value);
 
-    getter = php_v8_value_get_function_local(isolate, php_v8_getter);
+    getter = php_v8_value_get_local_as<v8::Function>(php_v8_getter);
 
     if (Z_TYPE_P(setter_zv) != IS_NULL) {
         PHP_V8_VALUE_FETCH_WITH_CHECK(setter_zv, php_v8_setter);
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_setter, php_v8_value);
 
-        setter = php_v8_value_get_function_local(isolate, php_v8_setter);
+        setter = php_v8_value_get_local_as<v8::Function>(php_v8_setter);
     }
 
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     local_object->SetAccessorProperty(local_name, getter, setter, static_cast<v8::PropertyAttribute>(attributes), static_cast<v8::AccessControl>(settings));
 }
@@ -554,16 +550,15 @@ static PHP_METHOD(V8Object, GetPropertyNames) {
 
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::MaybeLocal<v8::Array> maybe_local_array = local_object->GetPropertyNames(local_context);
+    v8::MaybeLocal<v8::Array> maybe_local_array = local_object->GetPropertyNames(context);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_local_array, "Failed to get property names")
@@ -585,16 +580,15 @@ static PHP_METHOD(V8Object, GetOwnPropertyNames) {
 
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::MaybeLocal<v8::Array> maybe_local_array = local_object->GetOwnPropertyNames(local_context);
+    v8::MaybeLocal<v8::Array> maybe_local_array = local_object->GetOwnPropertyNames(context);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_local_array, "Failed to get own property names")
@@ -613,7 +607,7 @@ static PHP_METHOD(V8Object, GetPrototype) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -641,18 +635,17 @@ static PHP_METHOD(V8Object, SetPrototype) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_prototype);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Value> local_prototype = php_v8_value_get_value_local(isolate, php_v8_prototype);
+    v8::Local<v8::Value> local_prototype = php_v8_value_get_local(php_v8_prototype);
 
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<bool> maybe_res = local_object->SetPrototype(local_context, local_prototype);
+    v8::Maybe<bool> maybe_res = local_object->SetPrototype(context, local_prototype);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to set prototype")
@@ -675,8 +668,8 @@ static PHP_METHOD(V8Object, FindInstanceInPrototypeChain) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::FunctionTemplate> local_function_template = php_v8_function_template_get_local(isolate, php_v8_function_template);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::FunctionTemplate> local_function_template = php_v8_function_template_get_local(php_v8_function_template);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -701,16 +694,15 @@ static PHP_METHOD(V8Object, ObjectProtoToString) {
 
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::MaybeLocal<v8::String> maybe_local_string = local_object->ObjectProtoToString(local_context);
+    v8::MaybeLocal<v8::String> maybe_local_string = local_object->ObjectProtoToString(context);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_local_string, "Failed to get")
@@ -729,7 +721,7 @@ static PHP_METHOD(V8Object, GetConstructorName) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     php_v8_get_or_create_value(return_value, local_object->GetConstructorName(), php_v8_value->php_v8_isolate);
 }
@@ -747,18 +739,17 @@ static PHP_METHOD(V8Object, SetIntegrityLevel) {
 
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     level = level ? level & PHP_V8_INTEGRITY_LEVEL_FLAGS : level;
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<bool> maybe_res = local_obj->SetIntegrityLevel(local_context, static_cast<v8::IntegrityLevel>(level));
+    v8::Maybe<bool> maybe_res = local_obj->SetIntegrityLevel(context, static_cast<v8::IntegrityLevel>(level));
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to set integrity level");
@@ -781,17 +772,16 @@ static PHP_METHOD(V8Object, HasOwnProperty) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<bool> maybe_res = local_object->HasOwnProperty(local_context, local_name);
+    v8::Maybe<bool> maybe_res = local_object->HasOwnProperty(context, local_name);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to perform check");
@@ -814,17 +804,16 @@ static PHP_METHOD(V8Object, HasRealNamedProperty) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<bool> maybe_res = local_object->HasRealNamedProperty(local_context, local_name);
+    v8::Maybe<bool> maybe_res = local_object->HasRealNamedProperty(context, local_name);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to perform check");
@@ -847,16 +836,15 @@ static PHP_METHOD(V8Object, HasRealIndexedProperty) {
 
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_obj = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_obj = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<bool> maybe_res = local_obj->HasRealIndexedProperty(local_context, (uint32_t) index);
+    v8::Maybe<bool> maybe_res = local_obj->HasRealIndexedProperty(context, (uint32_t) index);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to perform check");
@@ -879,17 +867,16 @@ static PHP_METHOD(V8Object, HasRealNamedCallbackProperty) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<bool> maybe_res = local_object->HasRealNamedCallbackProperty(local_context, local_name);
+    v8::Maybe<bool> maybe_res = local_object->HasRealNamedCallbackProperty(context, local_name);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to perform check");
@@ -912,17 +899,16 @@ static PHP_METHOD(V8Object, GetRealNamedPropertyInPrototypeChain) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::MaybeLocal<v8::Value> maybe_res = local_object->GetRealNamedPropertyInPrototypeChain(local_context, local_name);
+    v8::MaybeLocal<v8::Value> maybe_res = local_object->GetRealNamedPropertyInPrototypeChain(context, local_name);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_res, "No real property was located in the prototype chain");
@@ -947,17 +933,16 @@ static PHP_METHOD(V8Object, GetRealNamedPropertyAttributesInPrototypeChain) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<v8::PropertyAttribute> maybe_res = local_object->GetRealNamedPropertyAttributesInPrototypeChain(local_context, local_name);
+    v8::Maybe<v8::PropertyAttribute> maybe_res = local_object->GetRealNamedPropertyAttributesInPrototypeChain(context, local_name);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to get");
@@ -980,14 +965,13 @@ static PHP_METHOD(V8Object, GetRealNamedProperty) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
-    v8::MaybeLocal<v8::Value> maybe_res = local_object->GetRealNamedProperty(local_context, local_name);
+    v8::MaybeLocal<v8::Value> maybe_res = local_object->GetRealNamedProperty(context, local_name);
 
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_res, "No real property was located on the object or in the prototype chain");
 
@@ -1011,17 +995,16 @@ static PHP_METHOD(V8Object, GetRealNamedPropertyAttributes) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context)
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_name)
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Context> local_context = php_v8_context_get_local(isolate, php_v8_context);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Maybe<v8::PropertyAttribute> maybe_res = local_object->GetRealNamedPropertyAttributes(local_context, local_name);
+    v8::Maybe<v8::PropertyAttribute> maybe_res = local_object->GetRealNamedPropertyAttributes(context, local_name);
 
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_NOTHING(maybe_res, "Failed to get property attribute");
@@ -1037,7 +1020,7 @@ static PHP_METHOD(V8Object, HasNamedLookupInterceptor) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
     v8::Local<v8::Object> local_object = v8::Local<v8::Object>::Cast(local_value);
 
     RETURN_BOOL(local_object->HasNamedLookupInterceptor());
@@ -1051,7 +1034,7 @@ static PHP_METHOD(V8Object, HasIndexedLookupInterceptor) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
     v8::Local<v8::Object> local_object = v8::Local<v8::Object>::Cast(local_value);
 
     RETURN_BOOL(local_object->HasIndexedLookupInterceptor());
@@ -1067,7 +1050,7 @@ static PHP_METHOD(V8Object, GetIdentityHash)
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     RETVAL_LONG(local_object->GetIdentityHash());
 }
@@ -1081,7 +1064,7 @@ static PHP_METHOD(V8Object, Clone) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -1102,7 +1085,7 @@ static PHP_METHOD(V8Object, CreationContext) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
     v8::Local<v8::Object> local_object = v8::Local<v8::Object>::Cast(local_value);
 
     v8::Local<v8::Context> local_context= local_object->CreationContext();
@@ -1120,7 +1103,7 @@ static PHP_METHOD(V8Object, IsCallable) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
     v8::Local<v8::Object> local_object = v8::Local<v8::Object>::Cast(local_value);
 
     RETURN_BOOL(local_object->IsCallable());
@@ -1135,7 +1118,7 @@ static PHP_METHOD(V8Object, IsConstructor) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
     v8::Local<v8::Object> local_object = v8::Local<v8::Object>::Cast(local_value);
 
     RETURN_BOOL(local_object->IsConstructor());
@@ -1168,8 +1151,8 @@ static PHP_METHOD(V8Object, CallAsFunction) {
         return;
     }
 
-    v8::Local<v8::Value> local_recv = php_v8_value_get_value_local(isolate, php_v8_value_recv);
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Value> local_recv = php_v8_value_get_local(php_v8_value_recv);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);
@@ -1211,7 +1194,7 @@ static PHP_METHOD(V8Object, CallAsConstructor) {
         return;
     }
 
-    v8::Local<v8::Object> local_object = php_v8_value_get_object_local(isolate, php_v8_value);
+    v8::Local<v8::Object> local_object = php_v8_value_get_local_as<v8::Object>(php_v8_value);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_CONTEXT(php_v8_context);

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -113,7 +113,6 @@ static PHP_METHOD(V8Object, __construct) {
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_object, "Failed to create Object value");
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_object);
 
     php_v8_value->persistent->Reset(isolate, local_object);
@@ -1087,7 +1086,8 @@ static PHP_METHOD(V8Object, CreationContext) {
 
     php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_context);
 
-    RETVAL_ZVAL(&php_v8_context->this_ptr, 1, 0);
+    ZVAL_OBJ(return_value, &php_v8_context->std);
+    Z_ADDREF_P(return_value);
 }
 
 static PHP_METHOD(V8Object, IsCallable) {

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -1189,10 +1189,6 @@ static PHP_METHOD(V8Object, CallAsConstructor) {
     php_v8_get_or_create_value(return_value, local_res, php_v8_value->php_v8_isolate);
 }
 
-// Not supported yet
-//static PHP_METHOD(V8Object, Cast) {
-//}
-
 /* Non-standard, implementations of AdjustableExternalMemoryInterface::AdjustExternalAllocatedMemory */
 static PHP_METHOD(V8Object, AdjustExternalAllocatedMemory) {
     php_v8_ext_mem_interface_value_AdjustExternalAllocatedMemory(INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -1427,9 +1423,6 @@ static const zend_function_entry php_v8_object_methods[] = {
         PHP_ME(V8Object, IsConstructor, arginfo_v8_object_IsConstructor, ZEND_ACC_PUBLIC)
         PHP_ME(V8Object, CallAsFunction, arginfo_v8_object_CallAsFunction, ZEND_ACC_PUBLIC)
         PHP_ME(V8Object, CallAsConstructor, arginfo_v8_object_CallAsConstructor, ZEND_ACC_PUBLIC)
-
-        // NOTE: Not supported yet
-        //PHP_ME(V8Object, Cast, arginfo_v8_object_Cast, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
 
         PHP_ME(V8Object, AdjustExternalAllocatedMemory, arginfo_v8_object_AdjustExternalAllocatedMemory, ZEND_ACC_PUBLIC)
         PHP_ME(V8Object, GetExternalAllocatedMemory, arginfo_v8_object_GetExternalAllocatedMemory, ZEND_ACC_PUBLIC)

--- a/src/php_v8_object.cc
+++ b/src/php_v8_object.cc
@@ -1071,25 +1071,6 @@ static PHP_METHOD(V8Object, Clone) {
     php_v8_get_or_create_value(return_value, local_cloned_object, php_v8_value->php_v8_isolate);
 }
 
-static PHP_METHOD(V8Object, CreationContext) {
-    if (zend_parse_parameters_none() == FAILURE) {
-        return;
-    }
-
-    PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
-    PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
-
-    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
-    v8::Local<v8::Object> local_object = v8::Local<v8::Object>::Cast(local_value);
-
-    v8::Local<v8::Context> local_context= local_object->CreationContext();
-
-    php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_context);
-
-    ZVAL_OBJ(return_value, &php_v8_context->std);
-    Z_ADDREF_P(return_value);
-}
-
 static PHP_METHOD(V8Object, IsCallable) {
     if (zend_parse_parameters_none() == FAILURE) {
         return;
@@ -1377,9 +1358,6 @@ ZEND_END_ARG_INFO()
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_object_Clone, ZEND_RETURN_VALUE, 0, V8\\ObjectValue, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_object_CreationContext, ZEND_RETURN_VALUE, 0, V8\\Context, 0)
-ZEND_END_ARG_INFO()
-
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_object_IsCallable, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
@@ -1444,7 +1422,6 @@ static const zend_function_entry php_v8_object_methods[] = {
         PHP_ME(V8Object, HasIndexedLookupInterceptor, arginfo_v8_object_HasIndexedLookupInterceptor, ZEND_ACC_PUBLIC)
         PHP_ME(V8Object, GetIdentityHash, arginfo_v8_object_GetIdentityHash, ZEND_ACC_PUBLIC)
         PHP_ME(V8Object, Clone, arginfo_v8_object_Clone, ZEND_ACC_PUBLIC)
-        PHP_ME(V8Object, CreationContext, arginfo_v8_object_CreationContext, ZEND_ACC_PUBLIC)
 
         PHP_ME(V8Object, IsCallable, arginfo_v8_object_IsCallable, ZEND_ACC_PUBLIC)
         PHP_ME(V8Object, IsConstructor, arginfo_v8_object_IsConstructor, ZEND_ACC_PUBLIC)

--- a/src/php_v8_object.h
+++ b/src/php_v8_object.h
@@ -14,6 +14,7 @@
 #define PHP_V8_OBJECT_H
 
 #include "php_v8_value.h"
+#include "php_v8_isolate.h"
 #include <v8.h>
 
 extern "C" {
@@ -28,10 +29,9 @@ extern zend_class_entry* php_v8_object_class_entry;
 
 extern v8::Local<v8::Object> php_v8_value_get_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 
-extern bool php_v8_object_delete_self_ptr(v8::Isolate *isolate, v8::Local<v8::Object> local_object);
-extern bool php_v8_object_store_self_ptr(v8::Isolate *isolate, v8::Local<v8::Object> local_object,
-                                         php_v8_value_t *php_v8_value);
-extern php_v8_value_t * php_v8_object_get_self_ptr(v8::Isolate *isolate, v8::Local<v8::Object> local_object);
+extern bool php_v8_object_delete_self_ptr(php_v8_value_t *php_v8_value, v8::Local<v8::Object> local_object);
+extern bool php_v8_object_store_self_ptr(php_v8_value_t *php_v8_value, v8::Local<v8::Object> local_object);
+extern php_v8_value_t * php_v8_object_get_self_ptr(php_v8_isolate_t *php_v8_isolate, v8::Local<v8::Object> local_object);
 
 
 #define PHP_V8_OBJECT_STORE_CONTEXT(to_zval, from_context_zv) zend_update_property(php_v8_object_class_entry, (to_zval), ZEND_STRL("context"), (from_context_zv));

--- a/src/php_v8_object.h
+++ b/src/php_v8_object.h
@@ -27,7 +27,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_object_class_entry;
 
-extern v8::Local<v8::Object> php_v8_value_get_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 
 extern bool php_v8_object_delete_self_ptr(php_v8_value_t *php_v8_value, v8::Local<v8::Object> local_object);
 extern bool php_v8_object_store_self_ptr(php_v8_value_t *php_v8_value, v8::Local<v8::Object> local_object);

--- a/src/php_v8_object_template.cc
+++ b/src/php_v8_object_template.cc
@@ -31,9 +31,6 @@ zend_class_entry *php_v8_object_template_class_entry;
 
 static zend_object_handlers php_v8_object_template_object_handlers;
 
-v8::Local<v8::ObjectTemplate> php_v8_object_template_get_local(v8::Isolate *isolate, php_v8_object_template_t *php_v8_object_template) {
-    return v8::Local<v8::ObjectTemplate>::New(isolate, *php_v8_object_template->persistent);
-}
 
 php_v8_object_template_t * php_v8_object_template_fetch_object(zend_object *obj) {
     return (php_v8_object_template_t *)((char *)obj - XtOffsetOf(php_v8_object_template_t, std));
@@ -147,7 +144,7 @@ static PHP_METHOD(V8ObjectTemplate, __construct) {
         PHP_V8_FETCH_FUNCTION_TEMPLATE_WITH_CHECK(php_v8_function_template_zv, php_v8_function_template);
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_object_template, php_v8_function_template);
 
-        constructor = php_v8_function_template_get_local(isolate, php_v8_function_template);
+        constructor = php_v8_function_template_get_local(php_v8_function_template);
     }
 
     v8::Local<v8::ObjectTemplate> local_obj_tpl = v8::ObjectTemplate::New(isolate, constructor);
@@ -203,7 +200,7 @@ static PHP_METHOD(V8ObjectTemplate, NewInstance) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_object_template);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(isolate, php_v8_object_template);
+    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(php_v8_object_template);
 
     v8::MaybeLocal<v8::Object> maybe_local_obj = local_obj_tpl->NewInstance(context);
 
@@ -242,12 +239,12 @@ static PHP_METHOD(V8ObjectTemplate, SetAccessor) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_object_template);
 
-    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(isolate, php_v8_object_template);
+    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(php_v8_object_template);
 
     attributes = attributes ? attributes & PHP_V8_PROPERTY_ATTRIBUTE_FLAGS : attributes;
     settings = settings ? settings & PHP_V8_ACCESS_CONTROL_FLAGS : settings;
 
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     PHP_V8_CONVERT_FROM_V8_STRING_TO_STRING(name, local_name);
 
@@ -290,7 +287,7 @@ static PHP_METHOD(V8ObjectTemplate, SetHandlerForNamedProperty) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_object_template);
 
-    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(isolate, php_v8_object_template);
+    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(php_v8_object_template);
 
     phpv8::CallbacksBucket *bucket = php_v8_object_template->persistent_data->bucket("named_handlers");
     bucket->reset(php_v8_handlers->bucket);
@@ -322,7 +319,7 @@ static PHP_METHOD(V8ObjectTemplate, SetHandlerForIndexedProperty) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_object_template);
 
-    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(isolate, php_v8_object_template);
+    v8::Local<v8::ObjectTemplate> local_obj_tpl = php_v8_object_template_get_local(php_v8_object_template);
 
     phpv8::CallbacksBucket *bucket = php_v8_object_template->persistent_data->bucket("indexed_handlers");
     bucket->reset(php_v8_handlers->bucket);
@@ -365,7 +362,7 @@ static PHP_METHOD(V8ObjectTemplate, SetCallAsFunctionHandler) {
         callback = php_v8_callback_function;
     }
 
-    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(isolate, php_v8_object_template);
+    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(php_v8_object_template);
 
     local_template->SetCallAsFunctionHandler(callback, data);
 }
@@ -400,7 +397,7 @@ static PHP_METHOD(V8ObjectTemplate, SetAccessCheckCallback) {
     phpv8::CallbacksBucket *bucket = php_v8_object_template->persistent_data->bucket("access_check");
     bucket->add(0, fci_callback, fci_cache_callback);
 
-    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(isolate, php_v8_object_template);
+    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(php_v8_object_template);
 
     local_template->SetAccessCheckCallback(php_v8_callback_access_check, v8::External::New(isolate, bucket));
 }

--- a/src/php_v8_object_template.cc
+++ b/src/php_v8_object_template.cc
@@ -32,10 +32,6 @@ zend_class_entry *php_v8_object_template_class_entry;
 static zend_object_handlers php_v8_object_template_object_handlers;
 
 
-php_v8_object_template_t * php_v8_object_template_fetch_object(zend_object *obj) {
-    return (php_v8_object_template_t *)((char *)obj - XtOffsetOf(php_v8_object_template_t, std));
-}
-
 static void php_v8_object_template_weak_callback(const v8::WeakCallbackInfo<v8::Persistent<v8::ObjectTemplate>> &data) {
     v8::Isolate *isolate = data.GetIsolate();
     php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);

--- a/src/php_v8_object_template.cc
+++ b/src/php_v8_object_template.cc
@@ -531,9 +531,10 @@ PHP_MINIT_FUNCTION (php_v8_object_template) {
 
     memcpy(&php_v8_object_template_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_object_template_object_handlers.offset   = XtOffsetOf(php_v8_object_template_t, std);
-    php_v8_object_template_object_handlers.free_obj = php_v8_object_template_free;
-    php_v8_object_template_object_handlers.get_gc   = php_v8_object_template_gc;
+    php_v8_object_template_object_handlers.offset    = XtOffsetOf(php_v8_object_template_t, std);
+    php_v8_object_template_object_handlers.free_obj  = php_v8_object_template_free;
+    php_v8_object_template_object_handlers.get_gc    = php_v8_object_template_gc;
+    php_v8_object_template_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_object_template.cc
+++ b/src/php_v8_object_template.cc
@@ -211,7 +211,7 @@ static PHP_METHOD(V8ObjectTemplate, NewInstance) {
 
     v8::Local<v8::Object> local_obj = maybe_local_obj.ToLocalChecked();
 
-    php_v8_get_or_create_value(return_value, local_obj, isolate);
+    php_v8_get_or_create_value(return_value, local_obj, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8ObjectTemplate, SetAccessor) {

--- a/src/php_v8_object_template.h
+++ b/src/php_v8_object_template.h
@@ -31,8 +31,9 @@ extern "C" {
 
 extern zend_class_entry* php_v8_object_template_class_entry;
 
-extern v8::Local<v8::ObjectTemplate> php_v8_object_template_get_local(v8::Isolate *isolate, php_v8_object_template_t *php_v8_object_template);
+
 extern php_v8_object_template_t * php_v8_object_template_fetch_object(zend_object *obj);
+
 
 #define PHP_V8_OBJECT_TEMPLATE_FETCH(zv) php_v8_object_template_fetch_object(Z_OBJ_P(zv))
 #define PHP_V8_OBJECT_TEMPLATE_FETCH_INTO(pzval, into) php_v8_object_template_t *(into) = PHP_V8_OBJECT_TEMPLATE_FETCH((pzval));
@@ -69,6 +70,9 @@ struct _php_v8_object_template_t {
     zend_object std;
 };
 
+inline v8::Local<v8::ObjectTemplate> php_v8_object_template_get_local(php_v8_object_template_t *php_v8_object_template) {
+    return v8::Local<v8::ObjectTemplate>::New(php_v8_object_template->php_v8_isolate->isolate, *php_v8_object_template->persistent);
+}
 
 
 PHP_MINIT_FUNCTION(php_v8_object_template);

--- a/src/php_v8_object_template.h
+++ b/src/php_v8_object_template.h
@@ -32,7 +32,7 @@ extern "C" {
 extern zend_class_entry* php_v8_object_template_class_entry;
 
 
-extern php_v8_object_template_t * php_v8_object_template_fetch_object(zend_object *obj);
+inline php_v8_object_template_t * php_v8_object_template_fetch_object(zend_object *obj);
 
 
 #define PHP_V8_OBJECT_TEMPLATE_FETCH(zv) php_v8_object_template_fetch_object(Z_OBJ_P(zv))
@@ -69,6 +69,10 @@ struct _php_v8_object_template_t {
 
     zend_object std;
 };
+
+inline php_v8_object_template_t * php_v8_object_template_fetch_object(zend_object *obj) {
+    return (php_v8_object_template_t *)((char *)obj - XtOffsetOf(php_v8_object_template_t, std));
+}
 
 inline v8::Local<v8::ObjectTemplate> php_v8_object_template_get_local(php_v8_object_template_t *php_v8_object_template) {
     return v8::Local<v8::ObjectTemplate>::New(php_v8_object_template->php_v8_isolate->isolate, *php_v8_object_template->persistent);

--- a/src/php_v8_property_callback_info.cc
+++ b/src/php_v8_property_callback_info.cc
@@ -17,6 +17,7 @@
 #include "php_v8_property_callback_info.h"
 #include "php_v8_callback_info.h"
 #include "php_v8_return_value.h"
+#include "php_v8_value.h"
 #include "php_v8.h"
 
 zend_class_entry *php_v8_property_callback_info_class_entry;
@@ -24,33 +25,35 @@ zend_class_entry *php_v8_property_callback_info_class_entry;
 
 
 template<class T>
-php_v8_callback_info_t *php_v8_callback_info_create_from_info_meta(zval *this_ptr, const v8::PropertyCallbackInfo<T> &info, int accepts);
+php_v8_return_value_t *php_v8_callback_info_create_from_info_meta(zval *return_value, const v8::PropertyCallbackInfo<T> &args, int accepts);
 
 
-php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Value> &info) {
-    return php_v8_callback_info_create_from_info_meta(this_ptr, info, PHP_V8_RETVAL_ACCEPTS_ANY);
+php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Value> &info) {
+    return php_v8_callback_info_create_from_info_meta(return_value, info, PHP_V8_RETVAL_ACCEPTS_ANY);
 }
 
-php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Array> &info) {
-    return php_v8_callback_info_create_from_info_meta(this_ptr, info, PHP_V8_RETVAL_ACCEPTS_ARRAY);
+php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Array> &info) {
+    return php_v8_callback_info_create_from_info_meta(return_value, info, PHP_V8_RETVAL_ACCEPTS_ARRAY);
 }
 
-php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Integer> &info) {
-    return php_v8_callback_info_create_from_info_meta(this_ptr, info, PHP_V8_RETVAL_ACCEPTS_INTEGER);
+php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Integer> &info) {
+    return php_v8_callback_info_create_from_info_meta(return_value, info, PHP_V8_RETVAL_ACCEPTS_INTEGER);
 }
 
-php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Boolean> &info) {
-    return php_v8_callback_info_create_from_info_meta(this_ptr, info, PHP_V8_RETVAL_ACCEPTS_BOOLEAN);
+php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Boolean> &info) {
+    return php_v8_callback_info_create_from_info_meta(return_value, info, PHP_V8_RETVAL_ACCEPTS_BOOLEAN);
 }
 
-php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<void> &info) {
-    return php_v8_callback_info_create_from_info_meta(this_ptr, info, PHP_V8_RETVAL_ACCEPTS_VOID);
+php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<void> &info) {
+    return php_v8_callback_info_create_from_info_meta(return_value, info, PHP_V8_RETVAL_ACCEPTS_VOID);
 }
 
 template<class T>
-php_v8_callback_info_t *php_v8_callback_info_create_from_info_meta(zval *this_ptr, const v8::PropertyCallbackInfo<T> &info, int accepts) {
-    zval retval;
-    v8::Isolate *isolate = info.GetIsolate();
+php_v8_return_value_t *php_v8_callback_info_create_from_info_meta(zval *return_value, const v8::PropertyCallbackInfo<T> &args, int accepts) {
+    zval tmp;
+    php_v8_return_value_t *php_v8_return_value;
+
+    v8::Isolate *isolate = args.GetIsolate();
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
     if (context.IsEmpty()) {
@@ -58,26 +61,55 @@ php_v8_callback_info_t *php_v8_callback_info_create_from_info_meta(zval *this_pt
         return NULL;
     }
 
-    object_init_ex(this_ptr, this_ce);
-    PHP_V8_CALLBACK_INFO_FETCH_INTO(this_ptr, php_v8_callback_info);
+    php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
+    php_v8_context_t *php_v8_context = php_v8_context_get_reference(context);
 
-    php_v8_callback_info->php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);
-    php_v8_callback_info->php_v8_context = php_v8_context_get_reference(context);
+    object_init_ex(return_value, this_ce);
 
-    php_v8_callback_info->this_obj->Reset(isolate, info.This());
-    php_v8_callback_info->holder_obj->Reset(isolate, info.Holder());
+    // common to both callback structures:
+    // isolate
+    ZVAL_OBJ(&tmp, &php_v8_isolate->std);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("isolate"), &tmp);
+    // context
+    ZVAL_OBJ(&tmp, &php_v8_context->std);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("context"), &tmp);
+    // this
+    php_v8_get_or_create_value(&tmp, args.This(), php_v8_isolate);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("this"), &tmp);
+    Z_DELREF(tmp);
+    // holder
+    php_v8_get_or_create_value(&tmp, args.Holder(), php_v8_isolate);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("holder"), &tmp);
+    Z_DELREF(tmp);
+    // return value
+    php_v8_return_value = php_v8_return_value_create_from_return_value(&tmp, php_v8_context, PHP_V8_RETVAL_ACCEPTS_ANY);
+    zend_update_property(php_v8_callback_info_class_entry, return_value, ZEND_STRL("return_value"), &tmp);
+    Z_DELREF(tmp);
 
-    php_v8_callback_info->php_v8_return_value = php_v8_return_value_create_from_return_value(
-            &retval,
-            php_v8_callback_info->php_v8_isolate,
-            php_v8_callback_info->php_v8_context,
-            accepts
-    );
+    // specific to property callback structure:
+    // should_throw_on_error
+    zend_update_property_bool(this_ce, return_value, ZEND_STRL("should_throw_on_error"), static_cast<zend_bool>(args.ShouldThrowOnError()));
 
-    return php_v8_callback_info;
+    return php_v8_return_value;
 }
 
+static PHP_METHOD(PropertyCallbackInfo, ShouldThrowOnError) {
+    zval rv;
+    zval *tmp;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    tmp = zend_read_property(this_ce, getThis(), ZEND_STRL("should_throw_on_error"), 0, &rv);
+    ZVAL_COPY(return_value, tmp);
+}
+
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_property_callback_info_ShouldThrowOnError, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry php_v8_property_callback_info_methods[] = {
+        PHP_ME(PropertyCallbackInfo, ShouldThrowOnError, arginfo_v8_property_callback_info_ShouldThrowOnError, ZEND_ACC_PUBLIC)
         PHP_FE_END
 };
 
@@ -85,6 +117,8 @@ PHP_MINIT_FUNCTION (php_v8_property_callback_info) {
     zend_class_entry ce;
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "PropertyCallbackInfo", php_v8_property_callback_info_methods);
     this_ce = zend_register_internal_class_ex(&ce, php_v8_callback_info_class_entry);
+
+    zend_declare_property_null(this_ce, ZEND_STRL("should_throw_on_error"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/php_v8_property_callback_info.cc
+++ b/src/php_v8_property_callback_info.cc
@@ -54,7 +54,7 @@ php_v8_return_value_t *php_v8_callback_info_create_from_info_meta(zval *return_v
     php_v8_return_value_t *php_v8_return_value;
 
     v8::Isolate *isolate = args.GetIsolate();
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Context> context = isolate->GetEnteredContext();
 
     if (context.IsEmpty()) {
         PHP_V8_THROW_EXCEPTION("Internal exception: no calling context found");

--- a/src/php_v8_property_callback_info.h
+++ b/src/php_v8_property_callback_info.h
@@ -13,6 +13,7 @@
 #ifndef PHP_V8_PROPERTY_CALLBACK_INFO_H
 #define PHP_V8_PROPERTY_CALLBACK_INFO_H
 
+#include "php_v8_return_value.h"
 #include "php_v8_callback_info.h"
 #include <v8.h>
 
@@ -26,11 +27,11 @@ extern "C" {
 
 extern zend_class_entry* php_v8_property_callback_info_class_entry;
 
-extern php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Value> &info);
-extern php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Array> &info);
-extern php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Integer> &info);
-extern php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<v8::Boolean> &info);
-extern php_v8_callback_info_t *php_v8_callback_info_create_from_info(zval *this_ptr, const v8::PropertyCallbackInfo<void> &info);
+extern php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Value> &info);
+extern php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Array> &info);
+extern php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Integer> &info);
+extern php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<v8::Boolean> &info);
+extern php_v8_return_value_t *php_v8_callback_info_create_from_info(zval *return_value, const v8::PropertyCallbackInfo<void> &info);
 
 
 PHP_MINIT_FUNCTION (php_v8_property_callback_info);

--- a/src/php_v8_regexp.cc
+++ b/src/php_v8_regexp.cc
@@ -51,7 +51,6 @@ static PHP_METHOD(V8RegExp, __construct) {
 
     v8::Local<v8::RegExp> local_regexp = maybe_local_regexp.ToLocalChecked();
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_regexp);
 
     php_v8_value->persistent->Reset(isolate, local_regexp);

--- a/src/php_v8_regexp.cc
+++ b/src/php_v8_regexp.cc
@@ -26,9 +26,6 @@ zend_class_entry *php_v8_regexp_flags_class_entry;
 
 #define this_ce php_v8_regexp_class_entry
 
-v8::Local<v8::RegExp> php_v8_value_get_regexp_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::RegExp>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8RegExp, __construct) {
     zval rv;
@@ -44,7 +41,7 @@ static PHP_METHOD(V8RegExp, __construct) {
     PHP_V8_OBJECT_CONSTRUCT(getThis(), php_v8_context_zv, php_v8_context, php_v8_value);
     PHP_V8_VALUE_FETCH_WITH_CHECK(php_v8_string_zv, php_v8_pattern);
 
-    v8::Local<v8::String> local_pattern = php_v8_value_get_string_local(isolate, php_v8_pattern);
+    v8::Local<v8::String> local_pattern = php_v8_value_get_local_as<v8::String>(php_v8_pattern);
 
     flags = flags? flags & PHP_V8_REGEXP_FLAGS : flags;
 
@@ -69,7 +66,7 @@ static PHP_METHOD(V8RegExp, GetSource) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
 
-    v8::Local<v8::String> local_string = php_v8_value_get_regexp_local(isolate, php_v8_value)->GetSource();
+    v8::Local<v8::String> local_string = php_v8_value_get_local_as<v8::RegExp>(php_v8_value)->GetSource();
 
     php_v8_get_or_create_value(return_value, local_string, php_v8_value->php_v8_isolate);
 }
@@ -82,7 +79,7 @@ static PHP_METHOD(V8RegExp, GetFlags) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
 
-    RETURN_LONG(static_cast<long>(php_v8_value_get_regexp_local(isolate, php_v8_value)->GetFlags()));
+    RETURN_LONG(static_cast<long>(php_v8_value_get_local_as<v8::RegExp>(php_v8_value)->GetFlags()));
 }
 
 

--- a/src/php_v8_regexp.cc
+++ b/src/php_v8_regexp.cc
@@ -55,7 +55,7 @@ static PHP_METHOD(V8RegExp, __construct) {
     v8::Local<v8::RegExp> local_regexp = maybe_local_regexp.ToLocalChecked();
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_regexp, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_regexp);
 
     php_v8_value->persistent->Reset(isolate, local_regexp);
 }
@@ -71,7 +71,7 @@ static PHP_METHOD(V8RegExp, GetSource) {
 
     v8::Local<v8::String> local_string = php_v8_value_get_regexp_local(isolate, php_v8_value)->GetSource();
 
-    php_v8_get_or_create_value(return_value, local_string, isolate);
+    php_v8_get_or_create_value(return_value, local_string, php_v8_value->php_v8_isolate);
 }
 
 static PHP_METHOD(V8RegExp, GetFlags) {

--- a/src/php_v8_regexp.h
+++ b/src/php_v8_regexp.h
@@ -27,7 +27,6 @@ extern "C" {
 extern zend_class_entry* php_v8_regexp_class_entry;
 extern zend_class_entry* php_v8_regexp_flags_class_entry;
 
-extern v8::Local<v8::RegExp> php_v8_value_get_regexp_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 
 #define PHP_V8_REGEXP_FLAGS (v8::RegExp::Flags::kNone | v8::RegExp::Flags::kGlobal | v8::RegExp::Flags::kIgnoreCase | v8::RegExp::Flags::kMultiline | v8::RegExp::Flags::kSticky | v8::RegExp::Flags::kUnicode)
 

--- a/src/php_v8_return_value.cc
+++ b/src/php_v8_return_value.cc
@@ -150,7 +150,7 @@ static PHP_METHOD(V8ReturnValue, Set) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(php_v8_value_zv, php_v8_value);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_return_value, php_v8_value);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(php_v8_return_value->php_v8_isolate->isolate, php_v8_value);
+    v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
 
     if (PHP_V8_RETVAL_ACCEPTS_VOID == php_v8_return_value->accepts) {
         PHP_V8_THROW_EXCEPTION("ReturnValue doesn't accept any value");

--- a/src/php_v8_return_value.cc
+++ b/src/php_v8_return_value.cc
@@ -354,7 +354,8 @@ static PHP_METHOD(V8ReturnValue, GetIsolate) {
     PHP_V8_FETCH_RETURN_VALUE_WITH_CHECK(getThis(), php_v8_return_value);
     PHP_V8_RETURN_VALUE_CHECK_IN_CONTEXT(php_v8_return_value);
 
-    RETVAL_ZVAL(&php_v8_return_value->php_v8_isolate->this_ptr, 1, 0);
+    ZVAL_OBJ(return_value, &php_v8_return_value->php_v8_isolate->std);
+    Z_ADDREF_P(return_value);
 }
 
 // Convenience getter for Context
@@ -366,7 +367,8 @@ static PHP_METHOD(V8ReturnValue, GetContext) {
     PHP_V8_FETCH_RETURN_VALUE_WITH_CHECK(getThis(), php_v8_return_value);
     PHP_V8_RETURN_VALUE_CHECK_IN_CONTEXT(php_v8_return_value);
 
-    RETVAL_ZVAL(&php_v8_return_value->php_v8_context->this_ptr, 1, 0);
+    ZVAL_OBJ(return_value, &php_v8_return_value->php_v8_context->std);
+    Z_ADDREF_P(return_value);
 }
 
 static PHP_METHOD(V8ReturnValue, InContext) {

--- a/src/php_v8_return_value.cc
+++ b/src/php_v8_return_value.cc
@@ -133,7 +133,7 @@ static PHP_METHOD(V8ReturnValue, Get) {
 
     v8::Local<v8::Value> local_value = php_v8_return_value_get(php_v8_return_value);
 
-    php_v8_get_or_create_value(return_value, local_value, php_v8_return_value->php_v8_isolate->isolate);
+    php_v8_get_or_create_value(return_value, local_value, php_v8_return_value->php_v8_isolate);
 }
 
 

--- a/src/php_v8_return_value.cc
+++ b/src/php_v8_return_value.cc
@@ -25,9 +25,6 @@ zend_class_entry *php_v8_return_value_class_entry;
 
 static zend_object_handlers php_v8_return_value_object_handlers;
 
-php_v8_return_value_t * php_v8_return_value_fetch_object(zend_object *obj) {
-    return (php_v8_return_value_t *)((char *)obj - XtOffsetOf(php_v8_return_value_t, std));
-}
 
 static void php_v8_return_value_free(zend_object *object) {
 

--- a/src/php_v8_return_value.cc
+++ b/src/php_v8_return_value.cc
@@ -420,8 +420,9 @@ PHP_MINIT_FUNCTION (php_v8_return_value) {
 
     memcpy(&php_v8_return_value_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_return_value_object_handlers.offset   = XtOffsetOf(php_v8_return_value_t, std);
-    php_v8_return_value_object_handlers.free_obj = php_v8_return_value_free;
+    php_v8_return_value_object_handlers.offset    = XtOffsetOf(php_v8_return_value_t, std);
+    php_v8_return_value_object_handlers.free_obj  = php_v8_return_value_free;
+    php_v8_return_value_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_return_value.h
+++ b/src/php_v8_return_value.h
@@ -31,8 +31,8 @@ extern "C" {
 extern zend_class_entry *php_v8_return_value_class_entry;
 
 inline php_v8_return_value_t *php_v8_return_value_fetch_object(zend_object *obj);
-extern php_v8_return_value_t *php_v8_return_value_create_from_return_value(zval *this_ptr, php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, int accepts);
-extern void php_v8_return_value_mark_expired(php_v8_return_value_t *php_v8_return_value);
+extern php_v8_return_value_t * php_v8_return_value_create_from_return_value(zval *return_value, php_v8_context_t *php_v8_context, int accepts);
+inline void php_v8_return_value_mark_expired(php_v8_return_value_t *php_v8_return_value);
 
 
 #define PHP_V8_RETURN_VALUE_FETCH(zv) php_v8_return_value_fetch_object(Z_OBJ_P(zv))
@@ -74,12 +74,15 @@ struct _php_v8_return_value_t {
     v8::ReturnValue<v8::Boolean> *rv_boolean;
     v8::ReturnValue<v8::Array> *rv_array;
 
-    zval this_ptr;
     zend_object std;
 };
 
 inline php_v8_return_value_t * php_v8_return_value_fetch_object(zend_object *obj) {
     return (php_v8_return_value_t *)((char *)obj - XtOffsetOf(php_v8_return_value_t, std));
+}
+
+inline void php_v8_return_value_mark_expired(php_v8_return_value_t *php_v8_return_value) {
+    php_v8_return_value->accepts = PHP_V8_RETVAL_ACCEPTS_INVALID;
 }
 
 

--- a/src/php_v8_return_value.h
+++ b/src/php_v8_return_value.h
@@ -30,9 +30,9 @@ extern "C" {
 
 extern zend_class_entry *php_v8_return_value_class_entry;
 
+inline php_v8_return_value_t *php_v8_return_value_fetch_object(zend_object *obj);
 extern php_v8_return_value_t *php_v8_return_value_create_from_return_value(zval *this_ptr, php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, int accepts);
 extern void php_v8_return_value_mark_expired(php_v8_return_value_t *php_v8_return_value);
-extern php_v8_return_value_t *php_v8_return_value_fetch_object(zend_object *obj);
 
 
 #define PHP_V8_RETURN_VALUE_FETCH(zv) php_v8_return_value_fetch_object(Z_OBJ_P(zv))
@@ -77,6 +77,10 @@ struct _php_v8_return_value_t {
     zval this_ptr;
     zend_object std;
 };
+
+inline php_v8_return_value_t * php_v8_return_value_fetch_object(zend_object *obj) {
+    return (php_v8_return_value_t *)((char *)obj - XtOffsetOf(php_v8_return_value_t, std));
+}
 
 
 PHP_MINIT_FUNCTION (php_v8_return_value);

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -48,7 +48,6 @@ static void php_v8_script_free(zend_object *object)
 {
     php_v8_script_t *php_v8_script = php_v8_script_fetch_object(object);
 
-    // TODO: think about making script weak, it probably may still in use by returned functions from it, isn't it?
     if (php_v8_script->persistent) {
         if (PHP_V8_ISOLATE_HAS_VALID_HANDLE(php_v8_script)) {
             php_v8_script->persistent->Reset();

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -249,8 +249,9 @@ PHP_MINIT_FUNCTION(php_v8_script)
 
     memcpy(&php_v8_script_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_script_object_handlers.offset = XtOffsetOf(php_v8_script_t, std);
-    php_v8_script_object_handlers.free_obj = php_v8_script_free;
+    php_v8_script_object_handlers.offset    = XtOffsetOf(php_v8_script_t, std);
+    php_v8_script_object_handlers.free_obj  = php_v8_script_free;
+    php_v8_script_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -27,10 +27,6 @@ zend_class_entry* php_v8_script_class_entry;
 static zend_object_handlers php_v8_script_object_handlers;
 
 
-php_v8_script_t * php_v8_script_fetch_object(zend_object *obj) {
-    return (php_v8_script_t *)((char *)obj - XtOffsetOf(php_v8_script_t, std));
-}
-
 php_v8_script_t *php_v8_create_script(zval *return_value, v8::Local<v8::Script> local_script, php_v8_context_t *php_v8_context) {
     assert(!local_script.IsEmpty());
 

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -27,10 +27,6 @@ zend_class_entry* php_v8_script_class_entry;
 static zend_object_handlers php_v8_script_object_handlers;
 
 
-v8::Local<v8::Script> php_v8_script_get_local(v8::Isolate *isolate, php_v8_script_t *php_v8_script) {
-    return v8::Local<v8::Script>::New(isolate, *php_v8_script->persistent);
-}
-
 php_v8_script_t * php_v8_script_fetch_object(zend_object *obj) {
     return (php_v8_script_t *)((char *)obj - XtOffsetOf(php_v8_script_t, std));
 }
@@ -122,7 +118,7 @@ static PHP_METHOD(V8Script, __construct)
         }
     }
 
-    v8::Local<v8::String> local_source =  php_v8_value_get_string_local(isolate, php_v8_string);
+    v8::Local<v8::String> local_source =  php_v8_value_get_local_as<v8::String>(php_v8_string);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_SCRIPT(php_v8_script);
@@ -179,7 +175,7 @@ static PHP_METHOD(V8Script, Run)
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_script);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Script> local_script = php_v8_script_get_local(isolate, php_v8_script);
+    v8::Local<v8::Script> local_script = php_v8_script_get_local(php_v8_script);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_SCRIPT(php_v8_script);
@@ -204,7 +200,7 @@ static PHP_METHOD(V8Script, GetUnboundScript)
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_script);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_script);
 
-    v8::Local<v8::Script> local_script = php_v8_script_get_local(isolate, php_v8_script);
+    v8::Local<v8::Script> local_script = php_v8_script_get_local(php_v8_script);
 
     v8::Local<v8::UnboundScript> unbound_script = local_script->GetUnboundScript();
 

--- a/src/php_v8_script.cc
+++ b/src/php_v8_script.cc
@@ -191,7 +191,7 @@ static PHP_METHOD(V8Script, Run)
 
     v8::Local<v8::Value> local_result = result.ToLocalChecked();
 
-    php_v8_get_or_create_value(return_value, local_result, isolate);
+    php_v8_get_or_create_value(return_value, local_result, php_v8_script->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Script, GetUnboundScript)

--- a/src/php_v8_script.h
+++ b/src/php_v8_script.h
@@ -30,7 +30,7 @@ extern "C" {
 
 extern zend_class_entry *php_v8_script_class_entry;
 
-extern php_v8_script_t * php_v8_script_fetch_object(zend_object *obj);
+inline php_v8_script_t * php_v8_script_fetch_object(zend_object *obj);
 extern php_v8_script_t *php_v8_create_script(zval *return_value, v8::Local<v8::Script> local_script, php_v8_context_t *php_v8_context);
 
 #define PHP_V8_FETCH_SCRIPT(zv) php_v8_script_fetch_object(Z_OBJ_P(zv))
@@ -61,6 +61,10 @@ struct _php_v8_script_t {
 
   zend_object std;
 };
+
+inline php_v8_script_t * php_v8_script_fetch_object(zend_object *obj) {
+    return (php_v8_script_t *)((char *)obj - XtOffsetOf(php_v8_script_t, std));
+}
 
 inline v8::Local<v8::Script> php_v8_script_get_local(php_v8_script_t *php_v8_script) {
     return v8::Local<v8::Script>::New(php_v8_script->php_v8_isolate->isolate, *php_v8_script->persistent);

--- a/src/php_v8_script.h
+++ b/src/php_v8_script.h
@@ -30,7 +30,6 @@ extern "C" {
 
 extern zend_class_entry *php_v8_script_class_entry;
 
-extern v8::Local<v8::Script> php_v8_script_get_local(v8::Isolate *isolate, php_v8_script_t *php_v8_script);
 extern php_v8_script_t * php_v8_script_fetch_object(zend_object *obj);
 extern php_v8_script_t *php_v8_create_script(zval *return_value, v8::Local<v8::Script> local_script, php_v8_context_t *php_v8_context);
 
@@ -63,6 +62,9 @@ struct _php_v8_script_t {
   zend_object std;
 };
 
+inline v8::Local<v8::Script> php_v8_script_get_local(php_v8_script_t *php_v8_script) {
+    return v8::Local<v8::Script>::New(php_v8_script->php_v8_isolate->isolate, *php_v8_script->persistent);
+}
 
 PHP_MINIT_FUNCTION(php_v8_script);
 

--- a/src/php_v8_script_compiler.cc
+++ b/src/php_v8_script_compiler.cc
@@ -34,7 +34,7 @@ zend_class_entry* php_v8_script_compiler_class_entry;
 static v8::ScriptCompiler::Source * php_v8_build_source(zval *source_string_zv, zval *origin_zv, zval *cached_data_zv, v8::Isolate *isolate) {
     PHP_V8_VALUE_FETCH_INTO(source_string_zv, php_v8_source_string);
 
-    v8::Local<v8::String> local_source_string = php_v8_value_get_string_local(isolate, php_v8_source_string);
+    v8::Local<v8::String> local_source_string = php_v8_value_get_local_as<v8::String>(php_v8_source_string);
 
     v8::ScriptOrigin *origin = NULL;
 

--- a/src/php_v8_script_compiler.cc
+++ b/src/php_v8_script_compiler.cc
@@ -236,6 +236,14 @@ static PHP_METHOD(V8ScriptCompiler, CompileFunctionInContext)
                                                                   static_cast<size_t>(context_extensions_count),
                                                                   context_extensions);
 
+    if (arguments) {
+        efree(arguments);
+    }
+
+    if (context_extensions) {
+        efree(context_extensions);
+    }
+
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(maybe_function, "Failed to compile function in context");
 

--- a/src/php_v8_script_compiler.cc
+++ b/src/php_v8_script_compiler.cc
@@ -241,7 +241,7 @@ static PHP_METHOD(V8ScriptCompiler, CompileFunctionInContext)
 
     v8::Local<v8::Function> local_function = maybe_function.ToLocalChecked();
 
-    php_v8_get_or_create_value(return_value, local_function, isolate);
+    php_v8_get_or_create_value(return_value, local_function, php_v8_context->php_v8_isolate);
 }
 
 

--- a/src/php_v8_script_compiler.cc
+++ b/src/php_v8_script_compiler.cc
@@ -83,7 +83,7 @@ static PHP_METHOD(V8ScriptCompiler, CompileUnboundScript)
 
     PHP_V8_CHECK_COMPILER_OPTIONS_RANGE(options, "Invalid Script compiler options given. See V8\\ScriptCompiler\\CompileOptions class constants for available options.")
 
-    PHP_V8_CONTEXT_FETCH_INTO(php_v8_context_zv, php_v8_context);
+    PHP_V8_CONTEXT_FETCH_WITH_CHECK(php_v8_context_zv, php_v8_context);
 
     zval *source_string_zv = PHP_V8_SOURCE_READ_SOURCE_STRING(php_v8_source_zv);
     zval *origin_zv        = PHP_V8_SOURCE_READ_ORIGIN(php_v8_source_zv);
@@ -139,7 +139,7 @@ static PHP_METHOD(V8ScriptCompiler, Compile)
 
     PHP_V8_CHECK_COMPILER_OPTIONS_RANGE(options, "Invalid Script compiler options given. See V8\\ScriptCompiler\\CompileOptions class constants for available options.")
 
-    PHP_V8_CONTEXT_FETCH_INTO(php_v8_context_zv, php_v8_context);
+    PHP_V8_CONTEXT_FETCH_WITH_CHECK(php_v8_context_zv, php_v8_context);
 
     zval *source_string_zv = PHP_V8_SOURCE_READ_SOURCE_STRING(php_v8_source_zv);
     zval *origin_zv        = PHP_V8_SOURCE_READ_ORIGIN(php_v8_source_zv);
@@ -199,7 +199,7 @@ static PHP_METHOD(V8ScriptCompiler, CompileFunctionInContext)
         return;
     }
 
-    PHP_V8_CONTEXT_FETCH_INTO(php_v8_context_zv, php_v8_context);
+    PHP_V8_CONTEXT_FETCH_WITH_CHECK(php_v8_context_zv, php_v8_context);
 
     zval *source_string_zv = PHP_V8_SOURCE_READ_SOURCE_STRING(php_v8_source_zv);
     zval *origin_zv        = PHP_V8_SOURCE_READ_ORIGIN(php_v8_source_zv);

--- a/src/php_v8_script_origin.cc
+++ b/src/php_v8_script_origin.cc
@@ -122,7 +122,7 @@ v8::ScriptOrigin *php_v8_create_script_origin_from_zval(zval *value, v8::Isolate
 
     zval *options_zv = zend_read_property(this_ce, value, ZEND_STRL("options"), 0, &rv); // ScriptOriginOptions
 
-    if (Z_TYPE_P(options_zv) == IS_OBJECT) {
+    if (Z_TYPE_P(options_zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(options_zv), php_v8_script_origin_options_class_entry)) {
         zval *is_shared_cross_origin_zv = zend_read_property(php_v8_script_origin_options_class_entry, options_zv, ZEND_STRL("is_shared_cross_origin"), 0, &rv);
         zval *is_opaque_zv = zend_read_property(php_v8_script_origin_options_class_entry, options_zv, ZEND_STRL("is_opaque"), 0, &rv);
         zval *is_wasm_zv = zend_read_property(php_v8_script_origin_options_class_entry, options_zv, ZEND_STRL("is_wasm"), 0, &rv);

--- a/src/php_v8_set.cc
+++ b/src/php_v8_set.cc
@@ -42,7 +42,7 @@ static PHP_METHOD(V8Set, __construct) {
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_set, "Failed to create Map value");
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_set, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_set);
 
     php_v8_value->persistent->Reset(isolate, local_set);
 }
@@ -184,7 +184,7 @@ static PHP_METHOD(V8Set, AsArray) {
     PHP_V8_MAYBE_CATCH(php_v8_value->php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(local_array, "Failed to get property names")
 
-    php_v8_get_or_create_value(return_value, local_array, isolate);
+    php_v8_get_or_create_value(return_value, local_array, php_v8_value->php_v8_isolate);
 }
 
 

--- a/src/php_v8_set.cc
+++ b/src/php_v8_set.cc
@@ -23,9 +23,6 @@
 zend_class_entry *php_v8_set_class_entry;
 #define this_ce php_v8_set_class_entry
 
-v8::Local<v8::Set> php_v8_value_get_set_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Set>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8Set, __construct) {
     zval rv;
@@ -56,7 +53,7 @@ static PHP_METHOD(V8Set, Size) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    RETURN_DOUBLE(php_v8_value_get_set_local(isolate, php_v8_value)->Size());
+    RETURN_DOUBLE(php_v8_value_get_local_as<v8::Set>(php_v8_value)->Size());
 }
 
 static PHP_METHOD(V8Set, Clear) {
@@ -68,7 +65,7 @@ static PHP_METHOD(V8Set, Clear) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    php_v8_value_get_set_local(isolate, php_v8_value)->Clear();
+    php_v8_value_get_local_as<v8::Set>(php_v8_value)->Clear();
 }
 
 static PHP_METHOD(V8Set, Add) {
@@ -86,11 +83,11 @@ static PHP_METHOD(V8Set, Add) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Set> local_set = php_v8_value_get_set_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key = php_v8_value_get_value_local(isolate, php_v8_key);
+    v8::Local<v8::Set> local_set = php_v8_value_get_local_as<v8::Set>(php_v8_value);
+    v8::Local<v8::Value> local_key = php_v8_value_get_local(php_v8_key);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -118,11 +115,11 @@ static PHP_METHOD(V8Set, Has) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Set> local_set = php_v8_value_get_set_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key = php_v8_value_get_value_local(isolate, php_v8_key);
+    v8::Local<v8::Set> local_set = php_v8_value_get_local_as<v8::Set>(php_v8_value);
+    v8::Local<v8::Value> local_key = php_v8_value_get_local(php_v8_key);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -150,11 +147,11 @@ static PHP_METHOD(V8Set, Delete) {
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_context);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_value, php_v8_key);
 
-    PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::Set> local_set = php_v8_value_get_set_local(isolate, php_v8_value);
-    v8::Local<v8::Value> local_key = php_v8_value_get_value_local(isolate, php_v8_key);
+    v8::Local<v8::Set> local_set = php_v8_value_get_local_as<v8::Set>(php_v8_value);
+    v8::Local<v8::Value> local_key = php_v8_value_get_local(php_v8_key);
 
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
@@ -179,7 +176,7 @@ static PHP_METHOD(V8Set, AsArray) {
     PHP_V8_TRY_CATCH(isolate);
     PHP_V8_INIT_ISOLATE_LIMITS_ON_OBJECT_VALUE(php_v8_value);
 
-    v8::Local<v8::Array> local_array = php_v8_value_get_set_local(isolate, php_v8_value)->AsArray();
+    v8::Local<v8::Array> local_array = php_v8_value_get_local_as<v8::Set>(php_v8_value)->AsArray();
 
     PHP_V8_MAYBE_CATCH(php_v8_value->php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(local_array, "Failed to get property names")

--- a/src/php_v8_set.cc
+++ b/src/php_v8_set.cc
@@ -38,7 +38,6 @@ static PHP_METHOD(V8Set, __construct) {
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_set, "Failed to create Map value");
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_set);
 
     php_v8_value->persistent->Reset(isolate, local_set);
@@ -97,7 +96,7 @@ static PHP_METHOD(V8Set, Add) {
     PHP_V8_MAYBE_CATCH(php_v8_context, try_catch);
     PHP_V8_THROW_EXCEPTION_WHEN_EMPTY(maybe_local_res, "Failed to add");
 
-    RETVAL_ZVAL(&php_v8_value->this_ptr, 1, 0);
+    ZVAL_COPY(return_value, getThis());
 }
 
 static PHP_METHOD(V8Set, Has) {

--- a/src/php_v8_set.h
+++ b/src/php_v8_set.h
@@ -26,7 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_set_class_entry;
 
-extern v8::Local<v8::Set> php_v8_value_get_set_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 
 PHP_MINIT_FUNCTION(php_v8_set);
 

--- a/src/php_v8_source.cc
+++ b/src/php_v8_source.cc
@@ -39,6 +39,7 @@ void php_v8_update_source_cached_data(zval *src_zv, v8::ScriptCompiler::Source *
     php_v8_create_cached_data(&tmp, source->GetCachedData());
 
     zend_update_property(this_ce, src_zv, ZEND_STRL("cached_data"), &tmp);
+    Z_DELREF(tmp);
 }
 
 static PHP_METHOD(V8Source, __construct)

--- a/src/php_v8_stack_trace.cc
+++ b/src/php_v8_stack_trace.cc
@@ -53,7 +53,7 @@ void php_v8_stack_trace_create_from_stack_trace(zval *return_value, php_v8_isola
     /* v8::StackTrace::AsArray */
     zval as_array_zv;
     v8::Local<v8::Array> local_frames_array_v8 = trace->AsArray();
-    php_v8_get_or_create_value(&as_array_zv, local_frames_array_v8, isolate);
+    php_v8_get_or_create_value(&as_array_zv, local_frames_array_v8, php_v8_isolate);
     zend_update_property(this_ce, return_value, ZEND_STRL("as_array"), &as_array_zv);
     zval_ptr_dtor(&as_array_zv);
 }

--- a/src/php_v8_startup_data.cc
+++ b/src/php_v8_startup_data.cc
@@ -169,8 +169,9 @@ PHP_MINIT_FUNCTION (php_v8_startup_data) {
 
     memcpy(&php_v8_startup_data_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_startup_data_object_handlers.offset   = XtOffsetOf(php_v8_startup_data_t, std);
-    php_v8_startup_data_object_handlers.free_obj = php_v8_startup_data_free;
+    php_v8_startup_data_object_handlers.offset    = XtOffsetOf(php_v8_startup_data_t, std);
+    php_v8_startup_data_object_handlers.free_obj  = php_v8_startup_data_free;
+    php_v8_startup_data_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_startup_data.cc
+++ b/src/php_v8_startup_data.cc
@@ -115,8 +115,8 @@ static PHP_METHOD(V8StartupData, CreateFromSource) {
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &blob) == FAILURE) {
         return;
     }
+
     /* we can't try-catch here while we have no isolate yet */
-    // TODO: test to create blob from invalid source
 
     const char *source = ZSTR_VAL(blob);
     php_v8_init();

--- a/src/php_v8_startup_data.cc
+++ b/src/php_v8_startup_data.cc
@@ -26,10 +26,6 @@ zend_class_entry *php_v8_startup_data_class_entry;
 static zend_object_handlers php_v8_startup_data_object_handlers;
 
 
-php_v8_startup_data_t * php_v8_startup_data_fetch_object(zend_object *obj) {
-    return (php_v8_startup_data_t *) ((char *) obj - XtOffsetOf(php_v8_startup_data_t, std));
-}
-
 void php_v8_startup_data_create(zval *return_value, v8::StartupData *blob) {
     object_init_ex(return_value, this_ce);
 

--- a/src/php_v8_startup_data.h
+++ b/src/php_v8_startup_data.h
@@ -27,7 +27,7 @@ extern "C" {
 
 extern zend_class_entry* php_v8_stack_frame_class_entry;
 
-extern php_v8_startup_data_t * php_v8_startup_data_fetch_object(zend_object *obj);
+inline php_v8_startup_data_t * php_v8_startup_data_fetch_object(zend_object *obj);
 
 #define PHP_V8_STARTUP_DATA_FETCH(zv) php_v8_startup_data_fetch_object(Z_OBJ_P(zv))
 #define PHP_V8_STARTUP_DATA_FETCH_INTO(pzval, into) php_v8_startup_data_t *(into) = PHP_V8_STARTUP_DATA_FETCH((pzval))
@@ -38,6 +38,9 @@ struct _php_v8_startup_data_t {
     zend_object std;
 };
 
+inline php_v8_startup_data_t * php_v8_startup_data_fetch_object(zend_object *obj) {
+    return (php_v8_startup_data_t *) ((char *) obj - XtOffsetOf(php_v8_startup_data_t, std));
+}
 
 PHP_MINIT_FUNCTION(php_v8_startup_data);
 

--- a/src/php_v8_string.cc
+++ b/src/php_v8_string.cc
@@ -22,10 +22,6 @@
 zend_class_entry* php_v8_string_class_entry;
 #define this_ce php_v8_string_class_entry
 
-v8::Local<v8::String> php_v8_value_get_string_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::String>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
-
 
 static PHP_METHOD(V8String, __construct) {
     zval *php_v8_isolate_zv;
@@ -61,7 +57,7 @@ static PHP_METHOD(V8String, Value)
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> str_tpl = php_v8_value_get_value_local(isolate, php_v8_value);
+    v8::Local<v8::Value> str_tpl = php_v8_value_get_local(php_v8_value);
 
     v8::String::Utf8Value str(str_tpl);
 
@@ -80,7 +76,7 @@ static PHP_METHOD(V8String, Length)
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_string_local(isolate, php_v8_value);
+    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_local_as<v8::String>(php_v8_value);
 
     RETVAL_LONG(str_tpl_checked->Length());
 }
@@ -95,7 +91,7 @@ static PHP_METHOD(V8String, Utf8Length)
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_string_local(isolate, php_v8_value);
+    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_local_as<v8::String>(php_v8_value);
 
     RETVAL_LONG(str_tpl_checked->Utf8Length());
 }
@@ -110,7 +106,7 @@ static PHP_METHOD(V8String, IsOneByte)
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_string_local(isolate, php_v8_value);
+    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_local_as<v8::String>(php_v8_value);
 
     RETVAL_BOOL(str_tpl_checked->IsOneByte());
 }
@@ -125,7 +121,7 @@ static PHP_METHOD(V8String, ContainsOnlyOneByte)
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_string_local(isolate, php_v8_value);
+    v8::Local<v8::String> str_tpl_checked = php_v8_value_get_local_as<v8::String>(php_v8_value);
 
     RETVAL_BOOL(str_tpl_checked->ContainsOnlyOneByte());
 }

--- a/src/php_v8_string.h
+++ b/src/php_v8_string.h
@@ -28,7 +28,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_string_class_entry;
 
-extern v8::Local<v8::String> php_v8_value_get_string_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 
 #define MAYBE_ZSTR_VAL(zstr) ((zstr) ? ZSTR_VAL(zstr) : "")
 #define MAYBE_ZSTR_LEN(zstr) ((zstr) ? ZSTR_LEN(zstr) : 0)

--- a/src/php_v8_string_object.cc
+++ b/src/php_v8_string_object.cc
@@ -43,7 +43,6 @@ static PHP_METHOD(V8StringObject, __construct) {
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_string_obj, "Failed to create StringObject value");
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_string_obj);
 
     php_v8_value->persistent->Reset(isolate, local_string_obj);

--- a/src/php_v8_string_object.cc
+++ b/src/php_v8_string_object.cc
@@ -24,9 +24,6 @@
 zend_class_entry *php_v8_string_object_class_entry;
 #define this_ce php_v8_string_object_class_entry
 
-v8::Local<v8::StringObject> php_v8_value_get_string_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::StringObject>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
 
 static PHP_METHOD(V8StringObject, __construct) {
     zval rv;
@@ -41,7 +38,7 @@ static PHP_METHOD(V8StringObject, __construct) {
 
     PHP_V8_VALUE_FETCH_WITH_CHECK(php_v8_string_zv, php_v8_value_to_set);
 
-    v8::Local<v8::String> local_string = php_v8_value_get_string_local(isolate, php_v8_value_to_set);
+    v8::Local<v8::String> local_string = php_v8_value_get_local_as<v8::String>(php_v8_value_to_set);
     v8::Local<v8::StringObject> local_string_obj = v8::StringObject::New(local_string).As<v8::StringObject>();
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_string_obj, "Failed to create StringObject value");
@@ -60,7 +57,7 @@ static PHP_METHOD(V8StringObject, ValueOf) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
 
-    v8::Local<v8::String> local_string = php_v8_value_get_string_object_local(isolate, php_v8_value)->ValueOf();
+    v8::Local<v8::String> local_string = php_v8_value_get_local_as<v8::StringObject>(php_v8_value)->ValueOf();
 
     php_v8_get_or_create_value(return_value, local_string, php_v8_value->php_v8_isolate);
 }

--- a/src/php_v8_string_object.cc
+++ b/src/php_v8_string_object.cc
@@ -47,7 +47,7 @@ static PHP_METHOD(V8StringObject, __construct) {
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_string_obj, "Failed to create StringObject value");
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_string_obj, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_string_obj);
 
     php_v8_value->persistent->Reset(isolate, local_string_obj);
 }
@@ -59,11 +59,10 @@ static PHP_METHOD(V8StringObject, ValueOf) {
 
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
-    //PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
     v8::Local<v8::String> local_string = php_v8_value_get_string_object_local(isolate, php_v8_value)->ValueOf();
 
-    php_v8_get_or_create_value(return_value, local_string, isolate);
+    php_v8_get_or_create_value(return_value, local_string, php_v8_value->php_v8_isolate);
 }
 
 

--- a/src/php_v8_string_object.h
+++ b/src/php_v8_string_object.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_string_object_class_entry;
 
-extern v8::Local<v8::StringObject> php_v8_value_get_string_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_string_object);
 

--- a/src/php_v8_symbol.cc
+++ b/src/php_v8_symbol.cc
@@ -23,10 +23,6 @@
 zend_class_entry* php_v8_symbol_class_entry;
 #define this_ce php_v8_symbol_class_entry
 
-v8::Local<v8::Symbol> php_v8_value_get_symbol_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::Symbol>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
-
 
 static PHP_METHOD(V8Symbol, __construct) {
     zval *php_v8_isolate_zv;
@@ -44,7 +40,7 @@ static PHP_METHOD(V8Symbol, __construct) {
         PHP_V8_VALUE_FETCH_WITH_CHECK(php_v8_string_zv, php_v8_string);
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_string, php_v8_value);
 
-        local_name = php_v8_value_get_string_local(isolate, php_v8_string);
+        local_name = php_v8_value_get_local_as<v8::String>(php_v8_string);
     }
 
     v8::Local<v8::Symbol> local_symbol = v8::Symbol::New(isolate, local_name);
@@ -66,7 +62,7 @@ static PHP_METHOD(V8Symbol, Name)
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
 
-    v8::Local<v8::Symbol> local_symbol = php_v8_value_get_symbol_local(isolate, php_v8_value);
+    v8::Local<v8::Symbol> local_symbol = php_v8_value_get_local_as<v8::Symbol>(php_v8_value);
     v8::Local<v8::Value> local_name = local_symbol->Name();
 
     php_v8_get_or_create_value(return_value, local_name, php_v8_value->php_v8_isolate);
@@ -88,7 +84,7 @@ static PHP_METHOD(V8Symbol, For)
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::String> local_string = php_v8_value_get_string_local(isolate, php_v8_value);
+    v8::Local<v8::String> local_string = php_v8_value_get_local_as<v8::String>(php_v8_value);
     v8::Local<v8::Symbol> local_symbol = v8::Symbol::For(isolate, local_string);
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
@@ -112,7 +108,7 @@ static PHP_METHOD(V8Symbol, ForApi)
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::String> local_string = php_v8_value_get_string_local(isolate, php_v8_value);
+    v8::Local<v8::String> local_string = php_v8_value_get_local_as<v8::String>(php_v8_value);
     v8::Local<v8::Symbol> local_symbol = v8::Symbol::ForApi(isolate, local_string);
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");

--- a/src/php_v8_symbol.cc
+++ b/src/php_v8_symbol.cc
@@ -69,7 +69,7 @@ static PHP_METHOD(V8Symbol, Name)
     v8::Local<v8::Symbol> local_symbol = php_v8_value_get_symbol_local(isolate, php_v8_value);
     v8::Local<v8::Value> local_name = local_symbol->Name();
 
-    php_v8_get_or_create_value(return_value, local_name, isolate);
+    php_v8_get_or_create_value(return_value, local_name, php_v8_value->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Symbol, For)
@@ -93,7 +93,7 @@ static PHP_METHOD(V8Symbol, For)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Symbol, ForApi)
@@ -117,7 +117,7 @@ static PHP_METHOD(V8Symbol, ForApi)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_context->php_v8_isolate);
 }
 
 static PHP_METHOD(V8Symbol, GetIterator)
@@ -135,7 +135,7 @@ static PHP_METHOD(V8Symbol, GetIterator)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_isolate);
 }
 
 static PHP_METHOD(V8Symbol, GetUnscopables)
@@ -153,7 +153,7 @@ static PHP_METHOD(V8Symbol, GetUnscopables)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_isolate);
 }
 
 static PHP_METHOD(V8Symbol, GetToPrimitive)
@@ -171,7 +171,7 @@ static PHP_METHOD(V8Symbol, GetToPrimitive)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_isolate);
 }
 
 static PHP_METHOD(V8Symbol, GetToStringTag)
@@ -189,7 +189,7 @@ static PHP_METHOD(V8Symbol, GetToStringTag)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_isolate);
 }
 
 static PHP_METHOD(V8Symbol, GetIsConcatSpreadable)
@@ -207,7 +207,7 @@ static PHP_METHOD(V8Symbol, GetIsConcatSpreadable)
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol, "Failed to create Symbol value");
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_isolate);
 }
 
 

--- a/src/php_v8_symbol.h
+++ b/src/php_v8_symbol.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_symbol_class_entry;
 
-extern v8::Local<v8::Symbol> php_v8_value_get_symbol_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_symbol);
 

--- a/src/php_v8_symbol_object.cc
+++ b/src/php_v8_symbol_object.cc
@@ -24,10 +24,6 @@
 zend_class_entry *php_v8_symbol_object_class_entry;
 #define this_ce php_v8_symbol_object_class_entry
 
-v8::Local<v8::SymbolObject> php_v8_value_get_symbol_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value) {
-    return v8::Local<v8::SymbolObject>::Cast(php_v8_value_get_value_local(isolate, php_v8_value));
-};
-
 static PHP_METHOD(V8SymbolObject, __construct) {
     zval rv;
     zval *php_v8_context_zv;
@@ -41,7 +37,7 @@ static PHP_METHOD(V8SymbolObject, __construct) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(php_v8_symbol_zv, php_v8_value_to_set);
     PHP_V8_DATA_ISOLATES_CHECK(php_v8_context, php_v8_value_to_set);
 
-    v8::Local<v8::Symbol> local_symbol = php_v8_value_get_symbol_local(isolate, php_v8_value_to_set);
+    v8::Local<v8::Symbol> local_symbol = php_v8_value_get_local_as<v8::Symbol>(php_v8_value_to_set);
 
     v8::Local<v8::SymbolObject> local_symbol_obj = v8::SymbolObject::New(isolate, local_symbol).As<v8::SymbolObject>();
 
@@ -62,7 +58,7 @@ static PHP_METHOD(V8SymbolObject, ValueOf) {
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_value);
     PHP_V8_ENTER_STORED_CONTEXT(php_v8_value);
 
-    v8::Local<v8::Symbol> local_symbol = php_v8_value_get_symbol_object_local(isolate, php_v8_value)->ValueOf();
+    v8::Local<v8::Symbol> local_symbol = php_v8_value_get_local_as<v8::SymbolObject>(php_v8_value)->ValueOf();
 
     php_v8_get_or_create_value(return_value, local_symbol, php_v8_value->php_v8_isolate);
 }

--- a/src/php_v8_symbol_object.cc
+++ b/src/php_v8_symbol_object.cc
@@ -43,7 +43,6 @@ static PHP_METHOD(V8SymbolObject, __construct) {
 
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol_obj, "Failed to create SymbolObject value");
 
-    ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
     php_v8_object_store_self_ptr(php_v8_value, local_symbol_obj);
 
     php_v8_value->persistent->Reset(isolate, local_symbol_obj);

--- a/src/php_v8_symbol_object.cc
+++ b/src/php_v8_symbol_object.cc
@@ -48,7 +48,7 @@ static PHP_METHOD(V8SymbolObject, __construct) {
     PHP_V8_THROW_VALUE_EXCEPTION_WHEN_EMPTY(local_symbol_obj, "Failed to create SymbolObject value");
 
     ZVAL_COPY_VALUE(&php_v8_value->this_ptr, getThis());
-    php_v8_object_store_self_ptr(isolate, local_symbol_obj, php_v8_value);
+    php_v8_object_store_self_ptr(php_v8_value, local_symbol_obj);
 
     php_v8_value->persistent->Reset(isolate, local_symbol_obj);
 }
@@ -64,7 +64,7 @@ static PHP_METHOD(V8SymbolObject, ValueOf) {
 
     v8::Local<v8::Symbol> local_symbol = php_v8_value_get_symbol_object_local(isolate, php_v8_value)->ValueOf();
 
-    php_v8_get_or_create_value(return_value, local_symbol, isolate);
+    php_v8_get_or_create_value(return_value, local_symbol, php_v8_value->php_v8_isolate);
 }
 
 

--- a/src/php_v8_symbol_object.h
+++ b/src/php_v8_symbol_object.h
@@ -26,8 +26,6 @@ extern "C" {
 
 extern zend_class_entry* php_v8_symbol_object_class_entry;
 
-extern v8::Local<v8::SymbolObject> php_v8_value_get_symbol_object_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
-
 
 PHP_MINIT_FUNCTION(php_v8_symbol_object);
 

--- a/src/php_v8_template.cc
+++ b/src/php_v8_template.cc
@@ -306,7 +306,6 @@ PHP_MINIT_FUNCTION (php_v8_template) {
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, PHP_V8_NS, "Template", php_v8_template_methods);
-    //zend_class_implements()
     this_ce = zend_register_internal_class_ex(&ce, php_v8_data_class_entry);
 
     zend_declare_property_null(this_ce, ZEND_STRL("isolate"), ZEND_ACC_PRIVATE);

--- a/src/php_v8_template.cc
+++ b/src/php_v8_template.cc
@@ -39,7 +39,7 @@ void php_v8_object_template_Set(INTERNAL_FUNCTION_PARAMETERS) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_template);
 
-    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(isolate, php_v8_template);
+    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(php_v8_template);
 
     php_v8_template_Set(isolate, local_template, php_v8_template, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -50,7 +50,7 @@ void php_v8_function_template_Set(INTERNAL_FUNCTION_PARAMETERS)
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_template);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_template);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_template);
 
     php_v8_template_Set(isolate, local_template, php_v8_template, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -61,7 +61,7 @@ void php_v8_object_template_SetAccessorProperty(INTERNAL_FUNCTION_PARAMETERS) {
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_template);
 
-    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(isolate, php_v8_template);
+    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(php_v8_template);
 
     php_v8_template_SetAccessorProperty(isolate, local_template, php_v8_template, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -72,7 +72,7 @@ void php_v8_function_template_SetAccessorProperty(INTERNAL_FUNCTION_PARAMETERS)
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_template);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_template);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_template);
 
     php_v8_template_SetAccessorProperty(isolate, local_template, php_v8_template, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -84,7 +84,7 @@ void php_v8_object_template_SetNativeDataProperty(INTERNAL_FUNCTION_PARAMETERS) 
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_template);
 
-    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(isolate, php_v8_template);
+    v8::Local<v8::ObjectTemplate> local_template = php_v8_object_template_get_local(php_v8_template);
 
     php_v8_template_SetNativeDataProperty(isolate, local_template, php_v8_template, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -95,7 +95,7 @@ void php_v8_function_template_SetNativeDataProperty(INTERNAL_FUNCTION_PARAMETERS
 
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_template);
 
-    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(isolate, php_v8_template);
+    v8::Local<v8::FunctionTemplate> local_template = php_v8_function_template_get_local(php_v8_template);
 
     php_v8_template_SetNativeDataProperty(isolate, local_template, php_v8_template, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
@@ -133,7 +133,7 @@ void php_v8_template_Set(v8::Isolate *isolate, v8::Local<T> local_template, N* p
 
     attributes = attributes ? attributes & PHP_V8_PROPERTY_ATTRIBUTE_FLAGS : attributes;
 
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     if (instanceof_function(Z_OBJCE_P(php_v8_value_zv), php_v8_value_class_entry)) {
         // set persistent
@@ -141,7 +141,7 @@ void php_v8_template_Set(v8::Isolate *isolate, v8::Local<T> local_template, N* p
 
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_template, php_v8_value_to_set);
 
-        local_template->Set(local_name, php_v8_value_get_value_local(isolate, php_v8_value_to_set), static_cast<v8::PropertyAttribute>(attributes));
+        local_template->Set(local_name, php_v8_value_get_local(php_v8_value_to_set), static_cast<v8::PropertyAttribute>(attributes));
     } else if (instanceof_function(Z_OBJCE_P(php_v8_value_zv), php_v8_object_template_class_entry)) {
         // set object template
         PHP_V8_FETCH_OBJECT_TEMPLATE_WITH_CHECK(php_v8_value_zv, php_v8_object_template_to_set);
@@ -149,7 +149,7 @@ void php_v8_template_Set(v8::Isolate *isolate, v8::Local<T> local_template, N* p
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_template, php_v8_object_template_to_set);
 
         if (php_v8_template_node_set(php_v8_template, php_v8_object_template_to_set)) {
-            local_template->Set(local_name, php_v8_object_template_get_local(isolate, php_v8_object_template_to_set), static_cast<v8::PropertyAttribute>(attributes));
+            local_template->Set(local_name, php_v8_object_template_get_local(php_v8_object_template_to_set), static_cast<v8::PropertyAttribute>(attributes));
         }
 
     } else if (instanceof_function(Z_OBJCE_P(php_v8_value_zv), php_v8_function_template_class_entry)) {
@@ -159,7 +159,7 @@ void php_v8_template_Set(v8::Isolate *isolate, v8::Local<T> local_template, N* p
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_template, php_v8_function_template_to_set);
 
         if (php_v8_template_node_set(php_v8_template, php_v8_function_template_to_set)) {
-            local_template->Set(local_name, php_v8_function_template_get_local(isolate, php_v8_function_template_to_set), static_cast<v8::PropertyAttribute>(attributes));
+            local_template->Set(local_name, php_v8_function_template_get_local(php_v8_function_template_to_set), static_cast<v8::PropertyAttribute>(attributes));
         }
     } else {
         // should never get here
@@ -187,7 +187,7 @@ void php_v8_template_SetAccessorProperty(v8::Isolate *isolate, v8::Local<T> loca
     attributes = attributes ? attributes & PHP_V8_PROPERTY_ATTRIBUTE_FLAGS : attributes;
     settings = settings ? settings & PHP_V8_ACCESS_CONTROL_FLAGS : settings;
 
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
 
     v8::Local<v8::FunctionTemplate> getter;
@@ -199,7 +199,7 @@ void php_v8_template_SetAccessorProperty(v8::Isolate *isolate, v8::Local<T> loca
 
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_template, php_v8_getter);
 
-        getter = php_v8_function_template_get_local(isolate, php_v8_getter);
+        getter = php_v8_function_template_get_local(php_v8_getter);
     }
 
     if (Z_TYPE_P(setter_zv) != IS_NULL) {
@@ -208,7 +208,7 @@ void php_v8_template_SetAccessorProperty(v8::Isolate *isolate, v8::Local<T> loca
 
         PHP_V8_DATA_ISOLATES_CHECK(php_v8_template, php_v8_setter);
 
-        setter = php_v8_function_template_get_local(isolate, php_v8_setter);
+        setter = php_v8_function_template_get_local(php_v8_setter);
     }
 
     local_template->SetAccessorProperty(local_name, getter, setter, static_cast<v8::PropertyAttribute>(attributes), static_cast<v8::AccessControl>(settings));
@@ -238,7 +238,7 @@ void php_v8_template_SetNativeDataProperty(v8::Isolate *isolate, v8::Local<T> lo
     attributes = attributes ? attributes & PHP_V8_PROPERTY_ATTRIBUTE_FLAGS : attributes;
     settings = settings ? settings & PHP_V8_ACCESS_CONTROL_FLAGS : settings;
 
-    v8::Local<v8::Name> local_name = php_v8_value_get_name_local(isolate, php_v8_name);
+    v8::Local<v8::Name> local_name = php_v8_value_get_local_as<v8::Name>(php_v8_name);
 
     v8::AccessorNameGetterCallback getter;
     v8::AccessorNameSetterCallback setter = 0;

--- a/src/php_v8_try_catch.cc
+++ b/src/php_v8_try_catch.cc
@@ -26,7 +26,7 @@ zend_class_entry* php_v8_try_catch_class_entry;
 void php_v8_try_catch_create_from_try_catch(zval *return_value, php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, v8::TryCatch *try_catch) {
     object_init_ex(return_value, this_ce);
 
-    v8::Isolate *isolate = php_v8_isolate->isolate;
+    PHP_V8_DECLARE_ISOLATE(php_v8_isolate);
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
     zend_update_property(this_ce, return_value, ZEND_STRL("isolate"), &php_v8_isolate->this_ptr);
@@ -37,14 +37,14 @@ void php_v8_try_catch_create_from_try_catch(zval *return_value, php_v8_isolate_t
 
     if (try_catch && !try_catch->Exception().IsEmpty()) {
         zval exception_zv;
-        php_v8_get_or_create_value(&exception_zv, try_catch->Exception(), php_v8_isolate->isolate);
+        php_v8_get_or_create_value(&exception_zv, try_catch->Exception(), php_v8_isolate);
         zend_update_property(this_ce, return_value, ZEND_STRL("exception"), &exception_zv);
         zval_ptr_dtor(&exception_zv);
     }
 
     if (try_catch && !try_catch->StackTrace(context).IsEmpty()) {
         zval stack_trace_zv;
-        php_v8_get_or_create_value(&stack_trace_zv, try_catch->StackTrace(context).ToLocalChecked(), isolate);
+        php_v8_get_or_create_value(&stack_trace_zv, try_catch->StackTrace(context).ToLocalChecked(), php_v8_isolate);
         zend_update_property(this_ce, return_value, ZEND_STRL("stack_trace"), &stack_trace_zv);
         zval_ptr_dtor(&stack_trace_zv);
     }

--- a/src/php_v8_try_catch.cc
+++ b/src/php_v8_try_catch.cc
@@ -30,7 +30,7 @@ void php_v8_try_catch_create_from_try_catch(zval *return_value, php_v8_isolate_t
     object_init_ex(return_value, this_ce);
 
     PHP_V8_DECLARE_ISOLATE(php_v8_isolate);
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Context> context = isolate->GetEnteredContext();
 
     ZVAL_OBJ(&isolate_zv, &php_v8_isolate->std);
     ZVAL_OBJ(&context_zv, &php_v8_context->std);

--- a/src/php_v8_try_catch.cc
+++ b/src/php_v8_try_catch.cc
@@ -24,13 +24,19 @@ zend_class_entry* php_v8_try_catch_class_entry;
 
 
 void php_v8_try_catch_create_from_try_catch(zval *return_value, php_v8_isolate_t *php_v8_isolate, php_v8_context_t *php_v8_context, v8::TryCatch *try_catch) {
+    zval isolate_zv;
+    zval context_zv;
+
     object_init_ex(return_value, this_ce);
 
     PHP_V8_DECLARE_ISOLATE(php_v8_isolate);
     v8::Local<v8::Context> context = isolate->GetCurrentContext();
 
-    zend_update_property(this_ce, return_value, ZEND_STRL("isolate"), &php_v8_isolate->this_ptr);
-    zend_update_property(this_ce, return_value, ZEND_STRL("context"), &php_v8_context->this_ptr);
+    ZVAL_OBJ(&isolate_zv, &php_v8_isolate->std);
+    ZVAL_OBJ(&context_zv, &php_v8_context->std);
+
+    zend_update_property(this_ce, return_value, ZEND_STRL("isolate"), &isolate_zv);
+    zend_update_property(this_ce, return_value, ZEND_STRL("context"), &context_zv);
 
     zend_update_property_bool(this_ce, return_value, ZEND_STRL("can_continue"), static_cast<zend_long>(try_catch && try_catch->CanContinue()));
     zend_update_property_bool(this_ce, return_value, ZEND_STRL("has_terminated"), static_cast<zend_long>(try_catch && try_catch->HasTerminated()));

--- a/src/php_v8_uint32.cc
+++ b/src/php_v8_uint32.cc
@@ -52,8 +52,7 @@ static PHP_METHOD(V8Uint32, Value) {
     PHP_V8_VALUE_FETCH_WITH_CHECK(getThis(), php_v8_value);
     PHP_V8_ENTER_ISOLATE(php_v8_value->php_v8_isolate);
 
-    v8::Local<v8::Value> local_value = php_v8_value_get_value_local(isolate, php_v8_value);
-    v8::Local<v8::Uint32> local_number = v8::Local<v8::Uint32>::Cast(local_value);
+    v8::Local<v8::Uint32> local_number = php_v8_value_get_local_as<v8::Uint32>(php_v8_value);
 
     RETVAL_LONG(local_number->Value());
 }

--- a/src/php_v8_unbound_script.cc
+++ b/src/php_v8_unbound_script.cc
@@ -27,10 +27,6 @@ zend_class_entry* php_v8_unbound_script_class_entry;
 static zend_object_handlers php_v8_unbound_script_object_handlers;
 
 
-v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(v8::Isolate *isolate, php_v8_unbound_script_t *php_v8_unbound_script) {
-    return v8::Local<v8::UnboundScript>::New(isolate, *php_v8_unbound_script->persistent);
-}
-
 php_v8_unbound_script_t * php_v8_unbound_script_fetch_object(zend_object *obj) {
     return (php_v8_unbound_script_t *)((char *)obj - XtOffsetOf(php_v8_unbound_script_t, std));
 }
@@ -118,7 +114,7 @@ static PHP_METHOD(V8UnboundScript, BindToContext)
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
     PHP_V8_ENTER_CONTEXT(php_v8_context);
 
-    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(php_v8_unbound_script);
     v8::Local<v8::Script> local_script = local_unbound_script->BindToCurrentContext();
 
     php_v8_create_script(return_value, local_script, php_v8_context);
@@ -133,7 +129,7 @@ static PHP_METHOD(V8UnboundScript, GetId)
     PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
 
-    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(php_v8_unbound_script);
 
     RETURN_LONG(static_cast<zend_long>(local_unbound_script->GetId()));
 }
@@ -147,7 +143,7 @@ static PHP_METHOD(V8UnboundScript, GetScriptName)
     PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
 
-    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(php_v8_unbound_script);
 
     php_v8_get_or_create_value(return_value, local_unbound_script->GetScriptName(), php_v8_unbound_script->php_v8_isolate);
 }
@@ -161,7 +157,7 @@ static PHP_METHOD(V8UnboundScript, GetSourceURL)
     PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
 
-    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(php_v8_unbound_script);
 
     php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceURL(), php_v8_unbound_script->php_v8_isolate);
 }
@@ -175,7 +171,7 @@ static PHP_METHOD(V8UnboundScript, GetSourceMappingURL)
     PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
 
-    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(php_v8_unbound_script);
 
     php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceMappingURL(), php_v8_unbound_script->php_v8_isolate);
 }
@@ -193,7 +189,7 @@ static PHP_METHOD(V8UnboundScript, GetLineNumber)
     PHP_V8_FETCH_UNBOUND_SCRIPT_WITH_CHECK(getThis(), php_v8_unbound_script);
     PHP_V8_ENTER_STORED_ISOLATE(php_v8_unbound_script);
 
-    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
+    v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(php_v8_unbound_script);
 
     RETURN_LONG(static_cast<zend_long>(local_unbound_script->GetLineNumber(static_cast<int>(code_pos))));
 }

--- a/src/php_v8_unbound_script.cc
+++ b/src/php_v8_unbound_script.cc
@@ -27,10 +27,6 @@ zend_class_entry* php_v8_unbound_script_class_entry;
 static zend_object_handlers php_v8_unbound_script_object_handlers;
 
 
-php_v8_unbound_script_t * php_v8_unbound_script_fetch_object(zend_object *obj) {
-    return (php_v8_unbound_script_t *)((char *)obj - XtOffsetOf(php_v8_unbound_script_t, std));
-}
-
 php_v8_unbound_script_t * php_v8_create_unbound_script(zval *return_value, php_v8_isolate_t *php_v8_isolate, v8::Local<v8::UnboundScript> unbound_script) {
     assert(!unbound_script.IsEmpty());
 

--- a/src/php_v8_unbound_script.cc
+++ b/src/php_v8_unbound_script.cc
@@ -28,12 +28,15 @@ static zend_object_handlers php_v8_unbound_script_object_handlers;
 
 
 php_v8_unbound_script_t * php_v8_create_unbound_script(zval *return_value, php_v8_isolate_t *php_v8_isolate, v8::Local<v8::UnboundScript> unbound_script) {
+    zval isolate_zv;
     assert(!unbound_script.IsEmpty());
 
     object_init_ex(return_value, this_ce);
 
+    ZVAL_OBJ(&isolate_zv, &php_v8_isolate->std);
+
     PHP_V8_FETCH_UNBOUND_SCRIPT_INTO(return_value, php_v8_unbound_script);
-    PHP_V8_UNBOUND_SCRIPT_STORE_ISOLATE(return_value, &php_v8_isolate->this_ptr)
+    PHP_V8_UNBOUND_SCRIPT_STORE_ISOLATE(return_value, &isolate_zv)
     PHP_V8_STORE_POINTER_TO_ISOLATE(php_v8_unbound_script, php_v8_isolate);
 
     php_v8_unbound_script->persistent->Reset(php_v8_isolate->isolate, unbound_script);

--- a/src/php_v8_unbound_script.cc
+++ b/src/php_v8_unbound_script.cc
@@ -149,7 +149,7 @@ static PHP_METHOD(V8UnboundScript, GetScriptName)
 
     v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
 
-    php_v8_get_or_create_value(return_value, local_unbound_script->GetScriptName(), isolate);
+    php_v8_get_or_create_value(return_value, local_unbound_script->GetScriptName(), php_v8_unbound_script->php_v8_isolate);
 }
 
 static PHP_METHOD(V8UnboundScript, GetSourceURL)
@@ -163,7 +163,7 @@ static PHP_METHOD(V8UnboundScript, GetSourceURL)
 
     v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
 
-    php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceURL(), isolate);
+    php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceURL(), php_v8_unbound_script->php_v8_isolate);
 }
 
 static PHP_METHOD(V8UnboundScript, GetSourceMappingURL)
@@ -177,7 +177,7 @@ static PHP_METHOD(V8UnboundScript, GetSourceMappingURL)
 
     v8::Local<v8::UnboundScript> local_unbound_script = php_v8_unbound_script_get_local(isolate, php_v8_unbound_script);
 
-    php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceMappingURL(), isolate);
+    php_v8_get_or_create_value(return_value, local_unbound_script->GetSourceMappingURL(), php_v8_unbound_script->php_v8_isolate);
 }
 
 static PHP_METHOD(V8UnboundScript, GetLineNumber)

--- a/src/php_v8_unbound_script.cc
+++ b/src/php_v8_unbound_script.cc
@@ -248,8 +248,9 @@ PHP_MINIT_FUNCTION(php_v8_unbound_script)
 
     memcpy(&php_v8_unbound_script_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_unbound_script_object_handlers.offset = XtOffsetOf(php_v8_unbound_script_t, std);
-    php_v8_unbound_script_object_handlers.free_obj = php_v8_unbound_script_free;
+    php_v8_unbound_script_object_handlers.offset    = XtOffsetOf(php_v8_unbound_script_t, std);
+    php_v8_unbound_script_object_handlers.free_obj  = php_v8_unbound_script_free;
+    php_v8_unbound_script_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_unbound_script.h
+++ b/src/php_v8_unbound_script.h
@@ -29,6 +29,7 @@ extern "C" {
 
 extern zend_class_entry *php_v8_unbound_script_class_entry;
 
+inline php_v8_unbound_script_t * php_v8_unbound_script_fetch_object(zend_object *obj);
 extern v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(php_v8_unbound_script_t *php_v8_unbound_script);
 extern php_v8_unbound_script_t * php_v8_create_unbound_script(zval *return_value, php_v8_isolate_t *php_v8_isolate, v8::Local<v8::UnboundScript> unbound_script);
 
@@ -61,6 +62,10 @@ struct _php_v8_unbound_script_t {
 
   zend_object std;
 };
+
+inline php_v8_unbound_script_t * php_v8_unbound_script_fetch_object(zend_object *obj) {
+    return (php_v8_unbound_script_t *)((char *)obj - XtOffsetOf(php_v8_unbound_script_t, std));
+}
 
 inline v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(php_v8_unbound_script_t *php_v8_unbound_script) {
     return v8::Local<v8::UnboundScript>::New(php_v8_unbound_script->php_v8_isolate->isolate, *php_v8_unbound_script->persistent);

--- a/src/php_v8_unbound_script.h
+++ b/src/php_v8_unbound_script.h
@@ -29,8 +29,7 @@ extern "C" {
 
 extern zend_class_entry *php_v8_unbound_script_class_entry;
 
-extern v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(v8::Isolate *isolate, php_v8_unbound_script_t *php_v8_unbound_script);
-extern php_v8_unbound_script_t * php_v8_unbound_script_fetch_object(zend_object *obj);
+extern v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(php_v8_unbound_script_t *php_v8_unbound_script);
 extern php_v8_unbound_script_t * php_v8_create_unbound_script(zval *return_value, php_v8_isolate_t *php_v8_isolate, v8::Local<v8::UnboundScript> unbound_script);
 
 
@@ -62,6 +61,11 @@ struct _php_v8_unbound_script_t {
 
   zend_object std;
 };
+
+inline v8::Local<v8::UnboundScript> php_v8_unbound_script_get_local(php_v8_unbound_script_t *php_v8_unbound_script) {
+    return v8::Local<v8::UnboundScript>::New(php_v8_unbound_script->php_v8_isolate->isolate, *php_v8_unbound_script->persistent);
+}
+
 
 PHP_MINIT_FUNCTION(php_v8_unbound_script);
 

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -113,10 +113,6 @@ static void php_v8_value_free(zend_object *object) {
         }
     }
 
-    if (!Z_ISUNDEF(php_v8_value->this_ptr)) {
-        zval_ptr_dtor(&php_v8_value->this_ptr);
-    }
-
     if (php_v8_value->gc_data) {
         efree(php_v8_value->gc_data);
     }
@@ -270,11 +266,15 @@ zend_class_entry *php_v8_get_class_entry_from_value(v8::Local<v8::Value> value) 
 }
 
 php_v8_value_t *php_v8_create_value(zval *return_value, v8::Local<v8::Value> local_value, php_v8_isolate_t *php_v8_isolate) {
+    zval isolate_zv;
+    zval context_zv;
     assert(!local_value.IsEmpty());
 
     object_init_ex(return_value, php_v8_get_class_entry_from_value(local_value));
     PHP_V8_VALUE_FETCH_INTO(return_value, return_php_v8_value);
-    PHP_V8_VALUE_STORE_ISOLATE(return_value, &php_v8_isolate->this_ptr);
+
+    ZVAL_OBJ(&isolate_zv, &php_v8_isolate->std);
+    PHP_V8_VALUE_STORE_ISOLATE(return_value, &isolate_zv);
     PHP_V8_STORE_POINTER_TO_ISOLATE(return_php_v8_value, php_v8_isolate);
 
     if (local_value->IsObject()) {
@@ -282,10 +282,10 @@ php_v8_value_t *php_v8_create_value(zval *return_value, v8::Local<v8::Value> loc
 
         php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_value.As<v8::Object>()->CreationContext());
 
-        PHP_V8_OBJECT_STORE_CONTEXT(return_value, &php_v8_context->this_ptr);
+        ZVAL_OBJ(&context_zv, &php_v8_context->std);
+        PHP_V8_OBJECT_STORE_CONTEXT(return_value, &context_zv);
         PHP_V8_STORE_POINTER_TO_CONTEXT(return_php_v8_value, php_v8_context);
 
-        ZVAL_COPY_VALUE(&return_php_v8_value->this_ptr, return_value);
         php_v8_object_store_self_ptr(return_php_v8_value, v8::Local<v8::Object>::Cast(local_value));
     }
 
@@ -303,7 +303,8 @@ php_v8_value_t *php_v8_get_or_create_value(zval *return_value, v8::Local<v8::Val
         php_v8_value_t *data = php_v8_object_get_self_ptr(php_v8_isolate, v8::Local<v8::Object>::Cast(local_value));
 
         if (data) {
-            ZVAL_ZVAL(return_value, &data->this_ptr, 1, 0);
+            ZVAL_OBJ(return_value, &data->std);
+            Z_ADDREF_P(return_value);
             return data;
         }
     }

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -51,10 +51,6 @@ zend_class_entry *php_v8_value_class_entry;
 static zend_object_handlers php_v8_value_object_handlers;
 
 
-php_v8_value_t *php_v8_value_fetch_object(zend_object *obj) {
-    return (php_v8_value_t *)((char *)obj - XtOffsetOf(php_v8_value_t, std));
-}
-
 static void php_v8_value_weak_callback(const v8::WeakCallbackInfo<v8::Persistent<v8::Value>>& data) {
     v8::Isolate *isolate = data.GetIsolate();
     php_v8_isolate_t *php_v8_isolate = PHP_V8_ISOLATE_FETCH_REFERENCE(isolate);

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -280,7 +280,7 @@ php_v8_value_t *php_v8_create_value(zval *return_value, v8::Local<v8::Value> loc
     if (local_value->IsObject()) {
         assert(php_v8_isolate->isolate->InContext());
 
-        php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_value.As<v8::Object>()->CreationContext());
+        php_v8_context_t *php_v8_context = php_v8_context_get_reference(php_v8_isolate->isolate->GetEnteredContext());
 
         ZVAL_OBJ(&context_zv, &php_v8_context->std);
         PHP_V8_OBJECT_STORE_CONTEXT(return_value, &context_zv);

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -1123,9 +1123,10 @@ PHP_MINIT_FUNCTION (php_v8_value) {
 
     memcpy(&php_v8_value_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    php_v8_value_object_handlers.offset   = XtOffsetOf(php_v8_value_t, std);
-    php_v8_value_object_handlers.free_obj = php_v8_value_free;
-    php_v8_value_object_handlers.get_gc   = php_v8_value_gc;
+    php_v8_value_object_handlers.offset    = XtOffsetOf(php_v8_value_t, std);
+    php_v8_value_object_handlers.free_obj  = php_v8_value_free;
+    php_v8_value_object_handlers.get_gc    = php_v8_value_gc;
+    php_v8_value_object_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/src/php_v8_value.cc
+++ b/src/php_v8_value.cc
@@ -106,8 +106,8 @@ static void php_v8_value_free(zend_object *object) {
         if (local_value->IsObject()) {
             // TODO: at this point we SHOULD drop link to complete object and replace it with link to persistent handler and callbacks
 
-            /* NOTE: here we lose reference to persistent handler and callbacks. While in most cases this should be
-             *       rare case, it may lead to allocated memory bloating, so it may be a good idea to store proper reference
+            /* Here we lose reference to persistent handler and callbacks. While in most cases this should be
+             * rare case, it may lead to allocated memory bloating, so it may be a good idea to store proper reference
              */
             php_v8_object_delete_self_ptr(php_v8_value, v8::Local<v8::Object>::Cast(local_value));
         }
@@ -427,7 +427,6 @@ static PHP_V8_VALUE_IS_METHOD(V8Value, IsSharedArrayBuffer)
 static PHP_V8_VALUE_IS_METHOD(V8Value, IsProxy)
 //static PHP_V8_VALUE_IS_METHOD(V8Value, IsWebAssemblyCompiledModule) // Experimental
 
-// TODO: bind other methods that matters
 
 /* -----------------------------------------------------------------------
           Converters from v8::Value to high-level v8::Value's children

--- a/src/php_v8_value.h
+++ b/src/php_v8_value.h
@@ -36,8 +36,8 @@ extern v8::Local<v8::Value> php_v8_value_get_value_local(v8::Isolate *isolate, p
 extern php_v8_value_t *php_v8_value_fetch_object(zend_object *obj);
 
 extern zend_class_entry *php_v8_get_class_entry_from_value(v8::Local<v8::Value> value);
-extern php_v8_value_t *php_v8_create_value(zval *return_value, v8::Local<v8::Value> value, v8::Isolate *isolate);
-extern php_v8_value_t *php_v8_get_or_create_value(zval *return_value, v8::Local<v8::Value> local_value, v8::Isolate *isolate);
+extern php_v8_value_t *php_v8_create_value(zval *return_value, v8::Local<v8::Value> value, php_v8_isolate_t *php_v8_isolate);
+extern php_v8_value_t *php_v8_get_or_create_value(zval *return_value, v8::Local<v8::Value> local_value, php_v8_isolate_t *php_v8_isolate);
 
 #define PHP_V8_VALUE_FETCH(zv) php_v8_value_fetch_object(Z_OBJ_P(zv))
 #define PHP_V8_VALUE_FETCH_INTO(pzval, into) php_v8_value_t *(into) = PHP_V8_VALUE_FETCH((pzval));

--- a/src/php_v8_value.h
+++ b/src/php_v8_value.h
@@ -32,7 +32,6 @@ extern "C" {
 extern zend_class_entry *php_v8_value_class_entry;
 
 
-extern v8::Local<v8::Value> php_v8_value_get_value_local(v8::Isolate *isolate, php_v8_value_t *php_v8_value);
 extern php_v8_value_t *php_v8_value_fetch_object(zend_object *obj);
 
 extern zend_class_entry *php_v8_get_class_entry_from_value(v8::Local<v8::Value> value);
@@ -120,6 +119,16 @@ struct _php_v8_value_t {
 
     zval this_ptr; // makes sense for objects only
     zend_object std;
+};
+
+inline v8::Local<v8::Value> php_v8_value_get_local(php_v8_value_t *php_v8_value) {
+    return v8::Local<v8::Value>::New(php_v8_value->php_v8_isolate->isolate, *php_v8_value->persistent);
+};
+
+
+template<class T>
+v8::Local<T> php_v8_value_get_local_as(php_v8_value_t *php_v8_value) {
+    return php_v8_value_get_local(php_v8_value).As<T>();
 };
 
 

--- a/src/php_v8_value.h
+++ b/src/php_v8_value.h
@@ -70,7 +70,6 @@ extern php_v8_value_t *php_v8_get_or_create_value(zval *return_value, v8::Local<
     PHP_V8_ENTER_STORED_ISOLATE((value_v8)); \
     PHP_V8_ENTER_STORED_CONTEXT((value_v8)); \
 
-// TODO: move to better place or is it fine here too?
 #define PHP_V8_CONVERT_UTF8VALUE_TO_STRING(from, to) const char *(to) = (const char*) *(from);
 #define PHP_V8_CONVERT_UTF8VALUE_TO_STRING_NODECL(from, to) (to) = (const char*) *(from);
 
@@ -97,7 +96,6 @@ extern php_v8_value_t *php_v8_get_or_create_value(zval *return_value, v8::Local<
     PHP_V8_CONVERT_UTF8VALUE_TO_STRING_WITH_CHECK_NODECL(_v8_utf8_str_##cstr, cstr); \
 }
 
-// TODO: string length check?
 #define PHP_V8_SET_ZVAL_STRING_FROM_V8_STRING(zval_to, v8_local_string_from) { \
     v8::String::Utf8Value _v8_utf8_str((v8_local_string_from)); \
     PHP_V8_CONVERT_UTF8VALUE_TO_STRING_WITH_CHECK(_v8_utf8_str, _v8_utf8_cstr); \

--- a/src/php_v8_value.h
+++ b/src/php_v8_value.h
@@ -32,7 +32,7 @@ extern "C" {
 extern zend_class_entry *php_v8_value_class_entry;
 
 
-extern php_v8_value_t *php_v8_value_fetch_object(zend_object *obj);
+inline php_v8_value_t *php_v8_value_fetch_object(zend_object *obj);
 
 extern zend_class_entry *php_v8_get_class_entry_from_value(v8::Local<v8::Value> value);
 extern php_v8_value_t *php_v8_create_value(zval *return_value, v8::Local<v8::Value> value, php_v8_isolate_t *php_v8_isolate);
@@ -121,10 +121,13 @@ struct _php_v8_value_t {
     zend_object std;
 };
 
+inline php_v8_value_t *php_v8_value_fetch_object(zend_object *obj) {
+    return (php_v8_value_t *)((char *)obj - XtOffsetOf(php_v8_value_t, std));
+}
+
 inline v8::Local<v8::Value> php_v8_value_get_local(php_v8_value_t *php_v8_value) {
     return v8::Local<v8::Value>::New(php_v8_value->php_v8_isolate->isolate, *php_v8_value->persistent);
 };
-
 
 template<class T>
 v8::Local<T> php_v8_value_get_local_as(php_v8_value_t *php_v8_value) {

--- a/src/php_v8_value.h
+++ b/src/php_v8_value.h
@@ -117,7 +117,6 @@ struct _php_v8_value_t {
     zval *gc_data;
     int   gc_data_count;
 
-    zval this_ptr; // makes sense for objects only
     zend_object std;
 };
 

--- a/stubs/src/CallbackInfo.php
+++ b/stubs/src/CallbackInfo.php
@@ -51,13 +51,4 @@ class CallbackInfo
     public function GetReturnValue() : ReturnValue
     {
     }
-
-    /**
-     * Check whether object is in current calling context and thus is usable
-     *
-     * @return bool
-     */
-    public function InContext() : bool
-    {
-    }
 }

--- a/stubs/src/Exceptions/ValueException.php
+++ b/stubs/src/Exceptions/ValueException.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the pinepain/php-v8 PHP extension.
+ *
+ * Copyright (c) 2015-2017 Bogdan Padalko <pinepain@gmail.com>
+ *
+ * Licensed under the MIT license: http://opensource.org/licenses/MIT
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE file that was distributed with this source or visit
+ * http://opensource.org/licenses/MIT
+ */
+
+namespace V8\Exceptions;
+
+
+class ValueException extends GenericException
+{
+}

--- a/stubs/src/FunctionCallbackInfo.php
+++ b/stubs/src/FunctionCallbackInfo.php
@@ -25,6 +25,13 @@ namespace V8;
 class FunctionCallbackInfo extends CallbackInfo
 {
     /**
+     * @return int
+     */
+    public function Length() : int
+    {
+    }
+
+    /**
      * @return Value[] | StringValue[] | SymbolValue[] | NumberValue[] | ObjectValue[] | ArrayObject[] | FunctionObject[] | StringObject[] | SymbolObject[]
      */
     public function Arguments() : array

--- a/stubs/src/FunctionCallbackInfo.php
+++ b/stubs/src/FunctionCallbackInfo.php
@@ -31,10 +31,7 @@ class FunctionCallbackInfo extends CallbackInfo
     {
     }
 
-    /**
-     * @return int
-     */
-    public function Length() : int
+    public function NewTarget() : Value
     {
     }
 

--- a/stubs/src/Isolate.php
+++ b/stubs/src/Isolate.php
@@ -82,11 +82,11 @@ class Isolate
     }
 
     /**
-     * Returns the context that is on the top of the stack.
+     * Returns the last entered context.
      *
      * @return \V8\Context
      */
-    public function GetCurrentContext() : Context
+    public function GetEnteredContext() : Context
     {
     }
 

--- a/stubs/src/ObjectValue.php
+++ b/stubs/src/ObjectValue.php
@@ -412,16 +412,6 @@ class ObjectValue extends Value implements AdjustableExternalMemoryInterface
     }
 
     /**
-     * Returns the context in which the object was created.
-     * Note: Object may be created outside context!
-     *
-     * @return \V8\Context
-     */
-    public function CreationContext(): Context
-    {
-    }
-
-    /**
      * Checks whether a callback is set by the
      * ObjectTemplate::SetCallAsFunctionHandler method.
      * When an Object is callable this method returns true.

--- a/stubs/src/PropertyCallbackInfo.php
+++ b/stubs/src/PropertyCallbackInfo.php
@@ -19,5 +19,17 @@ namespace V8;
  * The information passed to a property callback about the context
  * of the property access.
  */
-class PropertyCallbackInfo extends CallbackInfo {
+class PropertyCallbackInfo extends CallbackInfo
+{
+    /**
+     * Returns true if the intercepted function should throw if an error occurs.
+     * Usually, true corresponds to 'use strict'.
+     *
+     * Always false when intercepting Reflect.set() independent of the language mode.
+     *
+     * @return bool
+     */
+    public function ShouldThrowOnError(): bool
+    {
+    }
 }

--- a/stubs/src/ReturnValue.php
+++ b/stubs/src/ReturnValue.php
@@ -30,7 +30,7 @@ class ReturnValue
      *
      * If the ReturnValue was not yet set, this will return the undefined value.
      *
-     * @return Value
+     * @return Value | StringValue | NumberValue | ObjectValue | ArrayObject | FunctionObject
      */
     public function Get() : Value
     {

--- a/stubs/src/Script.php
+++ b/stubs/src/Script.php
@@ -51,7 +51,7 @@ class Script
      *
      * @param \V8\Context $context
      *
-     * @return BooleanValue|FunctionObject|NumberValue|ObjectValue|StringValue|Value
+     * @return BooleanValue | FunctionObject | NumberValue | ObjectValue | StringValue | Value
      */
     public function Run(Context $context): Value
     {

--- a/stubs/src/Script.php
+++ b/stubs/src/Script.php
@@ -45,9 +45,7 @@ class Script
     }
 
     /**
-     * Runs the script returning the resulting value. It will be run in the
-     * context in which it was created (ScriptCompiler::CompileBound or
-     * UnboundScript::BindToCurrentContext()).
+     * Runs the script returning the resulting value.
      *
      * @param \V8\Context $context
      *

--- a/stubs/src/ScriptOrigin.php
+++ b/stubs/src/ScriptOrigin.php
@@ -58,55 +58,53 @@ class ScriptOrigin
      * @param bool   $is_wasm
      * @param bool   $is_module
      */
-    public function __construct(string $resource_name,
-                                int $resource_line_offset = Message::kNoLineNumberInfo,
-                                int $resource_column_offset = Message::kNoColumnInfo,
-                                bool $resource_is_shared_cross_origin = false,
-                                int $script_id = Message::kNoScriptIdInfo,
-                                string $source_map_url = '',
-                                bool $resource_is_opaque = false,
-                                bool $is_wasm = false,
-                                bool $is_module = false)
-    {
-        $this->resource_name = $resource_name;
-        $this->resource_line_offset = $resource_line_offset;
+    public function __construct(
+        string $resource_name,
+        int $resource_line_offset = Message::kNoLineNumberInfo,
+        int $resource_column_offset = Message::kNoColumnInfo,
+        bool $resource_is_shared_cross_origin = false,
+        int $script_id = Message::kNoScriptIdInfo,
+        string $source_map_url = '',
+        bool $resource_is_opaque = false,
+        bool $is_wasm = false,
+        bool $is_module = false
+    ) {
+        $this->resource_name          = $resource_name;
+        $this->resource_line_offset   = $resource_line_offset;
         $this->resource_column_offset = $resource_column_offset;
 
         $this->options = new ScriptOriginOptions($resource_is_shared_cross_origin, $resource_is_opaque, $is_wasm, $is_module);
 
-        $this->script_id = $script_id;
+        $this->script_id      = $script_id;
         $this->source_map_url = $source_map_url;
     }
 
-    public function ResourceName() : int
+    public function ResourceName(): string
     {
         return $this->resource_name;
     }
 
-    public function ResourceLineOffset() : int
+    public function ResourceLineOffset(): int
     {
         return $this->resource_line_offset;
     }
 
-    public function ResourceColumnOffset() : int
+    public function ResourceColumnOffset(): int
     {
         return $this->resource_column_offset;
     }
 
-    public function ScriptID() : int
+    public function ScriptID(): int
     {
         return $this->script_id;
     }
 
-    /**
-     * @return string
-     */
-    public function SourceMapUrl() : string
+    public function SourceMapUrl(): string
     {
         return $this->source_map_url;
     }
 
-    public function Options() : ScriptOriginOptions
+    public function Options(): ScriptOriginOptions
     {
         return $this->options;
     }

--- a/stubs/src/ScriptOriginOptions.php
+++ b/stubs/src/ScriptOriginOptions.php
@@ -44,22 +44,22 @@ class ScriptOriginOptions
      * @param bool $is_wasm
      * @param bool $is_module
      */
-    public function __construct(bool $is_shared_cross_origin = false,
-                                bool $is_opaque = false,
-                                bool $is_wasm = false,
-                                bool $is_module = false
-                                )
-    {
+    public function __construct(
+        bool $is_shared_cross_origin = false,
+        bool $is_opaque = false,
+        bool $is_wasm = false,
+        bool $is_module = false
+    ) {
         $this->is_shared_cross_origin = $is_shared_cross_origin;
-        $this->is_opaque = $is_opaque;
-        $this->is_wasm = $is_wasm;
-        $this->is_module = $is_module;
+        $this->is_opaque              = $is_opaque;
+        $this->is_wasm                = $is_wasm;
+        $this->is_module              = $is_module;
     }
 
     /**
      * @return bool
      */
-    public function IsSharedCrossOrigin() : bool
+    public function IsSharedCrossOrigin(): bool
     {
         return $this->is_shared_cross_origin;
     }
@@ -67,7 +67,7 @@ class ScriptOriginOptions
     /**
      * @return bool
      */
-    public function IsOpaque() : bool
+    public function IsOpaque(): bool
     {
         return $this->is_opaque;
     }
@@ -75,7 +75,7 @@ class ScriptOriginOptions
     /**
      * @return bool
      */
-    public function isIsWasm(): bool
+    public function IsWasm(): bool
     {
         return $this->is_wasm;
     }
@@ -83,7 +83,7 @@ class ScriptOriginOptions
     /**
      * @return bool
      */
-    public function isIsModule(): bool
+    public function IsModule(): bool
     {
         return $this->is_module;
     }

--- a/stubs/src/StackTrace.php
+++ b/stubs/src/StackTrace.php
@@ -53,7 +53,7 @@ class StackTrace
     /**
      * Returns a StackFrame at a particular index.
      *
-     * @return StackFrame
+     * @return StackFrame[]
      */
     public function GetFrames() : array
     {

--- a/tests/.tracking_dtors.php
+++ b/tests/.tracking_dtors.php
@@ -14,44 +14,50 @@
 
 namespace v8Tests\TrackingDtors;
 
-class Isolate extends \V8\Isolate {
-    public function __destruct() {
-        echo 'Isolate dies now!', PHP_EOL;
+
+trait DestructMessageAwareTrait {
+    //private $message = '';
+
+    //public function setOnDestructMessage($message) {
+    //    $this->message = $message;
+    //}
+
+    public function __destruct()
+    {
+        if (isset($this->destructor_test_message)) {
+            $message = $this->destructor_test_message;
+        }else {
+            $message = (new \ReflectionClass($this))->getShortName() . ' dies now!';
+        }
+
+        echo $message, PHP_EOL;
     }
+}
+
+class Isolate extends \V8\Isolate {
+    use DestructMessageAwareTrait;
 }
 
 class Context extends \V8\Context {
-    public function __destruct() {
-        echo 'Context dies now!', PHP_EOL;
-    }
+    use DestructMessageAwareTrait;
 }
 
 class Script extends \V8\Script {
-    public function __destruct() {
-        echo 'Script dies now!', PHP_EOL;
-    }
+    use DestructMessageAwareTrait;
 }
 
 class FunctionTemplate extends \V8\FunctionTemplate {
-    public function __destruct() {
-        echo 'FunctionTemplate dies now!', PHP_EOL;
-    }
+    use DestructMessageAwareTrait;
 }
 
 class ObjectTemplate extends \V8\ObjectTemplate {
-    public function __destruct() {
-        echo 'ObjectTemplate dies now!', PHP_EOL;
-    }
+    use DestructMessageAwareTrait;
 }
 
 class FunctionObject extends \V8\FunctionObject {
-    public function __destruct() {
-        echo 'FunctionObject dies now!', PHP_EOL;
-    }
+    use DestructMessageAwareTrait;
 }
 
 class Value extends \V8\Value {
-    public function __destruct() {
-        echo 'Value dies now!', PHP_EOL;
-    }
+    use DestructMessageAwareTrait;
 }

--- a/tests/V8ArrayObject.phpt
+++ b/tests/V8ArrayObject.phpt
@@ -29,7 +29,6 @@ $helper->line();
 $helper->header('Accessors');
 $helper->method_matches($value, 'GetIsolate', $isolate);
 $helper->method_matches($value, 'GetContext', $context);
-$helper->method_matches($value, 'CreationContext', $context);
 $helper->space();
 
 $v8_helper->run_checks($value, 'Checkers');
@@ -122,7 +121,6 @@ Accessors:
 ----------
 V8\ArrayObject::GetIsolate() matches expected value
 V8\ArrayObject::GetContext() matches expected value
-V8\ArrayObject::CreationContext() matches expected value
 
 
 Checkers:
@@ -184,7 +182,7 @@ V8\ArrayObject(V8\Value)->IsProxy(): bool(false)
 Converters:
 -----------
 V8\ArrayObject(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#118 (1) {
+    object(V8\BooleanValue)#117 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -200,7 +198,7 @@ V8\ArrayObject(V8\Value)->ToBoolean():
       }
     }
 V8\ArrayObject(V8\Value)->ToNumber():
-    object(V8\Int32Value)#118 (1) {
+    object(V8\Int32Value)#117 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -216,7 +214,7 @@ V8\ArrayObject(V8\Value)->ToNumber():
       }
     }
 V8\ArrayObject(V8\Value)->ToString():
-    object(V8\StringValue)#118 (1) {
+    object(V8\StringValue)#117 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -232,7 +230,7 @@ V8\ArrayObject(V8\Value)->ToString():
       }
     }
 V8\ArrayObject(V8\Value)->ToDetailString():
-    object(V8\StringValue)#118 (1) {
+    object(V8\StringValue)#117 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -298,7 +296,7 @@ V8\ArrayObject(V8\Value)->ToObject():
       }
     }
 V8\ArrayObject(V8\Value)->ToInteger():
-    object(V8\Int32Value)#118 (1) {
+    object(V8\Int32Value)#117 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -314,7 +312,7 @@ V8\ArrayObject(V8\Value)->ToInteger():
       }
     }
 V8\ArrayObject(V8\Value)->ToUint32():
-    object(V8\Int32Value)#118 (1) {
+    object(V8\Int32Value)#117 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -330,7 +328,7 @@ V8\ArrayObject(V8\Value)->ToUint32():
       }
     }
 V8\ArrayObject(V8\Value)->ToInt32():
-    object(V8\Int32Value)#118 (1) {
+    object(V8\Int32Value)#117 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8ArrayObject.phpt
+++ b/tests/V8ArrayObject.phpt
@@ -79,7 +79,7 @@ object(V8\ArrayObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (3) {
+  object(V8\Context)#5 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -93,24 +93,6 @@ object(V8\ArrayObject)#6 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 
@@ -261,7 +243,7 @@ V8\ArrayObject(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (3) {
+      object(V8\Context)#5 (1) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -275,24 +257,6 @@ V8\ArrayObject(V8\Value)->ToObject():
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        object(V8\ObjectTemplate)#4 (1) {
-          ["isolate":"V8\Template":private]=>
-          object(V8\Isolate)#3 (5) {
-            ["snapshot":"V8\Isolate":private]=>
-            NULL
-            ["time_limit":"V8\Isolate":private]=>
-            float(0)
-            ["time_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-            ["memory_limit":"V8\Isolate":private]=>
-            int(0)
-            ["memory_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-          }
-        }
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
 V8\ArrayObject(V8\Value)->ToInteger():

--- a/tests/V8BooleanObject.phpt
+++ b/tests/V8BooleanObject.phpt
@@ -72,7 +72,7 @@ object(V8\BooleanObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (3) {
+  object(V8\Context)#7 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -86,24 +86,6 @@ object(V8\BooleanObject)#8 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 

--- a/tests/V8Context_reference_lifecycle.phpt
+++ b/tests/V8Context_reference_lifecycle.phpt
@@ -45,7 +45,7 @@ $helper->dump($obj->GetContext());
 $obj = null;
 ?>
 --EXPECT--
-object(Context)#4 (3) {
+object(Context)#4 (1) {
   ["isolate":"V8\Context":private]=>
   object(V8\Isolate)#3 (5) {
     ["snapshot":"V8\Isolate":private]=>
@@ -59,17 +59,13 @@ object(Context)#4 (3) {
     ["memory_limit_hit":"V8\Isolate":private]=>
     bool(false)
   }
-  ["global_template":"V8\Context":private]=>
-  NULL
-  ["global_object":"V8\Context":private]=>
-  NULL
 }
 
 Context dies now
 
 Previous context should be dead, creating zval for object from old context
 
-object(Context)#6 (3) {
+object(Context)#6 (1) {
   ["isolate":"V8\Context":private]=>
   object(V8\Isolate)#3 (5) {
     ["snapshot":"V8\Isolate":private]=>
@@ -83,9 +79,5 @@ object(Context)#6 (3) {
     ["memory_limit_hit":"V8\Isolate":private]=>
     bool(false)
   }
-  ["global_template":"V8\Context":private]=>
-  NULL
-  ["global_object":"V8\Context":private]=>
-  NULL
 }
 Context dies now

--- a/tests/V8Context_reference_lifecycle.phpt
+++ b/tests/V8Context_reference_lifecycle.phpt
@@ -1,0 +1,91 @@
+--TEST--
+V8\Context reference lifecycle
+--SKIPIF--
+<?php if (!extension_loaded("v8")) {
+    print "skip";
+} ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+class Context extends V8\Context {
+    public function __destruct() {
+        echo 'Context dies now', PHP_EOL;
+    }
+}
+
+$isolate = new \V8\Isolate();
+
+
+$obj = $v8_helper->CompileRun(new Context($isolate), 'var obj = {}; obj');
+
+//$helper->dump($obj);
+$helper->dump($obj->GetContext());
+
+
+$context = new Context($isolate);
+$context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'obj'), $obj);
+
+$helper->line();
+$obj = null;
+$helper->line();
+
+$helper->message('Previous context should be dead, creating zval for object from old context');
+$helper->line();
+
+$obj = $v8_helper->CompileRun($context, 'var obj2 = obj; obj2');
+
+//$helper->dump($obj);
+$helper->dump($obj->GetContext());
+$obj = null;
+?>
+--EXPECT--
+object(Context)#4 (3) {
+  ["isolate":"V8\Context":private]=>
+  object(V8\Isolate)#3 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["global_template":"V8\Context":private]=>
+  NULL
+  ["global_object":"V8\Context":private]=>
+  NULL
+}
+
+Context dies now
+
+Previous context should be dead, creating zval for object from old context
+
+object(Context)#6 (3) {
+  ["isolate":"V8\Context":private]=>
+  object(V8\Isolate)#3 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["global_template":"V8\Context":private]=>
+  NULL
+  ["global_object":"V8\Context":private]=>
+  NULL
+}
+Context dies now

--- a/tests/V8DateObject.phpt
+++ b/tests/V8DateObject.phpt
@@ -130,7 +130,7 @@ object(V8\DateObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (3) {
+  object(V8\Context)#7 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -144,24 +144,6 @@ object(V8\DateObject)#8 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 

--- a/tests/V8Exception_CreateMessage.phpt
+++ b/tests/V8Exception_CreateMessage.phpt
@@ -24,7 +24,7 @@ $helper->line();
 
 $func_test_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) use ($helper, $v8_helper) {
 
-    $helper->assert('Exception passed', $info->Length() == 1);
+    $helper->assert('Exception passed', count($info->Arguments()) == 1);
     $helper->line();
 
     $exception = $info->Arguments()[0];
@@ -85,7 +85,7 @@ Message created from thrown value:
 V8\Message->Get(): string(18) "Uncaught #<Object>"
 V8\Message->GetSourceLine(): string(24) "        test(exception);"
 V8\Message->GetScriptOrigin():
-    object(V8\ScriptOrigin)#19 (6) {
+    object(V8\ScriptOrigin)#21 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(7) "test.js"
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -123,7 +123,7 @@ Message created from created value:
 V8\Message->Get(): string(13) "Uncaught test"
 V8\Message->GetSourceLine(): string(24) "        test(exception);"
 V8\Message->GetScriptOrigin():
-    object(V8\ScriptOrigin)#33 (6) {
+    object(V8\ScriptOrigin)#35 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(7) "test.js"
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -131,7 +131,7 @@ V8\Message->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#32 (4) {
+      object(V8\ScriptOriginOptions)#34 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>

--- a/tests/V8Exception_Error.phpt
+++ b/tests/V8Exception_Error.phpt
@@ -22,7 +22,7 @@ try {
 $helper->line();
 
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
-    $value = $info->Length() ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
+    $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
     $e = $info->GetIsolate()->ThrowException(V8\Exception::Error($info->GetContext(), $value));
 

--- a/tests/V8Exception_GetStackTrace.phpt
+++ b/tests/V8Exception_GetStackTrace.phpt
@@ -148,7 +148,7 @@ V8\StackTrace->AsArray():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#8 (3) {
+      object(V8\Context)#8 (1) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -162,24 +162,6 @@ V8\StackTrace->AsArray():
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        object(V8\ObjectTemplate)#7 (1) {
-          ["isolate":"V8\Template":private]=>
-          object(V8\Isolate)#3 (5) {
-            ["snapshot":"V8\Isolate":private]=>
-            NULL
-            ["time_limit":"V8\Isolate":private]=>
-            float(0)
-            ["time_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-            ["memory_limit":"V8\Isolate":private]=>
-            int(0)
-            ["memory_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-          }
-        }
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
 

--- a/tests/V8Exception_GetStackTrace.phpt
+++ b/tests/V8Exception_GetStackTrace.phpt
@@ -28,7 +28,7 @@ $helper->line();
 $func_test_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) use ($helper, $v8_helper, &$stack_trace_generation_allowed) {
     $isolate = $info->GetIsolate();
 
-    $helper->assert('Exception passed', $info->Length() == 1);
+    $helper->assert('Exception passed', count($info->Arguments()) == 1);
     $helper->line();
 
     $exception = $info->Arguments()[0];
@@ -112,7 +112,7 @@ Stack trace created from thrown value:
 V8\StackTrace->getFrames():
     array(1) {
       [0]=>
-      object(V8\StackFrame)#17 (8) {
+      object(V8\StackFrame)#19 (8) {
         ["line_number":"V8\StackFrame":private]=>
         int(5)
         ["column":"V8\StackFrame":private]=>

--- a/tests/V8Exception_RangeError.phpt
+++ b/tests/V8Exception_RangeError.phpt
@@ -23,7 +23,7 @@ try {
 $helper->line();
 
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
-    $value = $info->Length() ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
+    $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
     $e = $info->GetIsolate()->ThrowException(V8\Exception::RangeError($info->GetContext(), $value));
 

--- a/tests/V8Exception_ReferenceError.phpt
+++ b/tests/V8Exception_ReferenceError.phpt
@@ -23,7 +23,7 @@ try {
 $helper->line();
 
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
-    $value = $info->Length() ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
+    $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
     $e = $info->GetIsolate()->ThrowException(V8\Exception::ReferenceError($info->GetContext(), $value));
 

--- a/tests/V8Exception_SyntaxError.phpt
+++ b/tests/V8Exception_SyntaxError.phpt
@@ -23,7 +23,7 @@ try {
 $helper->line();
 
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
-    $value = $info->Length() ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
+    $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
     $e = $info->GetIsolate()->ThrowException(V8\Exception::SyntaxError($info->GetContext(), $value));
 

--- a/tests/V8Exception_TypeError.phpt
+++ b/tests/V8Exception_TypeError.phpt
@@ -23,7 +23,7 @@ try {
 $helper->line();
 
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
-    $value = $info->Length() ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
+    $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
     $e = $info->GetIsolate()->ThrowException(V8\Exception::TypeError($info->GetContext(), $value));
 

--- a/tests/V8ExceptionsTryCatchException.phpt
+++ b/tests/V8ExceptionsTryCatchException.phpt
@@ -60,7 +60,7 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
     bool(false)
   }
   ["context":"V8\Exceptions\TryCatchException":private]=>
-  object(V8\Context)#3 (3) {
+  object(V8\Context)#3 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -74,10 +74,6 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    NULL
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
   ["try_catch":"V8\Exceptions\TryCatchException":private]=>
   object(V8\TryCatch)#4 (7) {
@@ -95,7 +91,7 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
       bool(false)
     }
     ["context":"V8\TryCatch":private]=>
-    object(V8\Context)#3 (3) {
+    object(V8\Context)#3 (1) {
       ["isolate":"V8\Context":private]=>
       object(V8\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -109,10 +105,6 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      NULL
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
     ["exception":"V8\TryCatch":private]=>
     NULL

--- a/tests/V8FunctionCallbackInfo.phpt
+++ b/tests/V8FunctionCallbackInfo.phpt
@@ -33,6 +33,7 @@ $func = new v8Tests\TrackingDtors\FunctionObject($context1, function (V8\Functio
 
     $callback_info = $info;
     $helper->assert('Original arguments number passed', count($info->Arguments()) == 2);
+    $helper->assert('Arguments number matches Length() method output', count($info->Arguments()) == $info->Length());
 
     $helper->assert('Callback info holds original isolate object', $info->GetIsolate(), $isolate1);
     $helper->assert('Callback info holds original isolate object', $info->GetContext(), $context1);
@@ -274,6 +275,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
 
 
 Original arguments number passed: ok
+Arguments number matches Length() method output: ok
 Callback info holds original isolate object: ok
 Callback info holds original isolate object: ok
 Scalars hold no info about their zval, so that their zvals are recreated on each access: ok

--- a/tests/V8FunctionCallbackInfo.phpt
+++ b/tests/V8FunctionCallbackInfo.phpt
@@ -32,16 +32,13 @@ $func = new v8Tests\TrackingDtors\FunctionObject($context1, function (V8\Functio
     $helper->space();
 
     $callback_info = $info;
-    $helper->assert('Original arguments number passed', $info->Length() == 2);
+    $helper->assert('Original arguments number passed', count($info->Arguments()) == 2);
 
     $helper->assert('Callback info holds original isolate object', $info->GetIsolate(), $isolate1);
     $helper->assert('Callback info holds original isolate object', $info->GetContext(), $context1);
-    $helper->assert('Callback info object is in context', $info->InContext());
 
-    // scalars hold no info about their zval, so they their zvals are recreated on each access
-    $helper->value_matches_with_no_output($scalar, $info->Arguments()[0]); // shouldn't match
-    // while objects can hold info about their zval and keep it untill zval's free() object handler not called (or that info will not be cleaned manually)
-    $helper->value_matches_with_no_output($object, $info->Arguments()[1]); // will match
+    $helper->assert('Scalars hold no info about their zval, so that their zvals are recreated on each access', $scalar !== $info->Arguments()[0]);
+    $helper->assert("Objects can hold info about their zval and keep it until zval's get free() ", $object === $info->Arguments()[1]);
 });
 
 $context1->GlobalObject()->Set($context1, new \V8\StringValue($isolate1, 'print'), $func);
@@ -58,12 +55,12 @@ $helper->dump($script1->Run($context1)->ToString($context1)->Value());
 
 $helper->space();
 
-$helper->assert('Callback info object is out of context', false === $callback_info->InContext());
-try {
-    $callback_info->GetReturnValue();
-} catch (Exception $e) {
-    $helper->exception_export($e);
-}
+//try {
+$retval = $callback_info->GetReturnValue();
+$helper->dump($retval);
+//} catch (Exception $e) {
+//    $helper->exception_export($e);
+//}
 $helper->line();
 
 $helper->header('Object representation (outside of context)');
@@ -78,25 +75,639 @@ echo 'We are done for now', PHP_EOL;
 Function called
 Object representation:
 ----------------------
-object(V8\FunctionCallbackInfo)#10 (0) {
+object(V8\FunctionCallbackInfo)#10 (8) {
+  ["isolate":"V8\CallbackInfo":private]=>
+  object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["context":"V8\CallbackInfo":private]=>
+  object(V8\Context)#4 (3) {
+    ["isolate":"V8\Context":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["global_template":"V8\Context":private]=>
+    object(V8\ObjectTemplate)#3 (1) {
+      ["isolate":"V8\Template":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+    ["global_object":"V8\Context":private]=>
+    NULL
+  }
+  ["this":"V8\CallbackInfo":private]=>
+  object(V8\ObjectValue)#11 (2) {
+    ["isolate":"V8\Value":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ObjectValue":private]=>
+    object(V8\Context)#4 (3) {
+      ["isolate":"V8\Context":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["global_template":"V8\Context":private]=>
+      object(V8\ObjectTemplate)#3 (1) {
+        ["isolate":"V8\Template":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+      }
+      ["global_object":"V8\Context":private]=>
+      NULL
+    }
+  }
+  ["holder":"V8\CallbackInfo":private]=>
+  object(V8\ObjectValue)#11 (2) {
+    ["isolate":"V8\Value":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ObjectValue":private]=>
+    object(V8\Context)#4 (3) {
+      ["isolate":"V8\Context":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["global_template":"V8\Context":private]=>
+      object(V8\ObjectTemplate)#3 (1) {
+        ["isolate":"V8\Template":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+      }
+      ["global_object":"V8\Context":private]=>
+      NULL
+    }
+  }
+  ["return_value":"V8\CallbackInfo":private]=>
+  object(V8\ReturnValue)#12 (2) {
+    ["isolate":"V8\ReturnValue":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ReturnValue":private]=>
+    object(V8\Context)#4 (3) {
+      ["isolate":"V8\Context":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["global_template":"V8\Context":private]=>
+      object(V8\ObjectTemplate)#3 (1) {
+        ["isolate":"V8\Template":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+      }
+      ["global_object":"V8\Context":private]=>
+      NULL
+    }
+  }
+  ["arguments":"V8\FunctionCallbackInfo":private]=>
+  array(2) {
+    [0]=>
+    object(V8\StringValue)#13 (1) {
+      ["isolate":"V8\Value":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+    [1]=>
+    object(V8\ObjectValue)#6 (2) {
+      ["isolate":"V8\Value":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["context":"V8\ObjectValue":private]=>
+      object(V8\Context)#4 (3) {
+        ["isolate":"V8\Context":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+        ["global_template":"V8\Context":private]=>
+        object(V8\ObjectTemplate)#3 (1) {
+          ["isolate":"V8\Template":private]=>
+          object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+            ["snapshot":"V8\Isolate":private]=>
+            NULL
+            ["time_limit":"V8\Isolate":private]=>
+            float(0)
+            ["time_limit_hit":"V8\Isolate":private]=>
+            bool(false)
+            ["memory_limit":"V8\Isolate":private]=>
+            int(0)
+            ["memory_limit_hit":"V8\Isolate":private]=>
+            bool(false)
+          }
+        }
+        ["global_object":"V8\Context":private]=>
+        NULL
+      }
+    }
+  }
+  ["new_target":"V8\FunctionCallbackInfo":private]=>
+  object(V8\Value)#14 (1) {
+    ["isolate":"V8\Value":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+  }
+  ["is_constructor_call":"V8\FunctionCallbackInfo":private]=>
+  bool(false)
 }
 
 
 Original arguments number passed: ok
 Callback info holds original isolate object: ok
 Callback info holds original isolate object: ok
-Callback info object is in context: ok
-Expected value is not identical to actual value
-Expected value is identical to actual value
+Scalars hold no info about their zval, so that their zvals are recreated on each access: ok
+Objects can hold info about their zval and keep it until zval's get free() : ok
 string(11) "Script done"
 
 
-Callback info object is out of context: ok
-V8\Exceptions\GenericException: Attempt to use callback info object out of callback context
+object(V8\ReturnValue)#12 (2) {
+  ["isolate":"V8\ReturnValue":private]=>
+  object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["context":"V8\ReturnValue":private]=>
+  object(V8\Context)#4 (3) {
+    ["isolate":"V8\Context":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["global_template":"V8\Context":private]=>
+    object(V8\ObjectTemplate)#3 (1) {
+      ["isolate":"V8\Template":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+    ["global_object":"V8\Context":private]=>
+    NULL
+  }
+}
 
 Object representation (outside of context):
 -------------------------------------------
-object(V8\FunctionCallbackInfo)#10 (0) {
+object(V8\FunctionCallbackInfo)#10 (8) {
+  ["isolate":"V8\CallbackInfo":private]=>
+  object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["context":"V8\CallbackInfo":private]=>
+  object(V8\Context)#4 (3) {
+    ["isolate":"V8\Context":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["global_template":"V8\Context":private]=>
+    object(V8\ObjectTemplate)#3 (1) {
+      ["isolate":"V8\Template":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+    ["global_object":"V8\Context":private]=>
+    NULL
+  }
+  ["this":"V8\CallbackInfo":private]=>
+  object(V8\ObjectValue)#11 (2) {
+    ["isolate":"V8\Value":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ObjectValue":private]=>
+    object(V8\Context)#4 (3) {
+      ["isolate":"V8\Context":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["global_template":"V8\Context":private]=>
+      object(V8\ObjectTemplate)#3 (1) {
+        ["isolate":"V8\Template":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+      }
+      ["global_object":"V8\Context":private]=>
+      NULL
+    }
+  }
+  ["holder":"V8\CallbackInfo":private]=>
+  object(V8\ObjectValue)#11 (2) {
+    ["isolate":"V8\Value":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ObjectValue":private]=>
+    object(V8\Context)#4 (3) {
+      ["isolate":"V8\Context":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["global_template":"V8\Context":private]=>
+      object(V8\ObjectTemplate)#3 (1) {
+        ["isolate":"V8\Template":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+      }
+      ["global_object":"V8\Context":private]=>
+      NULL
+    }
+  }
+  ["return_value":"V8\CallbackInfo":private]=>
+  object(V8\ReturnValue)#12 (2) {
+    ["isolate":"V8\ReturnValue":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ReturnValue":private]=>
+    object(V8\Context)#4 (3) {
+      ["isolate":"V8\Context":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["global_template":"V8\Context":private]=>
+      object(V8\ObjectTemplate)#3 (1) {
+        ["isolate":"V8\Template":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+      }
+      ["global_object":"V8\Context":private]=>
+      NULL
+    }
+  }
+  ["arguments":"V8\FunctionCallbackInfo":private]=>
+  array(2) {
+    [0]=>
+    object(V8\StringValue)#13 (1) {
+      ["isolate":"V8\Value":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+    [1]=>
+    object(V8\ObjectValue)#6 (2) {
+      ["isolate":"V8\Value":private]=>
+      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+      ["context":"V8\ObjectValue":private]=>
+      object(V8\Context)#4 (3) {
+        ["isolate":"V8\Context":private]=>
+        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+          ["snapshot":"V8\Isolate":private]=>
+          NULL
+          ["time_limit":"V8\Isolate":private]=>
+          float(0)
+          ["time_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+          ["memory_limit":"V8\Isolate":private]=>
+          int(0)
+          ["memory_limit_hit":"V8\Isolate":private]=>
+          bool(false)
+        }
+        ["global_template":"V8\Context":private]=>
+        object(V8\ObjectTemplate)#3 (1) {
+          ["isolate":"V8\Template":private]=>
+          object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+            ["snapshot":"V8\Isolate":private]=>
+            NULL
+            ["time_limit":"V8\Isolate":private]=>
+            float(0)
+            ["time_limit_hit":"V8\Isolate":private]=>
+            bool(false)
+            ["memory_limit":"V8\Isolate":private]=>
+            int(0)
+            ["memory_limit_hit":"V8\Isolate":private]=>
+            bool(false)
+          }
+        }
+        ["global_object":"V8\Context":private]=>
+        NULL
+      }
+    }
+  }
+  ["new_target":"V8\FunctionCallbackInfo":private]=>
+  object(V8\Value)#14 (1) {
+    ["isolate":"V8\Value":private]=>
+    object(v8Tests\TrackingDtors\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+  }
+  ["is_constructor_call":"V8\FunctionCallbackInfo":private]=>
+  bool(false)
 }
 
 

--- a/tests/V8FunctionCallbackInfo.phpt
+++ b/tests/V8FunctionCallbackInfo.phpt
@@ -90,7 +90,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
     bool(false)
   }
   ["context":"V8\CallbackInfo":private]=>
-  object(V8\Context)#4 (3) {
+  object(V8\Context)#4 (1) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -104,24 +104,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#3 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
   ["this":"V8\CallbackInfo":private]=>
   object(V8\ObjectValue)#11 (2) {
@@ -139,7 +121,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(V8\Context)#4 (3) {
+    object(V8\Context)#4 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -153,24 +135,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      object(V8\ObjectTemplate)#3 (1) {
-        ["isolate":"V8\Template":private]=>
-        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-          ["snapshot":"V8\Isolate":private]=>
-          NULL
-          ["time_limit":"V8\Isolate":private]=>
-          float(0)
-          ["time_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-          ["memory_limit":"V8\Isolate":private]=>
-          int(0)
-          ["memory_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-        }
-      }
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
   ["holder":"V8\CallbackInfo":private]=>
@@ -189,7 +153,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(V8\Context)#4 (3) {
+    object(V8\Context)#4 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -203,24 +167,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      object(V8\ObjectTemplate)#3 (1) {
-        ["isolate":"V8\Template":private]=>
-        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-          ["snapshot":"V8\Isolate":private]=>
-          NULL
-          ["time_limit":"V8\Isolate":private]=>
-          float(0)
-          ["time_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-          ["memory_limit":"V8\Isolate":private]=>
-          int(0)
-          ["memory_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-        }
-      }
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
   ["return_value":"V8\CallbackInfo":private]=>
@@ -239,7 +185,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       bool(false)
     }
     ["context":"V8\ReturnValue":private]=>
-    object(V8\Context)#4 (3) {
+    object(V8\Context)#4 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -253,24 +199,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      object(V8\ObjectTemplate)#3 (1) {
-        ["isolate":"V8\Template":private]=>
-        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-          ["snapshot":"V8\Isolate":private]=>
-          NULL
-          ["time_limit":"V8\Isolate":private]=>
-          float(0)
-          ["time_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-          ["memory_limit":"V8\Isolate":private]=>
-          int(0)
-          ["memory_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-        }
-      }
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
   ["arguments":"V8\FunctionCallbackInfo":private]=>
@@ -307,7 +235,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#4 (3) {
+      object(V8\Context)#4 (1) {
         ["isolate":"V8\Context":private]=>
         object(v8Tests\TrackingDtors\Isolate)#2 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -321,24 +249,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        object(V8\ObjectTemplate)#3 (1) {
-          ["isolate":"V8\Template":private]=>
-          object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-            ["snapshot":"V8\Isolate":private]=>
-            NULL
-            ["time_limit":"V8\Isolate":private]=>
-            float(0)
-            ["time_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-            ["memory_limit":"V8\Isolate":private]=>
-            int(0)
-            ["memory_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-          }
-        }
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
   }
@@ -386,7 +296,7 @@ object(V8\ReturnValue)#12 (2) {
     bool(false)
   }
   ["context":"V8\ReturnValue":private]=>
-  object(V8\Context)#4 (3) {
+  object(V8\Context)#4 (1) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -400,24 +310,6 @@ object(V8\ReturnValue)#12 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#3 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 
@@ -438,7 +330,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
     bool(false)
   }
   ["context":"V8\CallbackInfo":private]=>
-  object(V8\Context)#4 (3) {
+  object(V8\Context)#4 (1) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -452,24 +344,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#3 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
   ["this":"V8\CallbackInfo":private]=>
   object(V8\ObjectValue)#11 (2) {
@@ -487,7 +361,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(V8\Context)#4 (3) {
+    object(V8\Context)#4 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -501,24 +375,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      object(V8\ObjectTemplate)#3 (1) {
-        ["isolate":"V8\Template":private]=>
-        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-          ["snapshot":"V8\Isolate":private]=>
-          NULL
-          ["time_limit":"V8\Isolate":private]=>
-          float(0)
-          ["time_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-          ["memory_limit":"V8\Isolate":private]=>
-          int(0)
-          ["memory_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-        }
-      }
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
   ["holder":"V8\CallbackInfo":private]=>
@@ -537,7 +393,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(V8\Context)#4 (3) {
+    object(V8\Context)#4 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -551,24 +407,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      object(V8\ObjectTemplate)#3 (1) {
-        ["isolate":"V8\Template":private]=>
-        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-          ["snapshot":"V8\Isolate":private]=>
-          NULL
-          ["time_limit":"V8\Isolate":private]=>
-          float(0)
-          ["time_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-          ["memory_limit":"V8\Isolate":private]=>
-          int(0)
-          ["memory_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-        }
-      }
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
   ["return_value":"V8\CallbackInfo":private]=>
@@ -587,7 +425,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
       bool(false)
     }
     ["context":"V8\ReturnValue":private]=>
-    object(V8\Context)#4 (3) {
+    object(V8\Context)#4 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -601,24 +439,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      object(V8\ObjectTemplate)#3 (1) {
-        ["isolate":"V8\Template":private]=>
-        object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-          ["snapshot":"V8\Isolate":private]=>
-          NULL
-          ["time_limit":"V8\Isolate":private]=>
-          float(0)
-          ["time_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-          ["memory_limit":"V8\Isolate":private]=>
-          int(0)
-          ["memory_limit_hit":"V8\Isolate":private]=>
-          bool(false)
-        }
-      }
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
   ["arguments":"V8\FunctionCallbackInfo":private]=>
@@ -655,7 +475,7 @@ object(V8\FunctionCallbackInfo)#10 (8) {
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#4 (3) {
+      object(V8\Context)#4 (1) {
         ["isolate":"V8\Context":private]=>
         object(v8Tests\TrackingDtors\Isolate)#2 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -669,24 +489,6 @@ object(V8\FunctionCallbackInfo)#10 (8) {
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        object(V8\ObjectTemplate)#3 (1) {
-          ["isolate":"V8\Template":private]=>
-          object(v8Tests\TrackingDtors\Isolate)#2 (5) {
-            ["snapshot":"V8\Isolate":private]=>
-            NULL
-            ["time_limit":"V8\Isolate":private]=>
-            float(0)
-            ["time_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-            ["memory_limit":"V8\Isolate":private]=>
-            int(0)
-            ["memory_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-          }
-        }
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
   }

--- a/tests/V8FunctionObject.phpt
+++ b/tests/V8FunctionObject.phpt
@@ -71,7 +71,7 @@ object(v8Tests\TrackingDtors\FunctionObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (3) {
+  object(V8\Context)#5 (1) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -85,24 +85,6 @@ object(v8Tests\TrackingDtors\FunctionObject)#6 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(v8Tests\TrackingDtors\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 

--- a/tests/V8FunctionObject.phpt
+++ b/tests/V8FunctionObject.phpt
@@ -170,7 +170,7 @@ Should output Hello World string
 string(11) "Script done"
 
 v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
-    object(V8\ScriptOrigin)#127 (6) {
+    object(V8\ScriptOrigin)#126 (6) {
       ["resource_name":"V8\ScriptOrigin":private]=>
       string(0) ""
       ["resource_line_offset":"V8\ScriptOrigin":private]=>
@@ -178,7 +178,7 @@ v8Tests\TrackingDtors\FunctionObject(V8\FunctionObject)->GetScriptOrigin():
       ["resource_column_offset":"V8\ScriptOrigin":private]=>
       int(0)
       ["options":"V8\ScriptOrigin":private]=>
-      object(V8\ScriptOriginOptions)#131 (4) {
+      object(V8\ScriptOriginOptions)#130 (4) {
         ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
         bool(false)
         ["is_opaque":"V8\ScriptOriginOptions":private]=>

--- a/tests/V8FunctionObject_die_different_isolates.phpt
+++ b/tests/V8FunctionObject_die_different_isolates.phpt
@@ -1,0 +1,64 @@
+--TEST--
+V8\FunctionObject - test die() called from different Isolate
+--SKIPIF--
+<?php if (!extension_loaded("v8")) {
+    print "skip";
+} ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+require '.tracking_dtors.php';
+
+$isolate_inner = new v8Tests\TrackingDtors\Isolate();
+$context_inner = new V8\Context($isolate_inner);
+
+$die_func = new v8Tests\TrackingDtors\FunctionObject($context_inner, function (\V8\FunctionCallbackInfo $info) {
+    echo 'going to die...', PHP_EOL;
+    die();
+});
+
+$context_inner->GlobalObject()->Set($context_inner, new \V8\StringValue($isolate_inner, 'die'), $die_func);
+
+$die_func->destructor_test_message      = 'die() function from inner isolate dtored';
+$isolate_inner->destructor_test_message = 'inner isolate dtored';
+
+
+$isolate_outer = new v8Tests\TrackingDtors\Isolate();
+$context_outer = new V8\Context($isolate_outer);
+
+
+$test_other_func = new v8Tests\TrackingDtors\FunctionObject($context_outer, function (\V8\FunctionCallbackInfo $info) use ($context_inner) {
+    echo 'calling inner...', PHP_EOL;
+    $isolate_inner = $context_inner->GetIsolate();
+    $global_inner = $context_inner->GlobalObject();
+
+    $global_inner->Get($context_inner, new \V8\StringValue($isolate_inner, 'die'))->Call($context_inner, $global_inner);
+});
+
+$test_other_func->destructor_test_message = 'test_other() function from outer isolate dtored';
+$isolate_outer->destructor_test_message = 'outer isolate dtored';
+
+
+$context_outer->GlobalObject()->Set($context_outer, new \V8\StringValue($isolate_outer, 'test_other'), $test_other_func);
+
+
+$res = $v8_helper->CompileRun($context_outer, 'test_other(); "Script done"');
+
+$helper->pretty_dump('Script result', $res->ToString($context_outer)->Value());
+
+echo 'We are done for now', PHP_EOL;
+
+?>
+--EXPECT--
+calling inner...
+going to die...
+test_other() function from outer isolate dtored
+inner isolate dtored
+die() function from inner isolate dtored
+outer isolate dtored

--- a/tests/V8FunctionObject_die_nested.phpt
+++ b/tests/V8FunctionObject_die_nested.phpt
@@ -1,0 +1,54 @@
+--TEST--
+V8\FunctionObject - test die() during nested calling
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+require '.tracking_dtors.php';
+
+$isolate1         = new v8Tests\TrackingDtors\Isolate();
+$global_template1 = new V8\ObjectTemplate($isolate1);
+$context1         = new V8\Context($isolate1, $global_template1);
+
+
+$die_func = new v8Tests\TrackingDtors\FunctionObject($context1, function (\V8\FunctionCallbackInfo $info) {
+    echo 'going to die...', PHP_EOL;
+    die();
+});
+
+$die_func->destructor_test_message = 'die() function dtored';
+
+$teste_nested_func = new v8Tests\TrackingDtors\FunctionObject($context1, function (\V8\FunctionCallbackInfo $info) {
+    echo 'calling nested...', PHP_EOL;
+    $context = $info->GetContext();
+
+    $context->GlobalObject()->Get($context, new \V8\StringValue($context->GetIsolate(), 'die'))->Call($context, $context->GlobalObject());
+});
+
+$teste_nested_func->destructor_test_message = 'test_nested() function dtored';
+
+
+$context1->GlobalObject()->Set($context1, new \V8\StringValue($isolate1, 'die'), $die_func);
+$context1->GlobalObject()->Set($context1, new \V8\StringValue($isolate1, 'test_nested'), $teste_nested_func);
+
+
+$res = $v8_helper->CompileRun($context1, 'test_nested(); "Script done"');
+
+$helper->pretty_dump('Script result', $res->ToString($context1)->Value());
+
+echo 'We are done for now', PHP_EOL;
+
+?>
+--EXPECT--
+calling nested...
+going to die...
+test_nested() function dtored
+Isolate dies now!
+die() function dtored

--- a/tests/V8FunctionTemplate_weakness.phpt
+++ b/tests/V8FunctionTemplate_weakness.phpt
@@ -96,10 +96,10 @@ echo 'We are done for now', PHP_EOL;
 EOF
 --EXPECT--
 FunctionTemplate dies now!
+ObjectTemplate dies now!
 Should output Hello World string
 Script dies now!
 Context dies now!
-ObjectTemplate dies now!
 Isolate dies now!
 MyCallaback::__destruct
 We are done for now

--- a/tests/V8Isolate.phpt
+++ b/tests/V8Isolate.phpt
@@ -17,7 +17,7 @@ $helper->dump($isolate);
 $helper->line();
 
 try {
-  $isolate->GetCurrentContext();
+  $isolate->GetEnteredContext();
 } catch (Exception $e) {
   $helper->exception_export($e);
 }

--- a/tests/V8Isolate_ThrowException.phpt
+++ b/tests/V8Isolate_ThrowException.phpt
@@ -22,7 +22,7 @@ try {
 $helper->line();
 
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
-    $value = $info->Length() ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
+    $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
     $e = $info->GetIsolate()->ThrowException($value);
 

--- a/tests/V8MapObject.phpt
+++ b/tests/V8MapObject.phpt
@@ -114,7 +114,7 @@ object(V8\MapObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (3) {
+  object(V8\Context)#5 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -128,24 +128,6 @@ object(V8\MapObject)#6 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 
@@ -303,7 +285,7 @@ V8\MapObject(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (3) {
+      object(V8\Context)#5 (1) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -317,24 +299,6 @@ V8\MapObject(V8\Value)->ToObject():
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        object(V8\ObjectTemplate)#4 (1) {
-          ["isolate":"V8\Template":private]=>
-          object(V8\Isolate)#3 (5) {
-            ["snapshot":"V8\Isolate":private]=>
-            NULL
-            ["time_limit":"V8\Isolate":private]=>
-            float(0)
-            ["time_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-            ["memory_limit":"V8\Isolate":private]=>
-            int(0)
-            ["memory_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-          }
-        }
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
 V8\MapObject(V8\Value)->ToInteger():

--- a/tests/V8MapObject.phpt
+++ b/tests/V8MapObject.phpt
@@ -31,7 +31,6 @@ $helper->line();
 $helper->header('Accessors');
 $helper->method_matches($value, 'GetIsolate', $isolate);
 $helper->method_matches($value, 'GetContext', $context);
-$helper->method_matches($value, 'CreationContext', $context);
 $helper->space();
 
 $helper->header('Getters');
@@ -159,7 +158,6 @@ Accessors:
 ----------
 V8\MapObject::GetIsolate() matches expected value
 V8\MapObject::GetContext() matches expected value
-V8\MapObject::CreationContext() matches expected value
 
 
 Getters:
@@ -226,7 +224,7 @@ V8\MapObject(V8\Value)->IsProxy(): bool(false)
 Converters:
 -----------
 V8\MapObject(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#119 (1) {
+    object(V8\BooleanValue)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -242,7 +240,7 @@ V8\MapObject(V8\Value)->ToBoolean():
       }
     }
 V8\MapObject(V8\Value)->ToNumber():
-    object(V8\NumberValue)#119 (1) {
+    object(V8\NumberValue)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -258,7 +256,7 @@ V8\MapObject(V8\Value)->ToNumber():
       }
     }
 V8\MapObject(V8\Value)->ToString():
-    object(V8\StringValue)#119 (1) {
+    object(V8\StringValue)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -274,7 +272,7 @@ V8\MapObject(V8\Value)->ToString():
       }
     }
 V8\MapObject(V8\Value)->ToDetailString():
-    object(V8\StringValue)#119 (1) {
+    object(V8\StringValue)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -340,7 +338,7 @@ V8\MapObject(V8\Value)->ToObject():
       }
     }
 V8\MapObject(V8\Value)->ToInteger():
-    object(V8\Int32Value)#119 (1) {
+    object(V8\Int32Value)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -356,7 +354,7 @@ V8\MapObject(V8\Value)->ToInteger():
       }
     }
 V8\MapObject(V8\Value)->ToUint32():
-    object(V8\Int32Value)#119 (1) {
+    object(V8\Int32Value)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -372,7 +370,7 @@ V8\MapObject(V8\Value)->ToUint32():
       }
     }
 V8\MapObject(V8\Value)->ToInt32():
-    object(V8\Int32Value)#119 (1) {
+    object(V8\Int32Value)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8Message.phpt
+++ b/tests/V8Message.phpt
@@ -113,7 +113,7 @@ object(V8\Message)#8 (12) {
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#3 (3) {
+      object(V8\Context)#3 (1) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#2 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -127,10 +127,6 @@ object(V8\Message)#8 (12) {
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        NULL
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
   }
@@ -221,7 +217,7 @@ object(V8\Message)#9 (12) {
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#3 (3) {
+      object(V8\Context)#3 (1) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#2 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -235,10 +231,6 @@ object(V8\Message)#9 (12) {
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        NULL
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
   }

--- a/tests/V8NumberObject.phpt
+++ b/tests/V8NumberObject.phpt
@@ -83,7 +83,7 @@ object(V8\NumberObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (3) {
+  object(V8\Context)#7 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -97,24 +97,6 @@ object(V8\NumberObject)#8 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 

--- a/tests/V8ObjectTemplate_SetAccessCheckCallback.phpt
+++ b/tests/V8ObjectTemplate_SetAccessCheckCallback.phpt
@@ -48,7 +48,7 @@ $AccessBlocker = function (\V8\Context $context, \V8\ObjectValue $object) use (&
     echo 'AccessBlocker called', PHP_EOL;
 //    echo '    access ', ($allowed_access ? 'allowed' : 'denied'), PHP_EOL;
 
-    //return $isolate->GetCurrentContext()->GlobalObject()->Equals($isolate->GetCurrentContext(), $object) || $allowed_access;
+    //return $isolate->GetEnteredContext()->GlobalObject()->Equals($isolate->GetCurrentContext(), $object) || $allowed_access;
     return true;
 };
 

--- a/tests/V8ObjectValue.phpt
+++ b/tests/V8ObjectValue.phpt
@@ -61,7 +61,7 @@ object(V8\ObjectValue)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (3) {
+  object(V8\Context)#5 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -75,24 +75,6 @@ object(V8\ObjectValue)#6 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 
@@ -250,7 +232,7 @@ V8\ObjectValue(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (3) {
+      object(V8\Context)#5 (1) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -264,24 +246,6 @@ V8\ObjectValue(V8\Value)->ToObject():
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        object(V8\ObjectTemplate)#4 (1) {
-          ["isolate":"V8\Template":private]=>
-          object(V8\Isolate)#3 (5) {
-            ["snapshot":"V8\Isolate":private]=>
-            NULL
-            ["time_limit":"V8\Isolate":private]=>
-            float(0)
-            ["time_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-            ["memory_limit":"V8\Isolate":private]=>
-            int(0)
-            ["memory_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-          }
-        }
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
 V8\ObjectValue(V8\Value)->ToInteger():

--- a/tests/V8ObjectValue.phpt
+++ b/tests/V8ObjectValue.phpt
@@ -31,7 +31,6 @@ $helper->line();
 $helper->header('Accessors');
 $helper->method_matches($value, 'GetIsolate', $isolate);
 $helper->method_matches($value, 'GetContext', $context);
-$helper->method_matches($value, 'CreationContext', $context);
 $helper->space();
 
 $helper->header('Getters');
@@ -106,7 +105,6 @@ Accessors:
 ----------
 V8\ObjectValue::GetIsolate() matches expected value
 V8\ObjectValue::GetContext() matches expected value
-V8\ObjectValue::CreationContext() matches expected value
 
 
 Getters:
@@ -173,7 +171,7 @@ V8\ObjectValue(V8\Value)->IsProxy(): bool(false)
 Converters:
 -----------
 V8\ObjectValue(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#116 (1) {
+    object(V8\BooleanValue)#115 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -189,7 +187,7 @@ V8\ObjectValue(V8\Value)->ToBoolean():
       }
     }
 V8\ObjectValue(V8\Value)->ToNumber():
-    object(V8\NumberValue)#116 (1) {
+    object(V8\NumberValue)#115 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -205,7 +203,7 @@ V8\ObjectValue(V8\Value)->ToNumber():
       }
     }
 V8\ObjectValue(V8\Value)->ToString():
-    object(V8\StringValue)#116 (1) {
+    object(V8\StringValue)#115 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -221,7 +219,7 @@ V8\ObjectValue(V8\Value)->ToString():
       }
     }
 V8\ObjectValue(V8\Value)->ToDetailString():
-    object(V8\StringValue)#116 (1) {
+    object(V8\StringValue)#115 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -287,7 +285,7 @@ V8\ObjectValue(V8\Value)->ToObject():
       }
     }
 V8\ObjectValue(V8\Value)->ToInteger():
-    object(V8\Int32Value)#116 (1) {
+    object(V8\Int32Value)#115 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -303,7 +301,7 @@ V8\ObjectValue(V8\Value)->ToInteger():
       }
     }
 V8\ObjectValue(V8\Value)->ToUint32():
-    object(V8\Int32Value)#116 (1) {
+    object(V8\Int32Value)#115 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -319,7 +317,7 @@ V8\ObjectValue(V8\Value)->ToUint32():
       }
     }
 V8\ObjectValue(V8\Value)->ToInt32():
-    object(V8\Int32Value)#116 (1) {
+    object(V8\Int32Value)#115 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8PropertyCallbackInfo.phpt
+++ b/tests/V8PropertyCallbackInfo.phpt
@@ -1,0 +1,195 @@
+--TEST--
+V8\PropertyCallbackInfo
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+use V8\Context;
+use V8\Isolate;
+use V8\NameValue;
+use V8\ObjectValue;
+use V8\PropertyCallbackInfo;
+use V8\Script;
+use V8\StringValue;
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+$isolate = new Isolate();
+
+$context = new Context($isolate);
+
+$prop_value = 'foo';
+
+$getter = function (NameValue $property, PropertyCallbackInfo $info) use (&$prop_value, $helper, $isolate, $context) {
+
+    $helper->message('Property callback called');
+    $helper->line();
+
+    $helper->header('Object representation');
+    $helper->dump($info);
+    $helper->space();
+
+    $helper->assert('Callback info holds original isolate object', $info->GetIsolate(), $isolate);
+    $helper->assert('Callback info holds original isolate object', $info->GetContext(), $context);
+
+    $helper->space();
+
+    $info->GetReturnValue()->Set(new StringValue($info->GetIsolate(), $prop_value));
+};
+
+
+$obj = new ObjectValue($context);
+
+$obj->SetAccessor($context, new StringValue($isolate, 'test'), $getter);
+
+$context->GlobalObject()->Set($context, new StringValue($isolate, 'obj'), $obj);
+
+$script1 = new Script($context, new StringValue($isolate, 'obj.test'));
+
+
+$helper->dump($script1->Run($context)->ToString($context)->Value());
+
+?>
+--EXPECT--
+Property callback called
+
+Object representation:
+----------------------
+object(V8\PropertyCallbackInfo)#8 (6) {
+  ["isolate":"V8\CallbackInfo":private]=>
+  object(V8\Isolate)#2 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["context":"V8\CallbackInfo":private]=>
+  object(V8\Context)#3 (1) {
+    ["isolate":"V8\Context":private]=>
+    object(V8\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+  }
+  ["this":"V8\CallbackInfo":private]=>
+  object(V8\ObjectValue)#5 (2) {
+    ["isolate":"V8\Value":private]=>
+    object(V8\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ObjectValue":private]=>
+    object(V8\Context)#3 (1) {
+      ["isolate":"V8\Context":private]=>
+      object(V8\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+  }
+  ["holder":"V8\CallbackInfo":private]=>
+  object(V8\ObjectValue)#5 (2) {
+    ["isolate":"V8\Value":private]=>
+    object(V8\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ObjectValue":private]=>
+    object(V8\Context)#3 (1) {
+      ["isolate":"V8\Context":private]=>
+      object(V8\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+  }
+  ["return_value":"V8\CallbackInfo":private]=>
+  object(V8\ReturnValue)#9 (2) {
+    ["isolate":"V8\ReturnValue":private]=>
+    object(V8\Isolate)#2 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["context":"V8\ReturnValue":private]=>
+    object(V8\Context)#3 (1) {
+      ["isolate":"V8\Context":private]=>
+      object(V8\Isolate)#2 (5) {
+        ["snapshot":"V8\Isolate":private]=>
+        NULL
+        ["time_limit":"V8\Isolate":private]=>
+        float(0)
+        ["time_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+        ["memory_limit":"V8\Isolate":private]=>
+        int(0)
+        ["memory_limit_hit":"V8\Isolate":private]=>
+        bool(false)
+      }
+    }
+  }
+  ["should_throw_on_error":"V8\PropertyCallbackInfo":private]=>
+  bool(false)
+}
+
+
+Callback info holds original isolate object: ok
+Callback info holds original isolate object: ok
+
+
+string(3) "foo"

--- a/tests/V8RegExpObject.phpt
+++ b/tests/V8RegExpObject.phpt
@@ -79,7 +79,7 @@ object(V8\RegExpObject)#8 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#7 (3) {
+  object(V8\Context)#7 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -93,24 +93,6 @@ object(V8\RegExpObject)#8 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 

--- a/tests/V8ReturnValue_context.phpt
+++ b/tests/V8ReturnValue_context.phpt
@@ -73,7 +73,40 @@ $helper->space();
 --EXPECT--
 Object representation:
 ----------------------
-object(V8\ReturnValue)#11 (0) {
+object(V8\ReturnValue)#12 (2) {
+  ["isolate":"V8\ReturnValue":private]=>
+  object(V8\Isolate)#3 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["context":"V8\ReturnValue":private]=>
+  object(V8\Context)#4 (3) {
+    ["isolate":"V8\Context":private]=>
+    object(V8\Isolate)#3 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["global_template":"V8\Context":private]=>
+    NULL
+    ["global_object":"V8\Context":private]=>
+    NULL
+  }
 }
 
 
@@ -89,5 +122,38 @@ V8\Exceptions\GenericException: Attempt to use return value out of calling funct
 
 Object representation (outside of context):
 -------------------------------------------
-object(V8\ReturnValue)#11 (0) {
+object(V8\ReturnValue)#12 (2) {
+  ["isolate":"V8\ReturnValue":private]=>
+  object(V8\Isolate)#3 (5) {
+    ["snapshot":"V8\Isolate":private]=>
+    NULL
+    ["time_limit":"V8\Isolate":private]=>
+    float(0)
+    ["time_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+    ["memory_limit":"V8\Isolate":private]=>
+    int(0)
+    ["memory_limit_hit":"V8\Isolate":private]=>
+    bool(false)
+  }
+  ["context":"V8\ReturnValue":private]=>
+  object(V8\Context)#4 (3) {
+    ["isolate":"V8\Context":private]=>
+    object(V8\Isolate)#3 (5) {
+      ["snapshot":"V8\Isolate":private]=>
+      NULL
+      ["time_limit":"V8\Isolate":private]=>
+      float(0)
+      ["time_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+      ["memory_limit":"V8\Isolate":private]=>
+      int(0)
+      ["memory_limit_hit":"V8\Isolate":private]=>
+      bool(false)
+    }
+    ["global_template":"V8\Context":private]=>
+    NULL
+    ["global_object":"V8\Context":private]=>
+    NULL
+  }
 }

--- a/tests/V8ReturnValue_context.phpt
+++ b/tests/V8ReturnValue_context.phpt
@@ -88,7 +88,7 @@ object(V8\ReturnValue)#12 (2) {
     bool(false)
   }
   ["context":"V8\ReturnValue":private]=>
-  object(V8\Context)#4 (3) {
+  object(V8\Context)#4 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -102,10 +102,6 @@ object(V8\ReturnValue)#12 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    NULL
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 
@@ -137,7 +133,7 @@ object(V8\ReturnValue)#12 (2) {
     bool(false)
   }
   ["context":"V8\ReturnValue":private]=>
-  object(V8\Context)#4 (3) {
+  object(V8\Context)#4 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -151,9 +147,5 @@ object(V8\ReturnValue)#12 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    NULL
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }

--- a/tests/V8Script.phpt
+++ b/tests/V8Script.phpt
@@ -66,7 +66,7 @@ object(V8\Script)#7 (2) {
     bool(false)
   }
   ["context":"V8\Script":private]=>
-  object(V8\Context)#6 (3) {
+  object(V8\Context)#6 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -80,24 +80,6 @@ object(V8\Script)#7 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 Accessors:

--- a/tests/V8ScriptOrigin.phpt
+++ b/tests/V8ScriptOrigin.phpt
@@ -32,28 +32,30 @@ $helper->method_matches_with_output($options, 'IsOpaque', false);
 $helper->space();
 
 
-$obj = new V8\ScriptOrigin('test', 1, 2, true, 3, 'map', true);
-//
-//$helper->header('Object representation');
-//$helper->dump($obj);
-//$helper->space();
-//
-//$helper->header('Test getters');
-//
-//$helper->method_matches_with_output($obj, 'ResourceName', 'test');
-//$helper->method_matches_with_output($obj, 'ResourceLineOffset', 1);
-//$helper->method_matches_with_output($obj, 'ResourceColumnOffset', 2);
-//$helper->method_matches_with_output($obj, 'ScriptID', 3);
-//$helper->method_matches_with_output($obj, 'SourceMapUrl', 'map');
-//$helper->method_matches_instanceof($obj, 'Options', V8\ScriptOriginOptions::class);
-//$helper->space();
-//
-//$options = $obj->Options();
-//
-//$helper->header('Test options getters');
-//$helper->method_matches_with_output($options, 'IsSharedCrossOrigin', true);
-//$helper->method_matches_with_output($options, 'IsOpaque', true);
-//$helper->space();
+$obj = new V8\ScriptOrigin('test', 1, 2, true, 3, 'map', true, true, true);
+
+$helper->header('Object representation');
+$helper->dump($obj);
+$helper->space();
+
+$helper->header('Test getters');
+
+$helper->method_matches_with_output($obj, 'ResourceName', 'test');
+$helper->method_matches_with_output($obj, 'ResourceLineOffset', 1);
+$helper->method_matches_with_output($obj, 'ResourceColumnOffset', 2);
+$helper->method_matches_with_output($obj, 'ScriptID', 3);
+$helper->method_matches_with_output($obj, 'SourceMapUrl', 'map');
+$helper->method_matches_instanceof($obj, 'Options', V8\ScriptOriginOptions::class);
+$helper->space();
+
+$options = $obj->Options();
+
+$helper->header('Test options getters');
+$helper->method_matches_with_output($options, 'IsSharedCrossOrigin', true);
+$helper->method_matches_with_output($options, 'IsOpaque', true);
+$helper->method_matches_with_output($options, 'IsWasm', true);
+$helper->method_matches_with_output($options, 'IsModule', true);
+$helper->space();
 
 ?>
 --EXPECT--
@@ -98,3 +100,48 @@ Test options getters (default):
 -------------------------------
 V8\ScriptOriginOptions::IsSharedCrossOrigin() matches expected false
 V8\ScriptOriginOptions::IsOpaque() matches expected false
+
+
+Object representation:
+----------------------
+object(V8\ScriptOrigin)#4 (6) {
+  ["resource_name":"V8\ScriptOrigin":private]=>
+  string(4) "test"
+  ["resource_line_offset":"V8\ScriptOrigin":private]=>
+  int(1)
+  ["resource_column_offset":"V8\ScriptOrigin":private]=>
+  int(2)
+  ["options":"V8\ScriptOrigin":private]=>
+  object(V8\ScriptOriginOptions)#5 (4) {
+    ["is_shared_cross_origin":"V8\ScriptOriginOptions":private]=>
+    bool(true)
+    ["is_opaque":"V8\ScriptOriginOptions":private]=>
+    bool(true)
+    ["is_wasm":"V8\ScriptOriginOptions":private]=>
+    bool(true)
+    ["is_module":"V8\ScriptOriginOptions":private]=>
+    bool(true)
+  }
+  ["script_id":"V8\ScriptOrigin":private]=>
+  int(3)
+  ["source_map_url":"V8\ScriptOrigin":private]=>
+  string(3) "map"
+}
+
+
+Test getters:
+-------------
+V8\ScriptOrigin::ResourceName() matches expected 'test'
+V8\ScriptOrigin::ResourceLineOffset() matches expected 1
+V8\ScriptOrigin::ResourceColumnOffset() matches expected 2
+V8\ScriptOrigin::ScriptID() matches expected 3
+V8\ScriptOrigin::SourceMapUrl() matches expected 'map'
+V8\ScriptOrigin::Options() result is instance of V8\ScriptOriginOptions
+
+
+Test options getters:
+---------------------
+V8\ScriptOriginOptions::IsSharedCrossOrigin() matches expected true
+V8\ScriptOriginOptions::IsOpaque() matches expected true
+V8\ScriptOriginOptions::IsWasm() matches expected true
+V8\ScriptOriginOptions::IsModule() matches expected true

--- a/tests/V8Script_Run_uncaught_exception.phpt
+++ b/tests/V8Script_Run_uncaught_exception.phpt
@@ -1,0 +1,23 @@
+--TEST--
+V8\Script::Run() - uncaught exception should not lead to leak
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+$obj = $v8_helper->CompileRun(new \V8\Context(new \V8\Isolate()), 'test');
+
+?>
+--EXPECTF--
+Fatal error: Uncaught V8\Exceptions\TryCatchException: ReferenceError: test is not defined in %s
+Stack trace:
+#0 %s: V8\Script->Run(Object(V8\Context))
+#1 %s: PhpV8Helpers->CompileRun(Object(V8\Context), Object(V8\Script))
+#2 {main}
+  thrown in %s

--- a/tests/V8Script_exit_during_script_execution.phpt
+++ b/tests/V8Script_exit_during_script_execution.phpt
@@ -52,11 +52,11 @@ echo 'Done here', PHP_EOL;
 ?>
 EOF
 --EXPECT--
+ObjectTemplate dies now!
 FunctionTemplate dies now!
 before exit
 Going to exit
 Doing shutdown
 Isolate dies now!
-ObjectTemplate dies now!
 Context dies now!
 Script dies now!

--- a/tests/V8SetObject.phpt
+++ b/tests/V8SetObject.phpt
@@ -31,7 +31,6 @@ $helper->line();
 $helper->header('Accessors');
 $helper->method_matches($value, 'GetIsolate', $isolate);
 $helper->method_matches($value, 'GetContext', $context);
-$helper->method_matches($value, 'CreationContext', $context);
 $helper->space();
 
 $helper->header('Getters');
@@ -166,7 +165,6 @@ Accessors:
 ----------
 V8\SetObject::GetIsolate() matches expected value
 V8\SetObject::GetContext() matches expected value
-V8\SetObject::CreationContext() matches expected value
 
 
 Getters:
@@ -233,7 +231,7 @@ V8\SetObject(V8\Value)->IsProxy(): bool(false)
 Converters:
 -----------
 V8\SetObject(V8\Value)->ToBoolean():
-    object(V8\BooleanValue)#120 (1) {
+    object(V8\BooleanValue)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -249,7 +247,7 @@ V8\SetObject(V8\Value)->ToBoolean():
       }
     }
 V8\SetObject(V8\Value)->ToNumber():
-    object(V8\NumberValue)#120 (1) {
+    object(V8\NumberValue)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -265,7 +263,7 @@ V8\SetObject(V8\Value)->ToNumber():
       }
     }
 V8\SetObject(V8\Value)->ToString():
-    object(V8\StringValue)#120 (1) {
+    object(V8\StringValue)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -281,7 +279,7 @@ V8\SetObject(V8\Value)->ToString():
       }
     }
 V8\SetObject(V8\Value)->ToDetailString():
-    object(V8\StringValue)#120 (1) {
+    object(V8\StringValue)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -347,7 +345,7 @@ V8\SetObject(V8\Value)->ToObject():
       }
     }
 V8\SetObject(V8\Value)->ToInteger():
-    object(V8\Int32Value)#120 (1) {
+    object(V8\Int32Value)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -363,7 +361,7 @@ V8\SetObject(V8\Value)->ToInteger():
       }
     }
 V8\SetObject(V8\Value)->ToUint32():
-    object(V8\Int32Value)#120 (1) {
+    object(V8\Int32Value)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -379,7 +377,7 @@ V8\SetObject(V8\Value)->ToUint32():
       }
     }
 V8\SetObject(V8\Value)->ToInt32():
-    object(V8\Int32Value)#120 (1) {
+    object(V8\Int32Value)#119 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8SetObject.phpt
+++ b/tests/V8SetObject.phpt
@@ -121,7 +121,7 @@ object(V8\SetObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (3) {
+  object(V8\Context)#5 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -135,24 +135,6 @@ object(V8\SetObject)#6 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 
@@ -310,7 +292,7 @@ V8\SetObject(V8\Value)->ToObject():
         bool(false)
       }
       ["context":"V8\ObjectValue":private]=>
-      object(V8\Context)#5 (3) {
+      object(V8\Context)#5 (1) {
         ["isolate":"V8\Context":private]=>
         object(V8\Isolate)#3 (5) {
           ["snapshot":"V8\Isolate":private]=>
@@ -324,24 +306,6 @@ V8\SetObject(V8\Value)->ToObject():
           ["memory_limit_hit":"V8\Isolate":private]=>
           bool(false)
         }
-        ["global_template":"V8\Context":private]=>
-        object(V8\ObjectTemplate)#4 (1) {
-          ["isolate":"V8\Template":private]=>
-          object(V8\Isolate)#3 (5) {
-            ["snapshot":"V8\Isolate":private]=>
-            NULL
-            ["time_limit":"V8\Isolate":private]=>
-            float(0)
-            ["time_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-            ["memory_limit":"V8\Isolate":private]=>
-            int(0)
-            ["memory_limit_hit":"V8\Isolate":private]=>
-            bool(false)
-          }
-        }
-        ["global_object":"V8\Context":private]=>
-        NULL
       }
     }
 V8\SetObject(V8\Value)->ToInteger():

--- a/tests/V8StackTrace.phpt
+++ b/tests/V8StackTrace.phpt
@@ -109,7 +109,7 @@ object(V8\StackTrace)#8 (2) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(v8Tests\TrackingDtors\Context)#4 (3) {
+    object(v8Tests\TrackingDtors\Context)#4 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -123,10 +123,6 @@ object(V8\StackTrace)#8 (2) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      NULL
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
 }

--- a/tests/V8StackTrace_CurrentStackTrace.phpt
+++ b/tests/V8StackTrace_CurrentStackTrace.phpt
@@ -22,13 +22,13 @@ $current_stack_trace_func_tpl = new \v8Tests\TrackingDtors\FunctionTemplate($iso
     $isolate = $args->GetIsolate();
     $context = $args->GetContext();
 
-    if ($args->Length()) {
+    if (count($args->Arguments())) {
         $frame_limit = $args->Arguments()[0]->NumberValue($context);
     } else {
         $frame_limit = 10;
     }
 
-    if ($args->Length() > 1) {
+    if (count($args->Arguments()) > 1) {
         $options = $args->Arguments()[1]->NumberValue($context);
     } else {
         $options = \V8\StackTrace\StackTraceOptions::kOverview;

--- a/tests/V8StackTrace_CurrentStackTrace.phpt
+++ b/tests/V8StackTrace_CurrentStackTrace.phpt
@@ -179,8 +179,8 @@ Error
     at test.js:64:7
 
 Script dies now!
+ObjectTemplate dies now!
 FunctionTemplate dies now!
 Context dies now!
-ObjectTemplate dies now!
 Isolate dies now!
 END

--- a/tests/V8StartupData_CreateFromSource.phpt
+++ b/tests/V8StartupData_CreateFromSource.phpt
@@ -27,6 +27,16 @@ $data = null;
 $context = new \V8\Context($isolate);
 
 $helper->assert('Context global is affected by snapshot blob', $context->GlobalObject()->Get($context, new \V8\StringValue($isolate, 'test_snapshot'))->IsFunction());
+
+
+try {
+    V8\StartupData::CreateFromSource(') bad +/^\\');
+    $helper->assert('Unable to create startup data from bad source', false);
+} catch (Exception $e) {
+    $helper->space();
+    $helper->exception_export($e);
+}
+
 ?>
 --EXPECT--
 Object representation:
@@ -39,3 +49,6 @@ Snapshot blob is large binary string: ok
 Snapshot raw_size is the same as binary_string length: ok
 Snapshot raw_size is the same as binary_string length: ok
 Context global is affected by snapshot blob: ok
+
+
+V8\Exceptions\GenericException: Failed to create startup blob

--- a/tests/V8StringObject.phpt
+++ b/tests/V8StringObject.phpt
@@ -82,7 +82,7 @@ object(V8\StringObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (3) {
+  object(V8\Context)#5 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -96,24 +96,6 @@ object(V8\StringObject)#6 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 

--- a/tests/V8StringObject.phpt
+++ b/tests/V8StringObject.phpt
@@ -123,7 +123,7 @@ StringObject extends ObjectValue: ok
 Getters:
 --------
 V8\StringObject->ValueOf():
-    object(V8\StringValue)#119 (1) {
+    object(V8\StringValue)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8SymbolObject.phpt
+++ b/tests/V8SymbolObject.phpt
@@ -126,7 +126,7 @@ SymbolObject extends ObjectValue: ok
 Getters:
 --------
 V8\SymbolObject->ValueOf():
-    object(V8\SymbolValue)#119 (1) {
+    object(V8\SymbolValue)#118 (1) {
       ["isolate":"V8\Value":private]=>
       object(V8\Isolate)#3 (5) {
         ["snapshot":"V8\Isolate":private]=>

--- a/tests/V8SymbolObject.phpt
+++ b/tests/V8SymbolObject.phpt
@@ -85,7 +85,7 @@ object(V8\SymbolObject)#6 (2) {
     bool(false)
   }
   ["context":"V8\ObjectValue":private]=>
-  object(V8\Context)#5 (3) {
+  object(V8\Context)#5 (1) {
     ["isolate":"V8\Context":private]=>
     object(V8\Isolate)#3 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -99,24 +99,6 @@ object(V8\SymbolObject)#6 (2) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    object(V8\ObjectTemplate)#4 (1) {
-      ["isolate":"V8\Template":private]=>
-      object(V8\Isolate)#3 (5) {
-        ["snapshot":"V8\Isolate":private]=>
-        NULL
-        ["time_limit":"V8\Isolate":private]=>
-        float(0)
-        ["time_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-        ["memory_limit":"V8\Isolate":private]=>
-        int(0)
-        ["memory_limit_hit":"V8\Isolate":private]=>
-        bool(false)
-      }
-    }
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
 }
 

--- a/tests/V8TryCatch.phpt
+++ b/tests/V8TryCatch.phpt
@@ -84,7 +84,7 @@ object(V8\TryCatch)#4 (7) {
     bool(false)
   }
   ["context":"V8\TryCatch":private]=>
-  object(v8Tests\TrackingDtors\Context)#3 (3) {
+  object(v8Tests\TrackingDtors\Context)#3 (1) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -98,10 +98,6 @@ object(V8\TryCatch)#4 (7) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    NULL
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
   ["exception":"V8\TryCatch":private]=>
   NULL
@@ -144,7 +140,7 @@ object(V8\TryCatch)#12 (7) {
     bool(false)
   }
   ["context":"V8\TryCatch":private]=>
-  object(v8Tests\TrackingDtors\Context)#3 (3) {
+  object(v8Tests\TrackingDtors\Context)#3 (1) {
     ["isolate":"V8\Context":private]=>
     object(v8Tests\TrackingDtors\Isolate)#2 (5) {
       ["snapshot":"V8\Isolate":private]=>
@@ -158,10 +154,6 @@ object(V8\TryCatch)#12 (7) {
       ["memory_limit_hit":"V8\Isolate":private]=>
       bool(false)
     }
-    ["global_template":"V8\Context":private]=>
-    NULL
-    ["global_object":"V8\Context":private]=>
-    NULL
   }
   ["exception":"V8\TryCatch":private]=>
   object(V8\ObjectValue)#5 (2) {
@@ -179,7 +171,7 @@ object(V8\TryCatch)#12 (7) {
       bool(false)
     }
     ["context":"V8\ObjectValue":private]=>
-    object(v8Tests\TrackingDtors\Context)#3 (3) {
+    object(v8Tests\TrackingDtors\Context)#3 (1) {
       ["isolate":"V8\Context":private]=>
       object(v8Tests\TrackingDtors\Isolate)#2 (5) {
         ["snapshot":"V8\Isolate":private]=>
@@ -193,10 +185,6 @@ object(V8\TryCatch)#12 (7) {
         ["memory_limit_hit":"V8\Isolate":private]=>
         bool(false)
       }
-      ["global_template":"V8\Context":private]=>
-      NULL
-      ["global_object":"V8\Context":private]=>
-      NULL
     }
   }
   ["stack_trace":"V8\TryCatch":private]=>
@@ -268,7 +256,7 @@ object(V8\TryCatch)#12 (7) {
           bool(false)
         }
         ["context":"V8\ObjectValue":private]=>
-        object(v8Tests\TrackingDtors\Context)#3 (3) {
+        object(v8Tests\TrackingDtors\Context)#3 (1) {
           ["isolate":"V8\Context":private]=>
           object(v8Tests\TrackingDtors\Isolate)#2 (5) {
             ["snapshot":"V8\Isolate":private]=>
@@ -282,10 +270,6 @@ object(V8\TryCatch)#12 (7) {
             ["memory_limit_hit":"V8\Isolate":private]=>
             bool(false)
           }
-          ["global_template":"V8\Context":private]=>
-          NULL
-          ["global_object":"V8\Context":private]=>
-          NULL
         }
       }
     }

--- a/tests/V8TryCatch_from_script.phpt
+++ b/tests/V8TryCatch_from_script.phpt
@@ -183,8 +183,8 @@ TryCatchException holds the same isolate it was thrown: ok
 string(49) "Uncaught SyntaxError: Invalid or unexpected token"
 
 Script dies now!
+ObjectTemplate dies now!
 FunctionTemplate dies now!
 Context dies now!
-ObjectTemplate dies now!
 Isolate dies now!
 END

--- a/v8.cc
+++ b/v8.cc
@@ -15,6 +15,7 @@
 #endif
 
 #include "php_v8.h"
+#include "php_v8_a.h"
 
 #include "php_v8_isolate.h"
 #include "php_v8_startup_data.h"
@@ -187,6 +188,7 @@ PHP_MSHUTDOWN_FUNCTION(v8)
     /* uncomment this line if you have INI entries
     UNREGISTER_INI_ENTRIES();
     */
+    php_v8_shutdown();
     return SUCCESS;
 }
 /* }}} */
@@ -240,6 +242,7 @@ static PHP_GINIT_FUNCTION(v8)
     ZEND_TSRMLS_CACHE_UPDATE();
 #endif
     v8_globals->v8_initialized = false;
+    v8_globals->platform = nullptr;
 }
 /* }}} */
 


### PR DESCRIPTION
This PR adds low-level optimizations, simplify some internal methods and fix few bugs. For more details see change list below.

 - `*` Replace `V8\Isolate::GetCurrentContext` with `V8\Isolate::GetEnteredContext()`;
 - `*` Remove `V8\ObjectValue::CreationContext()`, use `V8\ObjectValue::GetContext()`;
 - Add `V8\PropertyCallbackInfo::ShouldThrowOnError()` method;
 - Add `V8\FunctionCallbackInfo::NewTarget()` method;
 - `V8\ReturnValue` now explicitly holds isolate and context which could be accessed outside of calling context, though `ReturnValue::{Get,Set}` could be accessed only within calling context as before;
 - Fix potential problems with `V8\FunctionCallbackInfo` and `V8\PropertyCallbackInfo`, now they are fully build, properly stores owning isolate and context and could be safely used outside calling scope;
 - Fix leak when `V8\ScriptCompiler::CompileFunctionInContext()` invoked with arguments or arguments and context extensions;
 - Fix segfault under when abruptly exiting (`die()`, `exit()`, uncaught exception) from isolate which entered multiple time or from multiple nested isolates (quite rare use case).

Notes:
 - Add `V8\Exceptions\ValueException` to stubs. It support was in extension for ages but for some reason it was missed from stubs. 
 - Removed `$global_template` and `$global_object` private props from `V8\Context` were never exposed to end-user.
 
*`*` - BC-breaking or potentially BC-breaking changes*