### PR TITLE
Improve exceptions handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(php_v8)
 
 # NOTE: This CMake file is just for syntax highlighting in CLion
 
-include_directories(/usr/local/opt/v8@5.8/include)
-include_directories(/usr/local/opt/v8@5.8/include/libplatform)
+include_directories(/usr/local/opt/v8@5.9/include)
+include_directories(/usr/local/opt/v8@5.9/include/libplatform)
 
 include_directories(/usr/local/include/php)
 include_directories(/usr/local/include/php/TSRM)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,81 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'" # Prevent TTY Errors
+
+  config.vm.box = "bento/ubuntu-16.04"
+
+  # config.vm.box_check_update = false
+
+  config.vm.network  "private_network", ip: "192.168.33.44"
+  # config.vm.network "public_network"
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  config.vm.synced_folder ".", "/home/vagrant/php-v8"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+     # Don't boot with headless mode
+     # vb.gui = true
+
+     # Use VBoxManage to customize the VM. For example to change memory:
+     vb.customize ["modifyvm", :id, "--memory", 2048]
+     vb.customize ["modifyvm", :id, "--cpus", 2]
+  end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with CFEngine. CFEngine Community packages are
+  # automatically installed. For example, configure the host as a
+  # policy server and optionally a policy file to run:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.am_policy_hub = true
+  #   # cf.run_file = "motd.cf"
+  # end
+  #
+  # You can also configure and bootstrap a client to an existing
+  # policy server:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.policy_server_address = "10.0.2.15"
+  # end
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file default.pp in the manifests_path directory.
+  #
+  # config.vm.provision "puppet" do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "default.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { mysql_password: "foo" }
+  # end
+
+  #config.vm.provision "shell", path: './provision/provision.sh', privileged: false
+end

--- a/src/php_v8_callbacks.cc
+++ b/src/php_v8_callbacks.cc
@@ -239,7 +239,7 @@ void php_v8_callback_call_from_bucket_with_zargs(size_t index, v8::Local<v8::Val
     phpv8::CallbacksBucket *bucket;
 
     if (data.IsEmpty() || !data->IsExternal()) {
-        PHP_V8_THROW_EXCEPTION("Callback has no stored callback function");
+        PHP_V8_THROW_EXCEPTION("Callback doesn't have stored callback function");
         return;
     }
 
@@ -249,7 +249,7 @@ void php_v8_callback_call_from_bucket_with_zargs(size_t index, v8::Local<v8::Val
 
     // highly unlikely, but to play safe
     if (!cb) {
-        PHP_V8_THROW_EXCEPTION("Callback has no stored callback function");
+        PHP_V8_THROW_EXCEPTION("Callback doesn't have stored callback function");
         return;
     }
 

--- a/src/php_v8_exceptions.cc
+++ b/src/php_v8_exceptions.cc
@@ -215,7 +215,7 @@ static const zend_function_entry php_v8_value_exception_methods[] = {
 PHP_MINIT_FUNCTION(php_v8_exceptions) {
     zend_class_entry ce;
 
-    INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "GenericException", php_v8_exception_methods);
+    INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "Exception", php_v8_exception_methods);
     php_v8_generic_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default());
 
     INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "TryCatchException", php_v8_try_catch_exception_methods);

--- a/src/php_v8_exceptions.cc
+++ b/src/php_v8_exceptions.cc
@@ -22,7 +22,7 @@
 zend_class_entry* php_v8_generic_exception_class_entry;
 zend_class_entry* php_v8_try_catch_exception_class_entry;
 zend_class_entry* php_v8_termination_exception_class_entry;
-zend_class_entry* php_v8_abstract_resource_limit_exception_class_entry;
+zend_class_entry* php_v8_resource_limit_exception_class_entry;
 zend_class_entry* php_v8_time_limit_exception_class_entry;
 zend_class_entry* php_v8_memory_limit_exception_class_entry;
 
@@ -190,7 +190,7 @@ static const zend_function_entry php_v8_termination_exception_methods[] = {
         PHP_FE_END
 };
 
