### PR TITLE
Improve exceptions api

### DIFF
--- a/src/php_v8_exception.cc
+++ b/src/php_v8_exception.cc
@@ -191,27 +191,27 @@ static PHP_METHOD(V8Exception, GetStackTrace) {
 }
 
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_RangeError, ZEND_RETURN_VALUE, 2, V8\\Value, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_RangeError, ZEND_RETURN_VALUE, 2, V8\\ObjectValue, 0)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
                 ZEND_ARG_OBJ_INFO(0, message, V8\\StringValue, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_ReferenceError, ZEND_RETURN_VALUE, 2, V8\\Value, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_ReferenceError, ZEND_RETURN_VALUE, 2, V8\\ObjectValue, 0)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
                 ZEND_ARG_OBJ_INFO(0, message, V8\\StringValue, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_SyntaxError, ZEND_RETURN_VALUE, 2, V8\\Value, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_SyntaxError, ZEND_RETURN_VALUE, 2, V8\\ObjectValue, 0)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
                 ZEND_ARG_OBJ_INFO(0, message, V8\\StringValue, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_TypeError, ZEND_RETURN_VALUE, 2, V8\\Value, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_TypeError, ZEND_RETURN_VALUE, 2, V8\\ObjectValue, 0)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
                 ZEND_ARG_OBJ_INFO(0, message, V8\\StringValue, 0)
 ZEND_END_ARG_INFO()
 
-PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_Error, ZEND_RETURN_VALUE, 2, V8\\Value, 0)
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_exception_Error, ZEND_RETURN_VALUE, 2, V8\\ObjectValue, 0)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
                 ZEND_ARG_OBJ_INFO(0, message, V8\\StringValue, 0)
 ZEND_END_ARG_INFO()

--- a/src/php_v8_try_catch.cc
+++ b/src/php_v8_try_catch.cc
@@ -43,8 +43,15 @@ void php_v8_try_catch_create_from_try_catch(zval *return_value, php_v8_isolate_t
 
     if (try_catch && !try_catch->Exception().IsEmpty()) {
         zval exception_zv;
-        php_v8_get_or_create_value(&exception_zv, try_catch->Exception(), php_v8_isolate);
+        php_v8_value_t * php_v8_value = php_v8_get_or_create_value(&exception_zv, try_catch->Exception(), php_v8_isolate);
         zend_update_property(this_ce, return_value, ZEND_STRL("exception"), &exception_zv);
+
+        if (!Z_ISUNDEF(php_v8_value->exception)) {
+            zend_update_property(this_ce, return_value, ZEND_STRL("external_exception"), &php_v8_value->exception);
+            zval_ptr_dtor(&php_v8_value->exception);
+            ZVAL_UNDEF(&php_v8_value->exception);
+        }
+
         zval_ptr_dtor(&exception_zv);
     }
 
@@ -71,18 +78,20 @@ static PHP_METHOD(V8TryCatch, __construct) {
     zval *php_v8_exception_zv = NULL;
     zval *php_v8_stack_trace_zv = NULL;
     zval *php_v8_message_zv = NULL;
+    zval *external_exception_zv = NULL;
 
     zend_bool can_continue = '\0';
     zend_bool has_terminated = '\0';
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "oo|o!o!o!bb",
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "oo|o!o!o!bbo!",
                               &php_v8_isolate_zv,
                               &php_v8_context_zv,
                               &php_v8_exception_zv,
                               &php_v8_stack_trace_zv,
                               &php_v8_message_zv,
                               &can_continue,
-                              &has_terminated) == FAILURE) {
+                              &has_terminated,
+                              &external_exception_zv) == FAILURE) {
         return;
     }
 
@@ -114,6 +123,10 @@ static PHP_METHOD(V8TryCatch, __construct) {
 
     zend_update_property_bool(this_ce, getThis(), ZEND_STRL("can_continue"), can_continue);
     zend_update_property_bool(this_ce, getThis(), ZEND_STRL("has_terminated"), has_terminated);
+
+    if (external_exception_zv != NULL) {
+        zend_update_property(this_ce, getThis(), ZEND_STRL("external_exception"), external_exception_zv);
+    }
 }
 
 static PHP_METHOD(V8TryCatch, GetIsolate)
@@ -203,6 +216,18 @@ static PHP_METHOD(V8TryCatch, HasTerminated)
 }
 
 
+static PHP_METHOD(V8TryCatch, getExternalException)
+{
+    zval rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    RETVAL_ZVAL(zend_read_property(this_ce, getThis(), ZEND_STRL("external_exception"), 0, &rv), 1, 0);
+}
+
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_try_catch___construct, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 2)
                 ZEND_ARG_OBJ_INFO(0, isolate, V8\\Isolate, 0)
                 ZEND_ARG_OBJ_INFO(0, context, V8\\Context, 0)
@@ -211,6 +236,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_v8_try_catch___construct, ZEND_SEND_BY_VAL, ZEND_
                 ZEND_ARG_OBJ_INFO(0, message, V8\\Message, 1)
                 ZEND_ARG_TYPE_INFO(0, can_continue, _IS_BOOL, 0)
                 ZEND_ARG_TYPE_INFO(0, has_terminated, _IS_BOOL, 0)
+                ZEND_ARG_OBJ_INFO(0, external_exception, Throwable, 1)
 ZEND_END_ARG_INFO()
 
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_try_catch_GetIsolate, ZEND_RETURN_VALUE, 0, V8\\Isolate, 0)
@@ -234,6 +260,9 @@ ZEND_END_ARG_INFO()
 PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_v8_try_catch_HasTerminated, ZEND_RETURN_VALUE, 0, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