-static const zend_function_entry php_v8_abstract_resource_limit_exception_methods[] = {
+static const zend_function_entry php_v8_resource_limit_exception_methods[] = {
         PHP_FE_END
 };
 
@@ -201,11 +201,6 @@ static const zend_function_entry php_v8_time_limit_exception_methods[] = {
 static const zend_function_entry php_v8_memory_limit_exception_methods[] = {
         PHP_FE_END
 };
-
-static const zend_function_entry php_v8_script_exception_methods[] = {
-        PHP_FE_END
-};
-
 
 static const zend_function_entry php_v8_value_exception_methods[] = {
         PHP_FE_END
@@ -229,15 +224,14 @@ PHP_MINIT_FUNCTION(php_v8_exceptions) {
     INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "TerminationException", php_v8_termination_exception_methods);
     php_v8_termination_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_try_catch_exception_class_entry);
 
-    INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "AbstractResourceLimitException", php_v8_abstract_resource_limit_exception_methods);
-    php_v8_abstract_resource_limit_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_termination_exception_class_entry);
-    php_v8_abstract_resource_limit_exception_class_entry->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
+    INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "ResourceLimitException", php_v8_resource_limit_exception_methods);
+    php_v8_resource_limit_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_termination_exception_class_entry);
 
     INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "TimeLimitException", php_v8_time_limit_exception_methods);
-    php_v8_time_limit_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_abstract_resource_limit_exception_class_entry);
+    php_v8_time_limit_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_resource_limit_exception_class_entry);
 
     INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "MemoryLimitException", php_v8_memory_limit_exception_methods);
-    php_v8_memory_limit_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_abstract_resource_limit_exception_class_entry);
+    php_v8_memory_limit_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_resource_limit_exception_class_entry);
 
     INIT_NS_CLASS_ENTRY(ce, "V8\\Exceptions", "ValueException", php_v8_value_exception_methods);
     php_v8_value_exception_class_entry = zend_register_internal_class_ex(&ce, php_v8_generic_exception_class_entry);

--- a/src/php_v8_exceptions.h
+++ b/src/php_v8_exceptions.h
@@ -30,7 +30,7 @@ extern "C" {
 extern zend_class_entry* php_v8_generic_exception_class_entry;
 extern zend_class_entry* php_v8_try_catch_exception_class_entry;
 extern zend_class_entry* php_v8_termination_exception_class_entry;
-extern zend_class_entry* php_v8_abstract_resource_limit_exception_class_entry;
+extern zend_class_entry* php_v8_resource_limit_exception_class_entry;
 extern zend_class_entry* php_v8_time_limit_exception_class_entry;
 extern zend_class_entry* php_v8_memory_limit_exception_class_entry;
 

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -363,9 +363,12 @@ static PHP_METHOD(V8Isolate, GetEnteredContext) {
     PHP_V8_ISOLATE_FETCH_WITH_CHECK(getThis(), php_v8_isolate);
     PHP_V8_ENTER_ISOLATE(php_v8_isolate)
 
-    PHP_V8_ISOLATE_REQUIRE_IN_CONTEXT(isolate);
-
     v8::Local<v8::Context> local_context = php_v8_isolate->isolate->GetEnteredContext();
+
+    if (local_context.IsEmpty()) {
+        PHP_V8_THROW_EXCEPTION("Isolate doesn't have entered context");
+        return;
+    }
 
     php_v8_context_t *php_v8_context = php_v8_context_get_reference(local_context);
 

--- a/src/php_v8_isolate.cc
+++ b/src/php_v8_isolate.cc
@@ -374,20 +374,23 @@ static PHP_METHOD(V8Isolate, GetEnteredContext) {
 }
 
 static PHP_METHOD(V8Isolate, ThrowException) {
+    zval *php_v8_context_zv;
     zval *php_v8_value_zv;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "o", &php_v8_value_zv) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "oo", &php_v8_context_zv, &php_v8_value_zv) == FAILURE) {
         return;
     }
 
     PHP_V8_ISOLATE_FETCH_WITH_CHECK(getThis(), php_v8_isolate);
+
+    PHP_V8_CONTEXT_FETCH_WITH_CHECK(php_v8_context_zv, php_v8_context);
     PHP_V8_VALUE_FETCH_WITH_CHECK(php_v8_value_zv, php_v8_value);
 
+    PHP_V8_DATA_ISOLATES_CHECK_USING(php_v8_context, php_v8_isolate);
     PHP_V8_DATA_ISOLATES_CHECK_USING(php_v8_value, php_v8_isolate);
 
-    PHP_V8_ENTER_ISOLATE(php_v8_isolate);
-
-    PHP_V8_ISOLATE_REQUIRE_IN_CONTEXT(isolate);
+    PHP_V8_ENTER_STORED_ISOLATE(php_v8_context);
+    PHP_V8_ENTER_CONTEXT(php_v8_context);
 
     v8::Local<v8::Value> local_value = php_v8_value_get_local(php_v8_value);
     v8::Local<v8::Value> local_return_value = isolate->ThrowException(local_value);