+PHP_V8_ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_v8_try_catch_getExternalException, ZEND_RETURN_VALUE, 0, Throwable, 1)
+ZEND_END_ARG_INFO()
+
 
 static const zend_function_entry php_v8_try_catch_methods[] = {
         PHP_ME(V8TryCatch, __construct,     arginfo_v8_try_catch___construct,     ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -247,6 +276,8 @@ static const zend_function_entry php_v8_try_catch_methods[] = {
 
         PHP_ME(V8TryCatch, CanContinue,     arginfo_v8_try_catch_CanContinue,   ZEND_ACC_PUBLIC)
         PHP_ME(V8TryCatch, HasTerminated,   arginfo_v8_try_catch_HasTerminated, ZEND_ACC_PUBLIC)
+
+        PHP_ME(V8TryCatch, getExternalException, arginfo_v8_try_catch_getExternalException, ZEND_ACC_PUBLIC)
 
         PHP_FE_END
 };
@@ -265,6 +296,8 @@ PHP_MINIT_FUNCTION (php_v8_try_catch) {
 
     zend_declare_property_null(this_ce, ZEND_STRL("can_continue"), ZEND_ACC_PRIVATE);
     zend_declare_property_null(this_ce, ZEND_STRL("has_terminated"), ZEND_ACC_PRIVATE);
+
+    zend_declare_property_null(this_ce, ZEND_STRL("external_exception"), ZEND_ACC_PRIVATE);
 
     return SUCCESS;
 }

--- a/src/php_v8_value.h
+++ b/src/php_v8_value.h
@@ -111,6 +111,7 @@ struct _php_v8_value_t {
     bool is_weak;
     v8::Persistent<v8::Value> *persistent;
     phpv8::PersistentData *persistent_data;
+    zval exception;
 
     zval *gc_data;
     int   gc_data_count;

--- a/stubs/src/Exception.php
+++ b/stubs/src/Exception.php
@@ -26,9 +26,9 @@ class Exception
      * @param Context         $context
      * @param \V8\StringValue $message
      *
-     * @return Value
+     * @return \V8\ObjectValue
      */
-    public static function RangeError(Context $context, StringValue $message): Value
+    public static function RangeError(Context $context, StringValue $message): ObjectValue
     {
     }
 
@@ -36,9 +36,9 @@ class Exception
      * @param Context         $context
      * @param \V8\StringValue $message
      *
-     * @return Value
+     * @return \V8\ObjectValue
      */
-    public static function ReferenceError(Context $context, StringValue $message): Value
+    public static function ReferenceError(Context $context, StringValue $message): ObjectValue
     {
     }
 
@@ -46,9 +46,9 @@ class Exception
      * @param Context         $context
      * @param \V8\StringValue $message
      *
-     * @return Value
+     * @return \V8\ObjectValue
      */
-    public static function SyntaxError(Context $context, StringValue $message): Value
+    public static function SyntaxError(Context $context, StringValue $message): ObjectValue
     {
     }
 
@@ -56,9 +56,9 @@ class Exception
      * @param Context         $context
      * @param \V8\StringValue $message
      *
-     * @return Value
+     * @return \V8\ObjectValue
      */
-    public static function TypeError(Context $context, StringValue $message): Value
+    public static function TypeError(Context $context, StringValue $message): ObjectValue
     {
     }
 
@@ -66,9 +66,9 @@ class Exception
      * @param Context         $context
      * @param \V8\StringValue $message
      *
-     * @return Value | ObjectValue
+     * @return ObjectValue
      */
-    public static function Error(Context $context, StringValue $message): Value
+    public static function Error(Context $context, StringValue $message): ObjectValue
     {
     }
 

--- a/stubs/src/Isolate.php
+++ b/stubs/src/Isolate.php
@@ -15,6 +15,10 @@
 namespace V8;
 
 
+use Throwable;
+use V8\Exceptions\ValueException;
+
+
 class Isolate
 {
     public function __construct(StartupData $snapshot = null)
@@ -79,11 +83,17 @@ class Isolate
      * has been handled does it become legal to invoke JavaScript operations.
      *
      * @param Context $context
-     * @param Value   $value
+     * @param Value $value
+     * @param Throwable|null $e Exception to associate with a given value.
+     *                          Because how underlying object wiring done, wiring PHP to V8 exceptions
+     *                          is possible only for V8 exception that are instances of ObjectValue.
      *
      * @return void
+     *
+     * @throws ValueException When trying to associate external exception with non-object value
+     * @throws ValueException When another external exception is already associated with a given value
      */
-    public function ThrowException(Context $context, Value $value)
+    public function ThrowException(Context $context, Value $value, Throwable $e = null)
     {
     }
 
@@ -129,20 +139,6 @@ class Isolate
     public function CancelTerminateExecution()
     {
     }
-
-//    /**
-//     * Request V8 to interrupt long running JavaScript code and invoke
-//     * the given |callback| passing the given |data| to it. After |callback|
-//     * returns control will be returned to the JavaScript code.
-//     * There may be a number of interrupt requests in flight.
-//     * Can be called from another thread without acquiring a |Locker|.
-//     * Registered |callback| must not reenter interrupted Isolate.
-//     */
-////    void RequestInterrupt(InterruptCallback callback, void* data);
-//    public function RequestInterrupt()
-//    {
-//
-//    }
 
     /**
      * Optional notification that the embedder is idle.
@@ -199,7 +195,7 @@ class Isolate
      * and report it to the message listeners. The option is off by default.
      *
      * @param bool $capture
-     * @param int  $frame_limit
+     * @param int $frame_limit
      */
     public function SetCaptureStackTraceForUncaughtExceptions(bool $capture, int $frame_limit = 10)
     {

--- a/stubs/src/TryCatch.php
+++ b/stubs/src/TryCatch.php
@@ -14,6 +14,9 @@
 
 namespace V8;
 
+use Throwable;
+
+
 /**
  * An external exception handler.
  */
@@ -47,6 +50,10 @@ class TryCatch
      * @var bool
      */
     private $has_terminated;
+    /**
+     * @var null|Throwable
+     */
+    private $external_exception;
 
     /**
      * Creates a new try/catch block and registers it with v8.  Note that
@@ -55,11 +62,12 @@ class TryCatch
      *
      * @param Isolate $isolate
      * @param Context $context
-     * @param Value   $exception
-     * @param Value   $stack_trace
+     * @param Value $exception
+     * @param Value $stack_trace
      * @param Message $message
-     * @param bool    $can_continue
-     * @param bool    $has_terminated
+     * @param bool $can_continue
+     * @param bool $has_terminated
+     * @param Throwable|null $external_exception
      */
     public function __construct(
         Isolate $isolate,
@@ -68,7 +76,8 @@ class TryCatch
         Value $stack_trace = null,
         Message $message = null,
         bool $can_continue = false,
-        bool $has_terminated = false
+        bool $has_terminated = false,
+        Throwable $external_exception = null
     ) {
         $this->isolate        = $isolate;
         $this->exception      = $exception;
@@ -76,6 +85,7 @@ class TryCatch
         $this->message        = $message;
         $this->can_continue   = $can_continue;
         $this->has_terminated = $has_terminated;
+        $this->external_exception = $external_exception;
     }
 
     public function GetIsolate(): Isolate
@@ -159,5 +169,13 @@ class TryCatch
     public function HasTerminated(): bool
     {
         return $this->has_terminated;
+    }
+
+    /**
+     * @return null|Throwable
+     */
+    public function getExternalException()
+    {
+        return $this->external_exception;
     }
 }

--- a/tests/V8ExceptionsTryCatchException.phpt
+++ b/tests/V8ExceptionsTryCatchException.phpt
@@ -58,7 +58,7 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
     }
   }
   ["try_catch":"V8\Exceptions\TryCatchException":private]=>
-  object(V8\TryCatch)#4 (7) {
+  object(V8\TryCatch)#4 (8) {
     ["isolate":"V8\TryCatch":private]=>
     object(V8\Isolate)#2 (0) {
     }
@@ -78,6 +78,8 @@ object(V8\Exceptions\TryCatchException)#5 (10) {
     bool(false)
     ["has_terminated":"V8\TryCatch":private]=>
     bool(false)
+    ["external_exception":"V8\TryCatch":private]=>
+    NULL
   }
 }
 

--- a/tests/V8Isolate_ThrowException_with_external.phpt
+++ b/tests/V8Isolate_ThrowException_with_external.phpt
@@ -1,0 +1,78 @@
+--TEST--
+V8\Isolate::ThrowException() - exception object is still the same
+--SKIPIF--
+<?php if (!extension_loaded("v8")) print "skip"; ?>
+--FILE--
+<?php
+/** @var \Phpv8Testsuite $helper */
+$helper = require '.testsuite.php';
+
+require '.v8-helpers.php';
+$v8_helper = new PhpV8Helpers($helper);
+
+
+$isolate = new \V8\Isolate();
+$context = new \V8\Context($isolate);
+$v8_helper->injectConsoleLog($context);
+
+$global = $context->GlobalObject();
+
+try {
+    // associating external exception with non-object v8 values is not possible
+    $isolate->ThrowException($context, new \V8\StringValue($isolate, 'test'), new RuntimeException('test'));
+} catch (\V8\Exceptions\ValueException $e) {
+    $helper->exception_export($e);
+}
+
+
+$v8_exception = \V8\Exception::Error($context, new \V8\StringValue($isolate, 'test'));
+
+$func_tpl = new \V8\FunctionObject($context, function (\V8\FunctionCallbackInfo $info) use (&$v8_exception) {
+    $info->GetIsolate()->ThrowException($info->GetContext(), $v8_exception, new RuntimeException('test'));
+});
+
+$global->Set($context, new \V8\StringValue($isolate, 'e'), $func_tpl);
+
+
+try {
+    $v8_helper->CompileRun($context, 'e()');
+} catch (\V8\Exceptions\TryCatchException $e) {
+    $helper->exception_export($e);
+
+    $helper->assert('Thrown exception object is the same', $e->GetTryCatch()->Exception(), $v8_exception);
+
+    $helper->exception_export($e->GetTryCatch()->getExternalException());
+}
+
+$v8_helper->CompileRun($context, 'try {e()} catch(e) {}');
+
+try {
+    // when we catch thrown exception within v8 runtime, we can't un-wire association, so it becomes illegal to reuse
+    // the same v8 object exception to throw with external exception again
+    $isolate->ThrowException($context, $v8_exception, new RuntimeException('test'));
+} catch (\V8\Exceptions\ValueException $e) {
+    $helper->exception_export($e);
+}
+
+$v8_exception = \V8\Exception::Error($context, new \V8\StringValue($isolate, 'test'));
+
+
+// re-throw the same v8 object after it was propagated through TryCatch mechanism is OK
+$isolate->ThrowException($context, $v8_exception, new RuntimeException('test'));
+
+try {
+    // re-throw v8 object while it has not been propagated through TryCatch mechanism is NOT OK
+    $isolate->ThrowException($context, $v8_exception, new RuntimeException('test'));
+} catch (\V8\Exceptions\ValueException $e) {
+    $helper->exception_export($e);
+}
+
+
+?>
+--EXPECT--
+V8\Exceptions\ValueException: Unable to associate external exception with non-object value
+V8\Exceptions\TryCatchException: Error: test
+Thrown exception object is the same: ok
+RuntimeException: test
+V8\Exceptions\ValueException: Another external exception is already associated with a given value
+V8\Exceptions\ValueException: Another external exception is already associated with a given value