@@ -549,7 +552,8 @@ ZEND_END_ARG_INFO()
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_isolate_GetEnteredContext, ZEND_RETURN_VALUE, 0, V8\\Context, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_isolate_ThrowException, ZEND_RETURN_VALUE, 1, V8\\Value, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_isolate_ThrowException, ZEND_RETURN_VALUE, 2, V8\\Value, 0)
+                ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
                 ZEND_ARG_OBJ_INFO(0, value, V8\\Value, 0)
 ZEND_END_ARG_INFO()
 

--- a/src/php_v8_script_origin.cc
+++ b/src/php_v8_script_origin.cc
@@ -83,7 +83,7 @@ v8::ScriptOrigin *php_v8_create_script_origin_from_zval(zval *value, v8::Isolate
         v8::MaybeLocal<v8::String> local_resource_name =  v8::String::NewFromUtf8(isolate, Z_STRVAL_P(resource_name_zv), v8::NewStringType::kNormal, (int)Z_STRLEN_P(resource_name_zv));
 
         if (local_resource_name.IsEmpty()) {
-            zend_throw_exception(php_v8_generic_exception_class_entry, "Invalid resource name", 0);
+            PHP_V8_THROW_EXCEPTION("Invalid resource name");
             return nullptr;
         }
 
@@ -113,7 +113,7 @@ v8::ScriptOrigin *php_v8_create_script_origin_from_zval(zval *value, v8::Isolate
         v8::MaybeLocal<v8::String> local_source_map_url =  v8::String::NewFromUtf8(isolate, Z_STRVAL_P(source_map_url_zv), v8::NewStringType::kNormal, (int)Z_STRLEN_P(source_map_url_zv));
 
         if (local_source_map_url.IsEmpty()) {
-            zend_throw_exception(php_v8_generic_exception_class_entry, "Invalid source map url", 0);
+            PHP_V8_THROW_EXCEPTION("Invalid source map url");
             return nullptr;
         }
 

--- a/src/php_v8_stack_trace.cc
+++ b/src/php_v8_stack_trace.cc
@@ -99,14 +99,14 @@ static PHP_METHOD(V8StackTrace, GetFrame)
     frames = zend_read_property(this_ce, getThis(), ZEND_STRL("frames"), 0, &rv);
 
     if (index < 0) {
-        zend_throw_exception(php_v8_generic_exception_class_entry, "Fame index is out of range", 0);
+        PHP_V8_THROW_EXCEPTION("Fame index is out of range");
         return;
     }
 
     frame = zend_hash_index_find(Z_ARRVAL_P(frames), static_cast<zend_ulong>(index));
 
     if (frame == NULL) {
-        zend_throw_exception(php_v8_generic_exception_class_entry, "Fame index is out of range", 0);
+        PHP_V8_THROW_EXCEPTION("Fame index is out of range");
         return;
     }
 

--- a/src/php_v8_startup_data.cc
+++ b/src/php_v8_startup_data.cc
@@ -68,7 +68,7 @@ static PHP_METHOD(V8StartupData, __construct) {
     }
 
     if (ZSTR_LEN(blob) > INT_MAX) {
-        zend_throw_exception(php_v8_generic_exception_class_entry, "Failed to create startup blob due to blob size integer overflow", 0);
+        PHP_V8_THROW_EXCEPTION("Failed to create startup blob due to blob size integer overflow");
         return;
     }
 

--- a/stubs/src/Exceptions/Exception.php
+++ b/stubs/src/Exceptions/Exception.php
@@ -16,6 +16,6 @@
 namespace V8\Exceptions;
 
 
-class GenericException extends \Exception
+class Exception extends \Exception
 {
 }

--- a/stubs/src/Exceptions/MemoryLimitException.php
+++ b/stubs/src/Exceptions/MemoryLimitException.php
@@ -16,6 +16,6 @@
 namespace V8\Exceptions;
 
 
-class MemoryLimitException extends AbstractResourceLimitException
+class MemoryLimitException extends ResourceLimitException
 {
 }

--- a/stubs/src/Exceptions/ResourceLimitException.php
+++ b/stubs/src/Exceptions/ResourceLimitException.php
@@ -16,6 +16,6 @@
 namespace V8\Exceptions;
 
 
-abstract class AbstractResourceLimitException extends TerminationException
+class ResourceLimitException extends TerminationException
 {
 }

--- a/stubs/src/Exceptions/TimeLimitException.php
+++ b/stubs/src/Exceptions/TimeLimitException.php
@@ -16,6 +16,6 @@
 namespace V8\Exceptions;
 
 
-class TimeLimitException extends AbstractResourceLimitException
+class TimeLimitException extends ResourceLimitException
 {
 }

--- a/stubs/src/Exceptions/TryCatchException.php
+++ b/stubs/src/Exceptions/TryCatchException.php
@@ -20,7 +20,7 @@ use V8\Context;
 use V8\Isolate;
 use V8\TryCatch;
 
-class TryCatchException extends GenericException
+class TryCatchException extends Exception
 {
     /**
      * @var Isolate

--- a/stubs/src/Exceptions/ValueException.php
+++ b/stubs/src/Exceptions/ValueException.php
@@ -15,6 +15,6 @@
 namespace V8\Exceptions;
 
 
-class ValueException extends GenericException
+class ValueException extends Exception
 {
 }

--- a/stubs/src/Isolate.php
+++ b/stubs/src/Isolate.php
@@ -96,11 +96,12 @@ class Isolate
      * operation; the caller must return immediately and only after the exception
      * has been handled does it become legal to invoke JavaScript operations.
      *
-     * @param \V8\Value $value
+     * @param Context $context
+     * @param Value $value
      *
-     * @return \V8\Value
+     * @return Value
      */
-    public function ThrowException(Value $value) : Value
+    public function ThrowException(Context $context, Value $value) : Value
     {
     }
 

--- a/stubs/src/StackTrace.php
+++ b/stubs/src/StackTrace.php
@@ -16,7 +16,7 @@
 namespace V8;
 
 
-use V8\Exceptions\GenericException;
+use V8\Exceptions\Exception;
 use V8\StackTrace\StackTraceOptions;
 
 
@@ -67,12 +67,12 @@ class StackTrace
      *
      * @return StackFrame
      *
-     * @throws GenericException When index is out of range
+     * @throws Exception When index is out of range
      */
     public function GetFrame(int $index) : StackFrame
     {
         if ($index < 0 || !isset($this->frames[$index])) {
-            throw new GenericException('Frame index is out of range');
+            throw new Exception('Frame index is out of range');
         }
 
         return $this->frames[$index];

--- a/tests/003-V8ObjectTemplate_recursive_chain.phpt
+++ b/tests/003-V8ObjectTemplate_recursive_chain.phpt
@@ -5,7 +5,7 @@ V8\ObjectTemplate - recursive 2
 --FILE--
 <?php
 
-use V8\Exceptions\GenericException;
+use V8\Exceptions\Exception;
 
 /** @var \Phpv8Testsuite $helper */
 $helper = require '.testsuite.php';
@@ -26,7 +26,7 @@ $template2->Set(new \V8\StringValue($isolate, 'that3'), $template3);
 
 try {
     $template3->Set(new \V8\StringValue($isolate, 'that1'), $template2);
-} catch (GenericException $e) {
+} catch (Exception $e) {
     $helper->exception_export($e);
 }
 
@@ -36,4 +36,4 @@ $context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'test'), $
 
 ?>
 --EXPECT--
-V8\Exceptions\GenericException: Can't set: recursion detected
+V8\Exceptions\Exception: Can't set: recursion detected

--- a/tests/003-V8ObjectTemplate_recursive_global.phpt
+++ b/tests/003-V8ObjectTemplate_recursive_global.phpt
@@ -5,7 +5,7 @@ V8\ObjectTemplate
 --FILE--
 <?php
 
-use V8\Exceptions\GenericException;
+use V8\Exceptions\Exception;
 
 /** @var \Phpv8Testsuite $helper */
 $helper = require '.testsuite.php';
@@ -21,7 +21,7 @@ $template = new \V8\ObjectTemplate($isolate);
 
 try {
     $template->Set(new \V8\StringValue($isolate, 'self'), $template);
-} catch (GenericException $e) {
+} catch (Exception $e) {
     $helper->exception_export($e);
 }
 
@@ -30,4 +30,4 @@ $context = new \V8\Context($isolate, $template);
 
 ?>
 --EXPECT--
-V8\Exceptions\GenericException: Can't set: recursion detected
+V8\Exceptions\Exception: Can't set: recursion detected

--- a/tests/003-V8ObjectTemplate_recursive_self.phpt
+++ b/tests/003-V8ObjectTemplate_recursive_self.phpt
@@ -5,7 +5,7 @@ V8\ObjectTemplate::Set() - recursive self
 --FILE--
 <?php
 
-use V8\Exceptions\GenericException;
+use V8\Exceptions\Exception;
 
 /** @var \Phpv8Testsuite $helper */
 $helper = require '.testsuite.php';
@@ -21,7 +21,7 @@ $template = new \V8\ObjectTemplate($isolate);
 
 try {
     $template->Set(new \V8\StringValue($isolate, 'self'), $template);
-} catch (GenericException $e) {
+} catch (Exception $e) {
     $helper->exception_export($e);
 }
 
@@ -30,4 +30,4 @@ $context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'test'), $
 
 ?>
 --EXPECT--
-V8\Exceptions\GenericException: Can't set: recursion detected
+V8\Exceptions\Exception: Can't set: recursion detected

--- a/tests/003-V8ObjectTemplate_recursive_tree.phpt
+++ b/tests/003-V8ObjectTemplate_recursive_tree.phpt
@@ -48,14 +48,14 @@ $t7->Set($s9, $t9);
 
 try {
     $t9->Set($s1, $t1);
-} catch (\V8\Exceptions\GenericException $e) {
+} catch (\V8\Exceptions\Exception $e) {
     $helper->exception_export($e);
 }
 
 
 try {
     $t7->Set($s1, $t1);
-} catch (\V8\Exceptions\GenericException $e) {
+} catch (\V8\Exceptions\Exception $e) {
     $helper->exception_export($e);
 }
 
@@ -63,7 +63,7 @@ $t4->Set($s6, $t6);
 
 try {
     $t6->Set($s4, $t4);
-} catch (\V8\Exceptions\GenericException $e) {
+} catch (\V8\Exceptions\Exception $e) {
     $helper->exception_export($e);
 }
 
@@ -72,6 +72,6 @@ $context->GlobalObject()->Set($context, new \V8\StringValue($isolate, 'test'), $
 
 ?>
 --EXPECT--
-V8\Exceptions\GenericException: Can't set: recursion detected
-V8\Exceptions\GenericException: Can't set: recursion detected
-V8\Exceptions\GenericException: Can't set: recursion detected
+V8\Exceptions\Exception: Can't set: recursion detected
+V8\Exceptions\Exception: Can't set: recursion detected
+V8\Exceptions\Exception: Can't set: recursion detected

--- a/tests/V8ArrayObject.phpt
+++ b/tests/V8ArrayObject.phpt
@@ -307,7 +307,7 @@ V8\ArrayObject(V8\Value)->ToInt32():
         bool(false)
       }
     }
-V8\ArrayObject(V8\Value)->ToArrayIndex(): V8\Exceptions\GenericException: Failed to convert
+V8\ArrayObject(V8\Value)->ToArrayIndex(): V8\Exceptions\Exception: Failed to convert
 
 
 typeof arr: object

--- a/tests/V8Exception_Error.phpt
+++ b/tests/V8Exception_Error.phpt
@@ -24,7 +24,7 @@ $helper->line();
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
     $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
-    $e = $info->GetIsolate()->ThrowException(V8\Exception::Error($info->GetContext(), $value));
+    $e = $info->GetIsolate()->ThrowException($info->GetContext(), V8\Exception::Error($info->GetContext(), $value));
 
     $info->GetReturnValue()->Set($e);
 });

--- a/tests/V8Exception_RangeError.phpt
+++ b/tests/V8Exception_RangeError.phpt
@@ -25,7 +25,7 @@ $helper->line();
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
     $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
-    $e = $info->GetIsolate()->ThrowException(V8\Exception::RangeError($info->GetContext(), $value));
+    $e = $info->GetIsolate()->ThrowException($info->GetContext(), V8\Exception::RangeError($info->GetContext(), $value));
 
     $info->GetReturnValue()->Set($e);
 });

--- a/tests/V8Exception_ReferenceError.phpt
+++ b/tests/V8Exception_ReferenceError.phpt
@@ -25,7 +25,7 @@ $helper->line();
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
     $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
-    $e = $info->GetIsolate()->ThrowException(V8\Exception::ReferenceError($info->GetContext(), $value));
+    $e = $info->GetIsolate()->ThrowException($info->GetContext(), V8\Exception::ReferenceError($info->GetContext(), $value));
 
     $info->GetReturnValue()->Set($e);
 });

--- a/tests/V8Exception_SyntaxError.phpt
+++ b/tests/V8Exception_SyntaxError.phpt
@@ -25,7 +25,7 @@ $helper->line();
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
     $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
-    $e = $info->GetIsolate()->ThrowException(V8\Exception::SyntaxError($info->GetContext(), $value));
+    $e = $info->GetIsolate()->ThrowException($info->GetContext(), V8\Exception::SyntaxError($info->GetContext(), $value));
 
     $info->GetReturnValue()->Set($e);
 });