--- a/tests/V8TryCatch.phpt
+++ b/tests/V8TryCatch.phpt
@@ -38,7 +38,7 @@ $exception = new \V8\ObjectValue($context);
 $message = new \V8\Message('message', 'line', new \V8\ScriptOrigin('resource_name'), 'resource_name', new \V8\StackTrace([]));
 $trace = new \V8\StringValue($isolate, 'trace');
 
-$obj = new \V8\TryCatch($isolate, $context, $exception, $trace, $message, true, true);
+$obj = new \V8\TryCatch($isolate, $context, $exception, $trace, $message, true, true, $php_exception = new RuntimeException('test'));
 
 $helper->header('Object representation');
 $helper->dump($obj);
@@ -53,6 +53,8 @@ $helper->method_matches($obj, 'StackTrace', $trace);
 
 $helper->method_matches($obj, 'CanContinue', true);
 $helper->method_matches($obj, 'HasTerminated', true);
+
+$helper->method_matches($obj, 'getExternalException', $php_exception);
 $helper->space();
 
 
@@ -66,10 +68,10 @@ $context = null;
 
 echo 'END', PHP_EOL;
 ?>
---EXPECT--
+--EXPECTF--
 Object representation (default):
 --------------------------------
-object(V8\TryCatch)#4 (7) {
+object(V8\TryCatch)#4 (8) {
   ["isolate":"V8\TryCatch":private]=>
   object(v8Tests\TrackingDtors\Isolate)#2 (0) {
   }
@@ -89,6 +91,8 @@ object(V8\TryCatch)#4 (7) {
   bool(false)
   ["has_terminated":"V8\TryCatch":private]=>
   bool(false)
+  ["external_exception":"V8\TryCatch":private]=>
+  NULL
 }
 
 
@@ -105,7 +109,7 @@ V8\TryCatch::HasTerminated() matches expected value
 
 Object representation:
 ----------------------
-object(V8\TryCatch)#11 (7) {
+object(V8\TryCatch)#11 (8) {
   ["isolate":"V8\TryCatch":private]=>
   object(v8Tests\TrackingDtors\Isolate)#2 (0) {
   }
@@ -190,6 +194,24 @@ object(V8\TryCatch)#11 (7) {
   bool(true)
   ["has_terminated":"V8\TryCatch":private]=>
   bool(true)
+  ["external_exception":"V8\TryCatch":private]=>
+  object(RuntimeException)#12 (7) {
+    ["message":protected]=>
+    string(4) "test"
+    ["string":"Exception":private]=>
+    string(0) ""
+    ["code":protected]=>
+    int(0)
+    ["file":protected]=>
+    string(%d) "%s/V8TryCatch.php"
+    ["line":protected]=>
+    int(%d)
+    ["trace":"Exception":private]=>
+    array(0) {
+    }
+    ["previous":"Exception":private]=>
+    NULL
+  }
 }
 
 
@@ -202,6 +224,7 @@ V8\TryCatch::Message() matches expected value
 V8\TryCatch::StackTrace() matches expected value
 V8\TryCatch::CanContinue() matches expected value
 V8\TryCatch::HasTerminated() matches expected value
+V8\TryCatch::getExternalException() matches expected value
 
 
 Context dies now!


### PR DESCRIPTION
This PR extends and clarify existent API and does not introduce any BC-breaking changes.

Changes list:

 - Change `V8\Exception::*Error()` return type to `V8\ObjectValue` as the only possible type;
 - Add external exception wiring option to `V8\Isolate::ThrowException()`.