--- a/tests/V8Exception_TypeError.phpt
+++ b/tests/V8Exception_TypeError.phpt
@@ -25,7 +25,7 @@ $helper->line();
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
     $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
-    $e = $info->GetIsolate()->ThrowException(V8\Exception::TypeError($info->GetContext(), $value));
+    $e = $info->GetIsolate()->ThrowException($info->GetContext(), V8\Exception::TypeError($info->GetContext(), $value));
 
     $info->GetReturnValue()->Set($e);
 });

--- a/tests/V8FunctionObject_Call_bad_args.phpt
+++ b/tests/V8FunctionObject_Call_bad_args.phpt
@@ -58,5 +58,5 @@ try {
 --EXPECT--
 TypeError: Argument 3 passed to V8\FunctionObject::Call() should be array of \V8\Value objects, integer given at 0 offset
 TypeError: Argument 3 passed to V8\FunctionObject::Call() should be array of \V8\Value objects, instance of stdClass given at 0 offset
-V8\Exceptions\GenericException: Value is empty. Forgot to call parent::__construct()?: argument 3 passed to V8\FunctionObject::Call() at 0 offset
-V8\Exceptions\GenericException: Isolates mismatch: argument 3 passed to V8\FunctionObject::Call() at 0 offset
+V8\Exceptions\Exception: Value is empty. Forgot to call parent::__construct()?: argument 3 passed to V8\FunctionObject::Call() at 0 offset
+V8\Exceptions\Exception: Isolates mismatch: argument 3 passed to V8\FunctionObject::Call() at 0 offset

--- a/tests/V8FunctionTemplate.phpt
+++ b/tests/V8FunctionTemplate.phpt
@@ -209,8 +209,8 @@ object(V8\ObjectTemplate)#8 (1) {
 V8\FunctionTemplate::InstanceTemplate() doesn't match expected value
 
 
-V8\Exceptions\GenericException: Isolates mismatch
-V8\Exceptions\GenericException: Isolates mismatch
+V8\Exceptions\Exception: Isolates mismatch
+V8\Exceptions\Exception: Isolates mismatch
 Expected value matches actual value
 Expected value is not identical to actual value
 Hello, world!

--- a/tests/V8FunctionTemplate_SetCallHandler.phpt
+++ b/tests/V8FunctionTemplate_SetCallHandler.phpt
@@ -55,6 +55,6 @@ EOF
 TypeError: Argument 1 passed to V8\FunctionTemplate::SetCallHandler() must be callable, null given
 
 callback test()
-V8\Exceptions\GenericException: v8::FunctionTemplate::SetCallHandler FunctionTemplate already instantiated
+V8\Exceptions\Exception: v8::FunctionTemplate::SetCallHandler FunctionTemplate already instantiated
 We are done for now
 EOF

--- a/tests/V8Isolate.phpt
+++ b/tests/V8Isolate.phpt
@@ -16,13 +16,6 @@ $helper->header('Object representation');
 $helper->dump($isolate);
 $helper->line();
 
-try {
-  $isolate->GetEnteredContext();
-} catch (Exception $e) {
-  $helper->exception_export($e);
-}
-
-$helper->line();
 $helper->method_export($isolate, 'GetHeapStatistics');
 
 $isolate = null;
@@ -43,10 +36,8 @@ object(V8\Isolate)#2 (5) {
   bool(false)
 }
 
-V8\Exceptions\Exception: Not in context!
-
 V8\Isolate->GetHeapStatistics():
-    object(V8\HeapStatistics)#29 (9) {
+    object(V8\HeapStatistics)#28 (9) {
       ["total_heap_size":"V8\HeapStatistics":private]=>
       float(%d)
       ["total_heap_size_executable":"V8\HeapStatistics":private]=>

--- a/tests/V8Isolate.phpt
+++ b/tests/V8Isolate.phpt
@@ -43,7 +43,7 @@ object(V8\Isolate)#2 (5) {
   bool(false)
 }
 
-V8\Exceptions\GenericException: Not in context!
+V8\Exceptions\Exception: Not in context!
 
 V8\Isolate->GetHeapStatistics():
     object(V8\HeapStatistics)#29 (9) {

--- a/tests/V8Isolate_GetEnteredContext.phpt
+++ b/tests/V8Isolate_GetEnteredContext.phpt
@@ -1,0 +1,43 @@
+--TEST--
+V8\Isolate::GetEnteredContext()
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new \V8\Isolate();
+
+try {
+    $isolate->GetEnteredContext();
+}catch (\V8\Exceptions\Exception $e) {
+    $helper->exception_export($e);
+}
+
+
+$helper->line();
+
+$func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) use ($helper) {
+    $helper->assert('Isolate has entered context', $info->GetIsolate()->GetEnteredContext() === $info->GetContext());
+});
+
+
+$global_tpl = new \V8\ObjectTemplate($isolate);
+$global_tpl->Set(new \V8\StringValue($isolate, 'test'), $func_tpl);
+
+$context = new \V8\Context($isolate, $global_tpl);
+
+$v8_helper->CompileTryRun($context, 'test()');
+
+
+
+?>
+--EXPECT--
+V8\Exceptions\Exception: Isolate doesn't have entered context
+
+Isolate has entered context: ok

--- a/tests/V8Isolate_ThrowException.phpt
+++ b/tests/V8Isolate_ThrowException.phpt
@@ -13,8 +13,6 @@ $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new \V8\Isolate();
 
-$helper->line();
-
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
     $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 

--- a/tests/V8Isolate_ThrowException.phpt
+++ b/tests/V8Isolate_ThrowException.phpt
@@ -13,18 +13,12 @@ $v8_helper = new PhpV8Helpers($helper);
 
 $isolate = new \V8\Isolate();
 
-try {
-    $isolate->ThrowException(new \V8\StringValue($isolate, 'test exception'));
-} catch (\Exception $e) {
-    $helper->exception_export($e);
-}
-
 $helper->line();
 
 $func_tpl = new \V8\FunctionTemplate($isolate, function (\V8\FunctionCallbackInfo $info) {
     $value = count($info->Arguments()) ? $info->Arguments()[0] : new \V8\StringValue($info->GetIsolate(), "exception");
 
-    $e = $info->GetIsolate()->ThrowException($value);
+    $e = $info->GetIsolate()->ThrowException($info->GetContext(), $value);
 
     $info->GetReturnValue()->Set($e);
 });
@@ -35,6 +29,7 @@ $global_tpl->Set(new \V8\StringValue($isolate, 'e'), $func_tpl);
 $global_tpl->Set(new \V8\StringValue($isolate, 'print'), $v8_helper->getPrintFunctionTemplate($isolate));
 
 $context = new \V8\Context($isolate, $global_tpl);
+
 
 $v8_helper->CompileTryRun($context, 'e()');
 $v8_helper->CompileTryRun($context, 'e("test")');
@@ -105,8 +100,6 @@ $v8_helper->run_checks($res);
 
 ?>
 --EXPECT--
-V8\Exceptions\GenericException: Not in context!
-
 e(): V8\Exceptions\TryCatchException: exception
 e("test"): V8\Exceptions\TryCatchException: test
 

--- a/tests/V8MapObject.phpt
+++ b/tests/V8MapObject.phpt
@@ -349,7 +349,7 @@ V8\MapObject(V8\Value)->ToInt32():
         bool(false)
       }
     }
-V8\MapObject(V8\Value)->ToArrayIndex(): V8\Exceptions\GenericException: Failed to convert
+V8\MapObject(V8\Value)->ToArrayIndex(): V8\Exceptions\Exception: Failed to convert
 
 
 New value creation from V8 runtime:

--- a/tests/V8ObjectValue.phpt
+++ b/tests/V8ObjectValue.phpt
@@ -296,4 +296,4 @@ V8\ObjectValue(V8\Value)->ToInt32():
         bool(false)
       }
     }
-V8\ObjectValue(V8\Value)->ToArrayIndex(): V8\Exceptions\GenericException: Failed to convert
+V8\ObjectValue(V8\Value)->ToArrayIndex(): V8\Exceptions\Exception: Failed to convert

--- a/tests/V8ReturnValue_context.phpt
+++ b/tests/V8ReturnValue_context.phpt
@@ -114,7 +114,7 @@ Return value holds value: 42
 
 
 Return value object is out of context: ok
-V8\Exceptions\GenericException: Attempt to use return value out of calling function context
+V8\Exceptions\Exception: Attempt to use return value out of calling function context
 
 Object representation (outside of context):
 -------------------------------------------

--- a/tests/V8ScriptCompiler_Compile.phpt
+++ b/tests/V8ScriptCompiler_Compile.phpt
@@ -44,7 +44,7 @@ $cache_data = null;
         $source_string = new V8\StringValue($isolate, '"test"');
         $source        = new \V8\ScriptCompiler\Source($source_string, $origin);
         $script        = V8\ScriptCompiler::Compile($context, $source);
-    } catch (\V8\Exceptions\GenericException $e) {
+    } catch (\V8\Exceptions\Exception $e) {
         $helper->exception_export($e);
     }
 
@@ -72,7 +72,7 @@ $cache_data = null;
     $helper->assert('Source cache data is not set', $source->GetCachedData() === null);
     try {
         $script = V8\ScriptCompiler::Compile($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
-    } catch (\V8\Exceptions\GenericException $e) {
+    } catch (\V8\Exceptions\Exception $e) {
         $helper->exception_export($e);
     }
 }
@@ -266,7 +266,7 @@ Compiling:
 Compile script: ok
 Compile script: ok
 V8\Exceptions\TryCatchException: SyntaxError: Unexpected identifier
-V8\Exceptions\GenericException: Unable to compile module as script
+V8\Exceptions\Exception: Unable to compile module as script
 
 
 Testing:
@@ -277,7 +277,7 @@ string(11) "test passed"
 Test cache when no cache set:
 -----------------------------
 Source cache data is not set: ok
-V8\Exceptions\GenericException: Unable to consume cache when it's not set
+V8\Exceptions\Exception: Unable to consume cache when it's not set
 Test generating code cache:
 ---------------------------
 Source cache data is NULL: ok

--- a/tests/V8ScriptCompiler_CompileUnbound.phpt
+++ b/tests/V8ScriptCompiler_CompileUnbound.phpt
@@ -44,7 +44,7 @@ $cache_data = null;
         $source_string = new V8\StringValue($isolate, '"test"');
         $source        = new \V8\ScriptCompiler\Source($source_string, $origin);
         $unbound        = V8\ScriptCompiler::CompileUnboundScript($context, $source);
-    } catch (\V8\Exceptions\GenericException $e) {
+    } catch (\V8\Exceptions\Exception $e) {
         $helper->exception_export($e);
     }
 
@@ -80,7 +80,7 @@ $cache_data = null;
     $helper->assert('Source cache data is not set', $source->GetCachedData() === null);
     try {
         $unbound = V8\ScriptCompiler::CompileUnboundScript($context, $source, V8\ScriptCompiler\CompileOptions::kConsumeParserCache);
-    } catch (\V8\Exceptions\GenericException $e) {
+    } catch (\V8\Exceptions\Exception $e) {
         $helper->exception_export($e);
     }
 }
@@ -221,7 +221,7 @@ Compiling:
 Compile script: ok
 Compile script: ok
 V8\Exceptions\TryCatchException: SyntaxError: Unexpected identifier
-V8\Exceptions\GenericException: Unable to compile module as unbound script
+V8\Exceptions\Exception: Unable to compile module as unbound script
 
 
 Testing:
@@ -235,7 +235,7 @@ string(11) "test passed"
 Test cache when no cache set:
 -----------------------------
 Source cache data is not set: ok
-V8\Exceptions\GenericException: Unable to consume cache when it's not set
+V8\Exceptions\Exception: Unable to consume cache when it's not set
 Test generating code cache:
 ---------------------------
 Source cache data is NULL: ok

--- a/tests/V8SetObject.phpt
+++ b/tests/V8SetObject.phpt
@@ -356,7 +356,7 @@ V8\SetObject(V8\Value)->ToInt32():
         bool(false)
       }
     }
-V8\SetObject(V8\Value)->ToArrayIndex(): V8\Exceptions\GenericException: Failed to convert
+V8\SetObject(V8\Value)->ToArrayIndex(): V8\Exceptions\Exception: Failed to convert
 
 
 New value creation from V8 runtime:

--- a/tests/V8StartupData_CreateFromSource.phpt
+++ b/tests/V8StartupData_CreateFromSource.phpt
@@ -51,4 +51,4 @@ Snapshot raw_size is the same as binary_string length: ok
 Context global is affected by snapshot blob: ok
 
 
-V8\Exceptions\GenericException: Failed to create startup blob
+V8\Exceptions\Exception: Failed to create startup blob

--- a/tests/V8Value_empty.phpt
+++ b/tests/V8Value_empty.phpt
@@ -38,5 +38,5 @@ try {
 
 ?>
 --EXPECT--
-V8\Exceptions\GenericException: Value is empty. Forgot to call parent::__construct()?
-V8\Exceptions\GenericException: Value is empty. Forgot to call parent::__construct()?
+V8\Exceptions\Exception: Value is empty. Forgot to call parent::__construct()?
+V8\Exceptions\Exception: Value is empty. Forgot to call parent::__construct()?


### PR DESCRIPTION
This PR improves exceptions handling. It breaks few userland API, however, changes are trivial.  For more details see change list below.

 - `*` Require Context explicitly in `V8\Isolate::ThrowException()`;
 - `*` Rename `V8\Exceptions\GenericException` to `V8\Exceptions\Exception`;
 - `*` Rename `V8\Exceptions\AbstractResourceLimitException` to `V8\Exceptions\ResourceLimitException`;
 - `internal:` Check whether returned context is empty in `V8\Isolate\GetEnteredContext()` instead of checking `InContext()`.

*`*` - BC-breaking or potentially BC-breaking changes*